### PR TITLE
Fix Lua callback Vimscript calls, closes #181

### DIFF
--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -47,6 +47,16 @@ local function uuid()
   )
 end
 
+local function file_write(path, data, mode)
+  mode = mode or 'w' -- Default mode is write, which overwrites the file
+  local file, err = io.open(path, mode)
+  if not file then
+    error('Error opening file: ' .. tostring(err))
+  end
+  file:write(data)
+  file:close()
+end
+
 local function machine_id()
   local length = 65
   local hex_chars = '0123456789abcdef'
@@ -370,8 +380,8 @@ function Copilot:ask(prompt, opts)
 
   self.current_job_on_cancel = on_done
 
-  local temp_file = vim.fn.tempname()
-  vim.fn.writefile({ body }, temp_file)
+  local temp_file = os.tmpname()
+  file_write(temp_file, body)
   self.current_job = curl
     .post(url, {
       headers = headers,
@@ -487,8 +497,8 @@ function Copilot:embed(inputs, opts)
     local body = vim.json.encode(generate_embedding_request(chunk, model))
 
     table.insert(jobs, function(resolve)
-      local temp_file = vim.fn.tempname()
-      vim.fn.writefile({ body }, temp_file)
+      local temp_file = os.tmpname()
+      file_write(temp_file, body)
 
       curl.post(url, {
         headers = headers,


### PR DESCRIPTION
**Title: Resolve Lua-Vimscript Callback Issues (#181)**

**Changes:**
- Replaced `vim.fn.tempname` with `os.tmpname()` and `vim.fn.writefile` with custom Lua file writing function to fix `E5560` errors.
- Ensured compatibility by adapting plugin functionalities to native Lua operations.

**Motivation:**
Addressed errors related to calling Vimscript functions from Lua callbacks, improving plugin stability and performance.

**Testing:**
Conducted manual tests to confirm correct behavior.