### PR TITLE
Use g:python3_host_prog

### DIFF
--- a/lua/CopilotChat/health.lua
+++ b/lua/CopilotChat/health.lua
@@ -24,7 +24,8 @@ end
 --- Run a python command and handle potential errors
 ---@param command string
 local function run_python_command(command)
-  return run_command_on_executable('python3', command)
+  local python3_host_prog = vim.g["python3_host_prog"]
+  return run_command_on_executable(python3_host_prog or 'python3', command)
 end
 
 -- Add health check for python3 and pynvim


### PR DESCRIPTION
Hi, I want neovim to use an isolated python environment and specified the executable via `g:python3_host_prog` variable. 

I think it's legit to expect CopilotChat.nvim plugin to run on it also. Could you accept this patch?