### PR TITLE
feat: add git diff selection and commit message generation

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -435,6 +435,16 @@ M.config = {
       prompt = 'Please assist with the following diagnostic issue in file:',
       selection = select.diagnostics,
     },
+    Commit = {
+      prompt = 'Write commit message for the change with commitizen convention. Make sure the title has maximum 50 characters and message is wrapped at 72 characters. Wrap the whole message in code block with language gitcommit.',
+      selection = select.gitdiff,
+    },
+    CommitStaged = {
+      prompt = 'Write commit message for the change with commitizen convention. Make sure the title has maximum 50 characters and message is wrapped at 72 characters. Wrap the whole message in code block with language gitcommit.',
+      selection = function()
+        return select.gitdiff(true)
+      end,
+    },
   },
   selection = function()
     return select.visual() or select.line()

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -178,4 +178,31 @@ function M.diagnostics()
   return select_buffer
 end
 
+--- Select and process current git diff
+--- @param staged boolean @If true, it will return the staged changes
+--- @return table|nil
+function M.gitdiff(staged)
+  local select_buffer = M.buffer()
+  if not select_buffer then
+    return nil
+  end
+
+  local cmd = 'git diff --no-color --no-ext-diff' .. (staged and ' --staged' or '')
+  local handle = io.popen(cmd)
+  if not handle then
+    return nil
+  end
+
+  local result = handle:read('*a')
+  handle:close()
+
+  if not result or result == '' then
+    return nil
+  end
+
+  select_buffer.filetype = 'diff'
+  select_buffer.lines = result
+  return select_buffer
+end
+
 return M


### PR DESCRIPTION
This commit introduces the ability to select git diff content and generate commit messages following the commitizen convention. It adds two new selection methods, `Commit` and `CommitStaged`, to the `CopilotChat` module. These methods return the current git diff, with `CommitStaged` specifically returning staged changes. The `gitdiff` function in the `select` module is also updated to support this feature. This enhancement improves the utility of the chatbot in a version control context.

**This message was generated by this change :d**