### PR TITLE
feat: add option to disable tiktoken count in CopilotChat

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -57,6 +57,7 @@ local select = require('CopilotChat.select')
 ---@field auto_follow_cursor boolean?
 ---@field name string?
 ---@field separator string?
+---@field enable_tiktoken boolean?
 ---@field prompts table<string, CopilotChat.config.prompt|string>?
 ---@field selection nil|fun(source: CopilotChat.config.source):CopilotChat.config.selection?
 ---@field window CopilotChat.config.window?
@@ -76,6 +77,7 @@ return {
   auto_follow_cursor = true, -- Auto-follow cursor in chat
   name = 'CopilotChat', -- Name to use in chat
   separator = '---', -- Separator to use in chat
+  enable_tiktoken = false, -- Enable tiktoken count on chat response
   -- default prompts
   prompts = {
     Explain = {

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -507,7 +507,7 @@ function M.setup(config)
     M.reset()
   end)
 
-  tiktoken.setup()
+  tiktoken.setup(M.config.enable_tiktoken)
   debuginfo.setup()
   M.debug(M.config.debug)
 

--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -35,9 +35,12 @@ end
 
 local M = {}
 
-function M.setup()
+--- Setup the tiktoken module
+--- It might be a bit slower so it's disabled by default
+---@param is_enabled boolean
+function M.setup(is_enabled)
   local ok, core = pcall(require, 'tiktoken_core')
-  if not ok then
+  if not ok or not is_enabled then
     return
   end
 


### PR DESCRIPTION
# Why

It might be a bit slower with tiktoken module so it's disabled by default

# How

Add `enable_tiktoken` flag