### PR TITLE
fix: Typo in chat.lua

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -115,7 +115,7 @@ function Chat:open(config)
       local orig = vim.api.nvim_get_current_win()
       vim.cmd('vsplit')
       self.winnr = vim.api.nvim_get_current_win()
-      vim.api.nvim_win_set_buf(self .. window, self.bufnr)
+      vim.api.nvim_win_set_buf(self.winnr, self.bufnr)
       vim.api.nvim_set_current_win(orig)
     else
       win_opts.vertical = true


### PR DESCRIPTION
When migrating to the canary branch, making most of the migration changes, and using the same, but slightly modified, config by [@jellydn](https://github.com/jellydn/lazy-nvim-ide/blob/main/lua/plugins/extras/copilot-chat-v2.lua). 

I then highlighting a selection, using `<leader>ccp`, and then asking for a review, the following error appears.

```
Error: E5108: Error executing lua: ...hare/nvim/lazy/CopilotChat.nvim/lua/CopilotChat/chat.lua:118: attempt to concatenate local 'self' (a table value)
stack traceback:
	...hare/nvim/lazy/CopilotChat.nvim/lua/CopilotChat/chat.lua:118: in function 'open'
	...hare/nvim/lazy/CopilotChat.nvim/lua/CopilotChat/init.lua:263: in function 'open'
	...hare/nvim/lazy/CopilotChat.nvim/lua/CopilotChat/init.lua:292: in function 'ask'
	...ilotChat.nvim/lua/CopilotChat/integrations/telescope.lua:52: in function 'run_replace_or_original'
	...re/nvim/lazy/telescope.nvim/lua/telescope/actions/mt.lua:65: in function 'key_func'
	...hare/nvim/lazy/telescope.nvim/lua/telescope/mappings.lua:253: in function <...hare/nvim/lazy/telescope.nvim/lua/telescope/mappings.lua:252>
```

There is a typo on line 118 of chat.lua where

`vim.api.nvim_win_set_buf(self .. window, self.bufnr)`

should be 

`vim.api.nvim_win_set_buf(self.winnr, self.bufnr)`