### PR TITLE
fix: Improve stability of job cancellation and chat reset

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -86,8 +86,6 @@ local function find_lines_between_separator(lines, pattern, at_least_one)
   return result, separator_line_start, separator_line_finish, line_count
 end
 
-local function show_diff_between_selection_and_copilot(selection) end
-
 local function update_prompts(prompt, system_prompt)
   local prompts_to_use = M.prompts()
   local try_again = false
@@ -298,6 +296,10 @@ function M.ask(prompt, config, source)
     updated_prompt = updated_prompt .. ' ' .. selection.prompt_extra
   end
 
+  if state.copilot:stop() then
+    append('\n\n' .. config.separator .. '\n\n')
+  end
+
   append(updated_prompt)
   append('\n\n**' .. config.name .. '** ' .. config.separator .. '\n\n')
   state.chat:follow()
@@ -359,8 +361,8 @@ end
 --- Reset the chat window and show the help message.
 function M.reset()
   state.copilot:reset()
-  state.chat:clear()
   vim.schedule(function()
+    state.chat:clear()
     append('\n')
     state.chat:finish()
   end)
@@ -589,7 +591,8 @@ function M.setup(config)
       end, { buffer = bufnr })
     end
 
-    M.reset()
+    append('\n')
+    state.chat:finish()
   end)
 
   tiktoken.setup()

--- a/lua/CopilotChat/spinner.lua
+++ b/lua/CopilotChat/spinner.lua
@@ -38,7 +38,11 @@ function Spinner:start()
     0,
     100,
     vim.schedule_wrap(function()
-      if not vim.api.nvim_buf_is_valid(self.bufnr) then
+      if
+        not vim.api.nvim_buf_is_valid(self.bufnr)
+        or not vim.api.nvim_buf_is_loaded(self.bufnr)
+        or not self.timer
+      then
         self:finish()
         return
       end
@@ -68,10 +72,11 @@ function Spinner:finish()
     return
   end
 
-  self.timer:stop()
-  self.timer:close()
+  local timer = self.timer
   self.timer = nil
 
+  timer:stop()
+  timer:close()
   vim.api.nvim_buf_del_extmark(self.bufnr, self.ns, self.ns)
   vim.notify('Done!', vim.log.levels.INFO, { title = self.title })
 end


### PR DESCRIPTION
Without this when entering new prompt while one is already running, the chat do not properly outputs the change. Also this makes sure that job is cancelled early so on_done, on_error callbacks after are skipped to reduce text being written to buffer when not necessary/wanted.