### PR TITLE
feat: Add support for embeddings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.lua]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Also see [here](/lua/CopilotChat/config.lua):
   system_prompt = prompts.COPILOT_INSTRUCTIONS, -- System prompt to use
   model = 'gpt-4', -- GPT model to use
   temperature = 0.1, -- GPT temperature
+  context = 'manual', -- Context to use, 'buffers', 'buffer' or 'manual'
   debug = false, -- Enable debug logging
   show_user_selection = true, -- Shows user selection in chat
   show_system_prompt = false, -- Shows system prompt in chat
@@ -224,7 +225,7 @@ Also see [here](/lua/CopilotChat/config.lua):
   mappings = {
     close = 'q',
     reset = '<C-l>',
-    complete_after_slash = '<Tab>',
+    complete = '<Tab>',
     submit_prompt = '<CR>',
     accept_diff = '<C-y>',
     show_diff = '<C-d>',

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -7,6 +7,7 @@ local select = require('CopilotChat.select')
 
 ---@class CopilotChat.config.selection
 ---@field lines string
+---@field filename string?
 ---@field filetype string?
 ---@field start_row number?
 ---@field start_col number?
@@ -35,7 +36,7 @@ local select = require('CopilotChat.select')
 ---@class CopilotChat.config.mappings
 ---@field close string?
 ---@field reset string?
----@field complete_after_slash string?
+---@field complete string?
 ---@field submit_prompt string?
 ---@field accept_diff string?
 ---@field show_diff string?
@@ -45,6 +46,7 @@ local select = require('CopilotChat.select')
 ---@field system_prompt string?
 ---@field model string?
 ---@field temperature number?
+---@field context string?
 ---@field debug boolean?
 ---@field show_user_selection boolean?
 ---@field show_system_prompt boolean?
@@ -59,8 +61,9 @@ local select = require('CopilotChat.select')
 ---@field mappings CopilotChat.config.mappings?
 return {
   system_prompt = prompts.COPILOT_INSTRUCTIONS, -- System prompt to use
-  model = 'gpt-4', -- GPT model to use
+  model = 'gpt-4', -- GPT model to use, 'gpt-3.5-turbo' or 'gpt-4'
   temperature = 0.1, -- GPT temperature
+  context = 'manual', -- Context to use, 'buffers', 'buffer' or 'manual'
   debug = false, -- Enable debug logging
   show_user_selection = true, -- Shows user selection in chat
   show_system_prompt = false, -- Shows system prompt in chat
@@ -114,7 +117,7 @@ return {
   mappings = {
     close = 'q',
     reset = '<C-l>',
-    complete_after_slash = '<Tab>',
+    complete = '<Tab>',
     submit_prompt = '<CR>',
     accept_diff = '<C-y>',
     show_diff = '<C-d>',

--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -1,0 +1,223 @@
+local log = require('plenary.log')
+
+local M = {}
+
+local outline_types = {
+  'local_function',
+  'function_item',
+  'arrow_function',
+  'function_definition',
+  'function_declaration',
+  'method_definition',
+  'method_declaration',
+  'constructor_declaration',
+  'class_definition',
+  'class_declaration',
+  'interface_definition',
+  'interface_declaration',
+  'type_alias_declaration',
+  'import_statement',
+  'import_from_statement',
+}
+
+local comment_types = {
+  'comment',
+  'line_comment',
+  'block_comment',
+  'doc_comment',
+}
+
+local ignored_types = {
+  'export_statement',
+}
+
+local off_side_rule_languages = {
+  'python',
+  'coffeescript',
+  'nim',
+  'elm',
+  'curry',
+  'fsharp',
+}
+
+local function spatial_distance_cosine(a, b)
+  local dot_product = 0
+  local magnitude_a = 0
+  local magnitude_b = 0
+  for i = 1, #a do
+    dot_product = dot_product + a[i] * b[i]
+    magnitude_a = magnitude_a + a[i] * a[i]
+    magnitude_b = magnitude_b + b[i] * b[i]
+  end
+  magnitude_a = math.sqrt(magnitude_a)
+  magnitude_b = math.sqrt(magnitude_b)
+  return dot_product / (magnitude_a * magnitude_b)
+end
+
+local function data_ranked_by_relatedness(query, data, top_n)
+  local scores = {}
+  for i, item in pairs(data) do
+    scores[i] = { index = i, score = spatial_distance_cosine(item.embedding, query.embedding) }
+  end
+  table.sort(scores, function(a, b)
+    return a.score > b.score
+  end)
+  local result = {}
+  for i = 1, math.min(top_n, #scores) do
+    local srt = scores[i]
+    table.insert(result, vim.tbl_extend('keep', data[srt.index], { score = srt.score }))
+  end
+  return result
+end
+
+--- Build an outline for a buffer
+--- FIXME: Handle multiline function argument definitions when building the outline
+---@param bufnr number
+---@return CopilotChat.copilot.embed?
+function M.build_outline(bufnr)
+  local ft = vim.bo[bufnr].filetype
+  local name = vim.api.nvim_buf_get_name(bufnr)
+  local parser = vim.treesitter.get_parser(bufnr, ft)
+  if not parser then
+    return
+  end
+
+  local root = parser:parse()[1]:root()
+  local outline_lines = {}
+  local comment_lines = {}
+  local depth = 0
+
+  local function get_outline_lines(node)
+    local type = node:type()
+    local parent = node:parent()
+    local is_outline = vim.tbl_contains(outline_types, type)
+    local is_comment = vim.tbl_contains(comment_types, type)
+    local is_ignored = vim.tbl_contains(ignored_types, type)
+      or parent and vim.tbl_contains(ignored_types, parent:type())
+    local start_row, start_col, end_row, end_col = node:range()
+    local skip_inner = false
+
+    if is_outline then
+      depth = depth + 1
+
+      if #comment_lines > 0 then
+        for _, line in ipairs(comment_lines) do
+          table.insert(outline_lines, string.rep('  ', depth) .. line)
+        end
+        comment_lines = {}
+      end
+
+      local start_line = vim.api.nvim_buf_get_lines(bufnr, start_row, start_row + 1, false)[1]
+      local signature_start =
+        vim.api.nvim_buf_get_text(bufnr, start_row, start_col, start_row, #start_line, {})[1]
+      table.insert(outline_lines, string.rep('  ', depth) .. vim.trim(signature_start))
+
+      -- If the function definition spans multiple lines, add an ellipsis
+      if start_row ~= end_row then
+        table.insert(outline_lines, string.rep('  ', depth + 1) .. '...')
+      else
+        skip_inner = true
+      end
+    elseif is_comment then
+      skip_inner = true
+      local comment = vim.split(vim.treesitter.get_node_text(node, bufnr, {}), '\n')
+      for _, line in ipairs(comment) do
+        table.insert(comment_lines, vim.trim(line))
+      end
+    elseif not is_ignored then
+      comment_lines = {}
+    end
+
+    if not skip_inner then
+      for child in node:iter_children() do
+        get_outline_lines(child)
+      end
+    end
+
+    if is_outline then
+      if not skip_inner and not vim.tbl_contains(off_side_rule_languages, ft) then
+        local signature_end =
+          vim.trim(vim.api.nvim_buf_get_text(bufnr, end_row, 0, end_row, end_col, {})[1])
+        table.insert(outline_lines, string.rep('  ', depth) .. signature_end)
+      end
+      depth = depth - 1
+    end
+  end
+
+  get_outline_lines(root)
+  local content = table.concat(outline_lines, '\n')
+  if content == '' then
+    return
+  end
+
+  return {
+    content = table.concat(outline_lines, '\n'),
+    filename = name,
+    filetype = ft,
+  }
+end
+
+--- Find items for a query
+---@param copilot CopilotChat.Copilot
+---@param context string?
+---@param prompt string
+---@param selection string?
+---@param filename string
+---@param filetype string
+---@param bufnr number
+---@param on_done function
+function M.find_for_query(copilot, context, prompt, selection, filename, filetype, bufnr, on_done)
+  local outline = {}
+
+  if context == 'buffers' then
+    outline = vim.tbl_map(
+      function(b)
+        return M.build_outline(b)
+      end,
+      vim.tbl_filter(function(b)
+        return vim.api.nvim_buf_is_loaded(b) and vim.fn.buflisted(b) == 1
+      end, vim.api.nvim_list_bufs())
+    )
+  elseif context == 'buffer' then
+    table.insert(outline, M.build_outline(bufnr))
+  end
+
+  if #outline == 0 then
+    on_done({})
+    return
+  end
+
+  copilot:embed(outline, {
+    on_done = function(out)
+      log.debug(string.format('Got %s embeddings', #out))
+
+      if #out == 0 then
+        on_done({})
+        return
+      end
+
+      copilot:embed({
+        {
+          prompt = prompt,
+          content = selection,
+          filename = filename,
+          filetype = filetype,
+        },
+      }, {
+        on_done = function(query_out)
+          local query = query_out[1]
+          log.debug('Prompt:', query.prompt)
+          log.debug('Content:', query.content)
+          local data = data_ranked_by_relatedness(query, out, 20)
+          log.debug('Ranked data:', #data)
+          for i, item in ipairs(data) do
+            log.debug(string.format('%s: %s - %s', i, item.score, item.filename))
+          end
+          on_done(data)
+        end,
+      })
+    end,
+  })
+end
+
+return M

--- a/lua/CopilotChat/debuginfo.lua
+++ b/lua/CopilotChat/debuginfo.lua
@@ -1,4 +1,5 @@
 local utils = require('CopilotChat.utils')
+local context = require('CopilotChat.context')
 local M = {}
 
 function M.setup()
@@ -9,29 +10,54 @@ function M.setup()
 
     -- Create a popup with the log file path
     local lines = {
-      'CopilotChat.nvim Info:',
-      '- Log file path: ' .. log_file_path,
       'If you are facing issues, run `:checkhealth CopilotChat` and share the output.',
-      'Press `q` to close this window.',
+      '',
+      'Log file path:',
+      '`' .. log_file_path .. '`',
+      '',
     }
+
+    local outline = context.build_outline(vim.api.nvim_get_current_buf())
+    if outline then
+      table.insert(lines, 'Current buffer outline:')
+      table.insert(lines, '`' .. outline.filename .. '`')
+      table.insert(lines, '```' .. outline.filetype)
+      local outline_lines = vim.split(outline.content, '\n')
+      for _, line in ipairs(outline_lines) do
+        table.insert(lines, line)
+      end
+      table.insert(lines, '```')
+    end
 
     local width = 0
     for _, line in ipairs(lines) do
       width = math.max(width, #line)
     end
-    local height = #lines
+    local height = math.min(vim.o.lines - 3, #lines)
     local opts = {
+      title = 'CopilotChat.nvim Debug Info',
+      footer = "Press 'q' to close this window.",
       relative = 'editor',
-      width = width + 4,
-      height = height + 2,
+      width = width,
+      height = height,
       row = (vim.o.lines - height) / 2 - 1,
       col = (vim.o.columns - width) / 2,
       style = 'minimal',
       border = 'rounded',
     }
+
     local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.bo[bufnr].syntax = 'markdown'
     vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
-    vim.api.nvim_open_win(bufnr, true, opts)
+    vim.bo[bufnr].modifiable = false
+    vim.treesitter.start(bufnr, 'markdown')
+
+    local win = vim.api.nvim_open_win(bufnr, true, opts)
+    vim.wo[win].wrap = true
+    vim.wo[win].linebreak = true
+    vim.wo[win].cursorline = true
+    vim.wo[win].conceallevel = 2
+    vim.wo[win].concealcursor = 'niv'
 
     -- Bind 'q' to close the window
     vim.api.nvim_buf_set_keymap(

--- a/lua/CopilotChat/prompts.lua
+++ b/lua/CopilotChat/prompts.lua
@@ -95,7 +95,7 @@ The reply should be a codeblock containing the original code with the documentat
 Use the most appropriate documentation style for the programming language used (e.g. JSDoc for JavaScript, docstrings for Python etc.)
 ]]
 
-COPILOT_WORKSPACE =
+M.COPILOT_WORKSPACE =
   [[You are a software engineer with expert knowledge of the codebase the user has open in their workspace.
 When asked for your name, you must respond with "GitHub Copilot".
 Follow the user's requirements carefully & to the letter.
@@ -156,7 +156,7 @@ Response:
 To read a file, you can use a [`FileReader`](src/fs/fileReader.ts) class from [src/fs/fileReader.ts](src/fs/fileReader.ts).
 ]]
 
-EMBEDDING_KEYWORDS =
+M.COPILOT_KEYWORDS =
   [[You are a coding assistant who help the user answer questions about code in their workspace by providing a list of relevant keywords they can search for to answer the question.
 The user will provide you with potentially relevant information from the workspace. This information may be incomplete.
 DO NOT ask the user for additional information or clarification.

--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -55,6 +55,10 @@ function M.setup()
   end)
 end
 
+function M.available()
+  return tiktoken_core ~= nil
+end
+
 function M.encode(prompt)
   if not tiktoken_core then
     return nil
@@ -70,6 +74,10 @@ function M.encode(prompt)
 end
 
 function M.count(prompt)
+  if not tiktoken_core then
+    return math.ceil(#prompt * 0.5) -- Fallback to 1/2 character count
+  end
+
   local tokens = M.encode(prompt)
   if not tokens then
     return 0

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -33,4 +33,22 @@ function M.is_stable()
   return vim.fn.has('nvim-0.10.0') == 0
 end
 
+--- Join multiple async functions
+function M.join(on_done, fns)
+  local count = #fns
+  local results = {}
+  local function done()
+    count = count - 1
+    if count == 0 then
+      on_done(results)
+    end
+  end
+  for i, fn in ipairs(fns) do
+    fn(function(result)
+      results[i] = result
+      done()
+    end)
+  end
+end
+
 return M


### PR DESCRIPTION
Closes #5 

How it works:
1. Grabs outline for all functions for all currently opened buffers
2. Generates embeddings for all the functions
3. Generates embedding from current code selection
4. Uses spatial cosine distance to find similar embeddings to code selection
5. Sends top x matched embeddings as part of the query to copilot in format:

````markdown
query
File: `<filename1>`
```<filetype_for_filename1>
<embeddings_for_filename1>
```
File: `<filename2>`
```<filetype_for_filename2>
<embeddings_for_filename2>
```
etc
````

TODO:
- [x] Embed all open buffers
- [x] Embed current buffer
- [x] Limit based on token count (wait for tiktoken lua)
- [x] Add config options of what should be embedded

## Example
![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/5115805/4935d650-134b-4227-a112-95b794f4e6eb)

![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/5115805/6b489550-8d4f-43f0-b8bc-f15b9a8f106c)

## Outline debugging (inside of `CopilotChatDebugInfo`):

![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/5115805/06334bea-b0c0-4da3-845a-c537c305dacf)

## Context selection

![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/5115805/9a107f7e-81c5-484c-a228-fe394eb1a952)

