### PR TITLE
Fix issues with visual selection and folds, add set_debug

### DIFF
--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -242,7 +242,7 @@ function Copilot:ask(prompt, opts)
         })
 
         if not ok then
-          log.error('Failed parse response: ' .. tostring(err))
+          log.error('Failed parse response: ' .. tostring(content))
           if on_error then
             on_error(content)
           end

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -49,7 +49,7 @@ local function find_lines_between_separator_at_cursor(bufnr, separator)
     table.insert(result, lines[i])
   end
 
-  return vim.trim(table.concat(result, '\n')), last_separator_line, next_separator_line, line_count
+  return table.concat(result, '\n'), last_separator_line, next_separator_line, line_count
 end
 
 local function update_prompts(prompt, system_prompt)
@@ -206,7 +206,8 @@ function M.open(config)
       vim.keymap.set('n', config.mappings.submit_prompt, function()
         local input, start_line, end_line, line_count =
           find_lines_between_separator_at_cursor(state.chat.bufnr, config.separator)
-        if input ~= '' and not vim.startswith(vim.trim(input), '**' .. config.name .. ':**') then
+        input = vim.trim(input)
+        if input ~= '' then
           -- If we are entering the input at the end, replace it
           if line_count == end_line then
             vim.api.nvim_buf_set_lines(state.chat.bufnr, start_line, end_line, false, { '' })
@@ -233,7 +234,7 @@ function M.open(config)
           vim.api.nvim_buf_set_text(
             state.selection.buffer,
             state.selection.start_row - 1,
-            state.selection.start_col,
+            state.selection.start_col - 1,
             state.selection.end_row - 1,
             state.selection.end_col,
             vim.split(input, '\n')

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -55,22 +55,28 @@ end
 --- @return table|nil
 function M.visual()
   local mode = vim.fn.mode()
-  if mode ~= 'v' and mode ~= 'V' and mode ~= '\22' then
-    return nil
-  end
-
   local start = vim.fn.getpos('v')
   local finish = vim.fn.getpos('.')
 
-  -- Exit visual mode
-  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<esc>', true, false, true), 'x', true)
+  if start[2] == finish[2] and start[3] == finish[3] then
+    start = vim.fn.getpos("'<")
+    finish = vim.fn.getpos("'>")
+    mode = finish[3] == vim.v.maxcol and 'V' or 'v'
+  else
+    -- Exit visual mode
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<esc>', true, false, true), 'x', true)
+  end
 
   local lines, start_row, start_col, end_row, end_col = get_selection_lines(start, finish, mode)
+  local lines_content = table.concat(lines, '\n')
+  if vim.trim(lines_content) == '' then
+    return nil
+  end
 
   return {
     buffer = vim.api.nvim_get_current_buf(),
     filetype = vim.bo.filetype,
-    lines = table.concat(lines, '\n'),
+    lines = lines_content,
     start_row = start_row,
     start_col = start_col,
     end_row = end_row,

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -10,11 +10,14 @@ local function get_selection_lines(start, finish, mode)
   if start_col > finish_col then
     start_col, finish_col = finish_col, start_col
   end
+  if finish_col == vim.v.maxcol or mode == 'V' then
+    finish_col = #vim.api.nvim_buf_get_lines(0, finish_line - 1, finish_line, false)[1]
+  end
 
   if mode == 'V' then
     return vim.api.nvim_buf_get_lines(0, start_line - 1, finish_line, false),
       start_line,
-      start_col,
+      1,
       finish_line,
       finish_col
   end
@@ -61,7 +64,7 @@ function M.visual()
   if start[2] == finish[2] and start[3] == finish[3] then
     start = vim.fn.getpos("'<")
     finish = vim.fn.getpos("'>")
-    mode = finish[3] == vim.v.maxcol and 'V' or 'v'
+    mode = 'v'
   else
     -- Exit visual mode
     vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<esc>', true, false, true), 'x', true)


### PR DESCRIPTION
- Visual selection now uses also '< and '> as fallback when in command line mode
- Remove vim.print that I forgot when setting folds
- Add set_debug function that updates M.config.debug and updates logger
- Properly update prompts in case reference in prompt references another reference