### PR TITLE
fix: add check for temperature if empty string

### DIFF
--- a/rplugin/python3/CopilotChat/handlers/chat_handler.py
+++ b/rplugin/python3/CopilotChat/handlers/chat_handler.py
@@ -45,7 +45,7 @@ class ChatHandler:
             self.nvim.eval("g:copilot_chat_disable_separators") == "yes"
         )
         temperature = self.nvim.eval("g:copilot_chat_temperature")
-        if temperature is None:
+        if temperature is None or temperature == "":
             temperature = 0.1
         else:
             temperature = float(temperature)


### PR DESCRIPTION
This was causing an error on a fresh install.

100% understand if rather have a different fix!

Thanks for an awesome plugin.