### PR TITLE
fix: fixed a typo in the prompt

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -4,7 +4,7 @@ local M = {}
 
 local default_prompts = {
   Explain = 'Explain how it works.',
-  Tests = 'Briefly how selected code works then generate unit tests.',
+  Tests = 'Briefly explain how selected code works then generate unit tests.',
 }
 
 _COPILOT_CHAT_GLOBAL_CONFIG = {}


### PR DESCRIPTION
Fixed a minor typo. The typo didn't break anything.