### PR TITLE
docs: input for items with args

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ return {
     end,
     event = "VeryLazy",
     keys = {
-      { "<leader>ccb", "<cmd>CopilotChatBuffer<cr>", desc = "CopilotChat - Chat with current buffer" },
+      { "<leader>ccb", "<cmd>CopilotChatBuffer ", desc = "CopilotChat - Chat with current buffer" },
       { "<leader>cce", "<cmd>CopilotChatExplain<cr>", desc = "CopilotChat - Explain code" },
       { "<leader>cct", "<cmd>CopilotChatTests<cr>", desc = "CopilotChat - Generate tests" },
       {
@@ -63,7 +63,7 @@ return {
       },
       {
         "<leader>ccv",
-        ":CopilotChatVisual",
+        ":CopilotChatVisual ",
         mode = "x",
         desc = "CopilotChat - Open in vertical split",
       },


### PR DESCRIPTION
Hi, 
I don't know if this the correct way to use this, but when i tried it made more sense to have a space after these commands for input.

calling CopilotChatBuffer with no args throw

```
E471: Argument Required
```