### PR TITLE
fix: Fix diff highlights for overlays

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -29,9 +29,8 @@ function CopilotChatFoldExpr(lnum, separator)
   return '='
 end
 
-local Chat = class(function(self, mark_ns, hl_ns, help, on_buf_create)
+local Chat = class(function(self, mark_ns, help, on_buf_create)
   self.mark_ns = mark_ns
-  self.hl_ns = hl_ns
   self.help = help
   self.on_buf_create = on_buf_create
   self.bufnr = nil
@@ -153,7 +152,6 @@ function Chat:open(config)
     self.winnr = vim.api.nvim_open_win(self.bufnr, false, win_opts)
   end
 
-  vim.api.nvim_win_set_hl_ns(self.winnr, self.hl_ns)
   vim.wo[self.winnr].wrap = true
   vim.wo[self.winnr].linebreak = true
   vim.wo[self.winnr].cursorline = true

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -453,6 +453,7 @@ function M.setup(config)
   state.diff = Overlay(
     'copilot-diff',
     mark_ns,
+    hl_ns,
     "'"
       .. M.config.mappings.close
       .. "' to close diff.\n'"
@@ -493,21 +494,33 @@ function M.setup(config)
     end
   )
 
-  state.system_prompt = Overlay('copilot-system-prompt', mark_ns, overlay_help, function(bufnr)
-    if M.config.mappings.close then
-      vim.keymap.set('n', M.config.mappings.close, function()
-        state.system_prompt:restore(state.chat.winnr, state.chat.bufnr)
-      end, { buffer = bufnr })
+  state.system_prompt = Overlay(
+    'copilot-system-prompt',
+    mark_ns,
+    hl_ns,
+    overlay_help,
+    function(bufnr)
+      if M.config.mappings.close then
+        vim.keymap.set('n', M.config.mappings.close, function()
+          state.system_prompt:restore(state.chat.winnr, state.chat.bufnr)
+        end, { buffer = bufnr })
+      end
     end
-  end)
+  )
 
-  state.user_selection = Overlay('copilot-user-selection', mark_ns, overlay_help, function(bufnr)
-    if M.config.mappings.close then
-      vim.keymap.set('n', M.config.mappings.close, function()
-        state.user_selection:restore(state.chat.winnr, state.chat.bufnr)
-      end, { buffer = bufnr })
+  state.user_selection = Overlay(
+    'copilot-user-selection',
+    mark_ns,
+    hl_ns,
+    overlay_help,
+    function(bufnr)
+      if M.config.mappings.close then
+        vim.keymap.set('n', M.config.mappings.close, function()
+          state.user_selection:restore(state.chat.winnr, state.chat.bufnr)
+        end, { buffer = bufnr })
+      end
     end
-  end)
+  )
 
   local chat_help = ''
   local chat_keys = vim.tbl_keys(M.config.mappings)
@@ -529,7 +542,7 @@ function M.setup(config)
     .. M.config.mappings.complete
     .. ' for different completion options.'
 
-  state.chat = Chat(mark_ns, hl_ns, chat_help, function(bufnr)
+  state.chat = Chat(mark_ns, chat_help, function(bufnr)
     if M.config.mappings.complete then
       vim.keymap.set('i', M.config.mappings.complete, complete, { buffer = bufnr })
     end

--- a/lua/CopilotChat/overlay.lua
+++ b/lua/CopilotChat/overlay.lua
@@ -9,8 +9,9 @@ local utils = require('CopilotChat.utils')
 local class = utils.class
 local show_virt_line = utils.show_virt_line
 
-local Overlay = class(function(self, name, mark_ns, help, on_buf_create)
+local Overlay = class(function(self, name, mark_ns, hl_ns, help, on_buf_create)
   self.mark_ns = mark_ns
+  self.hl_ns = hl_ns
   self.help = help
   self.on_buf_create = on_buf_create
   self.bufnr = nil
@@ -52,6 +53,7 @@ function Overlay:show(text, filetype, syntax, winnr)
   show_virt_line(self.help, math.max(0, line), self.bufnr, self.mark_ns)
 
   -- Dual mode with treesitter (for diffs for example)
+  vim.api.nvim_win_set_hl_ns(winnr, self.hl_ns)
   local ok, parser = pcall(vim.treesitter.get_parser, self.bufnr, syntax)
   if ok and parser then
     vim.treesitter.start(self.bufnr, syntax)
@@ -64,6 +66,7 @@ end
 function Overlay:restore(winnr, bufnr)
   self.current = nil
   vim.api.nvim_win_set_buf(winnr, bufnr)
+  vim.api.nvim_win_set_hl_ns(winnr, 0)
 end
 
 return Overlay


### PR DESCRIPTION
Needs to be set when showing the text and not in advance. Accidentally broke this in a72ad269de9621a3df31afab281674b54ce3320b