### PR TITLE
docs: fixed up incorrect syntax for CopilotChatBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ return {
     end,
     event = "VeryLazy",
     keys = {
-      { "<leader>ccb", "<cmd>CopilotChatBuffer ", desc = "CopilotChat - Chat with current buffer" },
+      { "<leader>ccb", ":CopilotChatBuffer ", desc = "CopilotChat - Chat with current buffer" },
       { "<leader>cce", "<cmd>CopilotChatExplain<cr>", desc = "CopilotChat - Explain code" },
       { "<leader>cct", "<cmd>CopilotChatTests<cr>", desc = "CopilotChat - Generate tests" },
       {


### PR DESCRIPTION
I accidently made a PR with broken code for CopilotChatBuffer thanks @MikaelElkiaer for pointing that out

refer to this https://github.com/CopilotC-Nvim/CopilotChat.nvim/pull/79#discussion_r1505437986 