### PR TITLE
Fix some inconsistencies with Lua refactor

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -14,15 +14,14 @@ local Chat = class(function(self, name)
   self.spinner = Spinner(self.bufnr, name)
 end)
 
-function Chat:validate()
-  if not vim.api.nvim_buf_is_valid(self.bufnr) then
-    self.bufnr = create_buf()
-    self.spinner.bufnr = self.bufnr
-  end
+function Chat:valid()
+  return vim.api.nvim_buf_is_valid(self.bufnr)
 end
 
 function Chat:append(str)
-  self:validate()
+  if not self:valid() then
+    return
+  end
 
   local last_line, last_column = self:last()
   vim.api.nvim_buf_set_text(
@@ -38,8 +37,6 @@ function Chat:append(str)
 end
 
 function Chat:last()
-  self:validate()
-
   local last_line = vim.api.nvim_buf_line_count(self.bufnr) - 1
   local last_line_content = vim.api.nvim_buf_get_lines(self.bufnr, -2, -1, false)
   local last_column = #last_line_content[1]

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -174,7 +174,7 @@ function M.open(config)
 
   local just_created = false
 
-  if not state.chat then
+  if not state.chat or not state.chat:valid() then
     state.chat = Chat(M.config.name)
     just_created = true
 
@@ -304,6 +304,7 @@ function M.ask(prompt, config)
     return
   end
 
+  M.open(config)
   config = vim.tbl_deep_extend('force', M.config, config or {})
 
   local system_prompt, updated_prompt = update_prompts(prompt)
@@ -314,8 +315,6 @@ function M.ask(prompt, config)
   if vim.trim(prompt) == '' then
     return
   end
-
-  M.open(config)
 
   if config.clear_chat_on_new_prompt then
     M.reset()
@@ -336,6 +335,7 @@ function M.ask(prompt, config)
     on_start = function()
       state.chat.spinner:start()
       append('**' .. M.config.name .. ':** ')
+      just_started = true
     end,
     on_done = function()
       append('\n\n' .. M.config.separator .. '\n\n')

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -300,11 +300,12 @@ end
 ---@param prompt (string)
 ---@param config (table | nil)
 function M.ask(prompt, config)
-  if not prompt then
+  M.open(config)
+
+  if not prompt or prompt == '' then
     return
   end
 
-  M.open(config)
   config = vim.tbl_deep_extend('force', M.config, config or {})
 
   local system_prompt, updated_prompt = update_prompts(prompt)
@@ -447,11 +448,7 @@ function M.setup(config)
   end
 
   vim.api.nvim_create_user_command('CopilotChat', function(args)
-    local input = ''
-    if args.args and vim.trim(args.args) ~= '' then
-      input = input .. ' ' .. args.args
-    end
-    M.ask(input)
+    M.ask(args.args)
   end, {
     nargs = '*',
     force = true,


### PR DESCRIPTION
- Do not send config that is merged with global config to M.open in M.ask so M.open do not thinks we are sendign layout change
- Properly mark chat as started from on_start event so the check for word at start of new copilot chat always works
- Add support for Visual Block selection to select.visual and optimize the existing code for other visual modes
- Fix issue where select.visual would enter insert mode instead of just exiting visual mode to normal mode
- Add support for getting cached copilot token on windows and error handling