### PR TITLE
Language settings for copilot answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ return {
       show_help = "yes", -- Show help text for CopilotChatInPlace, default: yes
       debug = false, -- Enable or disable debug mode, the log file will be in ~/.local/state/nvim/CopilotChat.nvim.log
       disable_extra_info = 'no', -- Disable extra information (e.g: system prompt) in the response.
+      language = "English" -- Copilot answer language settings when using default prompts. Default language is English.
       -- proxy = "socks5://127.0.0.1:3000", -- Proxies requests via https or socks.
     },
     build = function()

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -15,6 +15,7 @@ _COPILOT_CHAT_GLOBAL_CONFIG = {}
 --       - disable_extra_info: ('yes' | 'no') default: 'yes'.
 --       - hide_system_prompt: ('yes' | 'no') default: 'yes'.
 --       - proxy: (string?) default: ''.
+--       - language: (string?) default: ''.
 --       - prompts: (table?) default: default_prompts.
 --       - debug: (boolean?) default: false.
 M.setup = function(options)

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -22,6 +22,7 @@ M.setup = function(options)
   vim.g.copilot_chat_disable_separators = options and options.disable_extra_info or 'yes'
   vim.g.copilot_chat_hide_system_prompt = options and options.hide_system_prompt or 'yes'
   vim.g.copilot_chat_proxy = options and options.proxy or ''
+  vim.g.copilot_chat_language = options and options.language or ''
   local debug = options and options.debug or false
   _COPILOT_CHAT_GLOBAL_CONFIG.debug = debug
 

--- a/rplugin/python3/CopilotChat/handlers/chat_handler.py
+++ b/rplugin/python3/CopilotChat/handlers/chat_handler.py
@@ -81,7 +81,7 @@ class ChatHandler:
         elif prompt == system_prompts.EXPLAIN_SHORTCUT:
             system_prompt = system_prompts.COPILOT_EXPLAIN
         if self.language != "":
-            system_prompt = system_prompts.PROMPT_ANSWER_LANGUAGE_TEMPLATE.substitute(language=self.language)
+            system_prompt = system_prompt + "\n" + system_prompts.PROMPT_ANSWER_LANGUAGE_TEMPLATE.substitute(language=self.language)
         return system_prompt
 
     def _add_start_separator(

--- a/rplugin/python3/CopilotChat/handlers/chat_handler.py
+++ b/rplugin/python3/CopilotChat/handlers/chat_handler.py
@@ -26,6 +26,7 @@ class ChatHandler:
         self.copilot: Copilot = None
         self.buffer: MyBuffer = buffer
         self.proxy: str = os.getenv("HTTPS_PROXY") or os.getenv("ALL_PROXY") or ""
+        self.language = self.nvim.eval("g:copilot_chat_language")
 
     # public
 
@@ -79,6 +80,8 @@ class ChatHandler:
             system_prompt = system_prompts.COPILOT_TESTS
         elif prompt == system_prompts.EXPLAIN_SHORTCUT:
             system_prompt = system_prompts.COPILOT_EXPLAIN
+        if self.language != "":
+            system_prompt = system_prompts.PROMPT_ANSWER_LANGUAGE_TEMPLATE.substitute(language=self.language)
         return system_prompt
 
     def _add_start_separator(

--- a/rplugin/python3/CopilotChat/handlers/inplace_chat_handler.py
+++ b/rplugin/python3/CopilotChat/handlers/inplace_chat_handler.py
@@ -20,6 +20,7 @@ class InPlaceChatHandler:
         self.diff_mode: bool = False
         self.model: str = MODEL_GPT4
         self.system_prompt: str = "SENIOR_DEVELOPER_PROMPT"
+        self.language = self.nvim.eval("g:copilot_chat_language")
 
         # Add user prompts collection
         self.user_prompts = self.nvim.eval("g:copilot_chat_user_prompts")

--- a/rplugin/python3/CopilotChat/handlers/vsplit_chat_handler.py
+++ b/rplugin/python3/CopilotChat/handlers/vsplit_chat_handler.py
@@ -14,6 +14,7 @@ class VSplitChatHandler(ChatHandler):
                 "filetype": "copilot-chat",
             },
         )
+        self.language = self.nvim.eval("g:copilot_chat_language")
 
     def vsplit(self):
         self.buffer.option("filetype", "copilot-chat")

--- a/rplugin/python3/CopilotChat/prompts.py
+++ b/rplugin/python3/CopilotChat/prompts.py
@@ -1,3 +1,5 @@
+from string import Template
+
 # pylint: disable=locally-disabled, multiple-statements, fixme, line-too-long
 COPILOT_INSTRUCTIONS = """You are an AI programming assistant.
 When asked for you name, you must respond with "GitHub Copilot".
@@ -249,3 +251,4 @@ You MUST add whitespace in the beginning of each line as needed to match the use
 """
 PROMPT_SIMPLE_DOCSTRING = "add simple docstring to this code"
 PROMPT_SEPARATE = "add comments separating the code into sections"
+PROMPT_ANSWER_LANGUAGE_TEMPLATE = Template("Please answer in ${language}")


### PR DESCRIPTION
Hi! I added the ability to set the language of Copilot answers.
If you originally create a prompt in the language you want the answer to be in "opts.prompts", the answer will be created in the corresponding language.
However, it is difficult to configure with "CopilotChatFixDiagnostic", so I added this setting item.
It works by adding language to opts in the settings.
If nothing is set, you will receive answers in English as before.
```
opts = {
      show_help = "yes",         -- Show help text for CopilotChatInPlace, default: yes
      debug = false,             -- Enable or disable debug mode, the log file will be in ~/.local/state/nvim/CopilotChat.nvim.log
      disable_extra_info = 'no', -- Disable extra information (e.g: system prompt) in the response.
      language = 'Japanese',
}
```
If it is not unnecessary, please consider merging it.
