### PR TITLE
 Add relativenumber to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ Also see [here](/lua/CopilotChat/config.lua):
     title = 'Copilot Chat', -- title of chat window
     footer = nil, -- footer of chat window
     zindex = 1, -- determines if window is on top or below other floating windows
+    options = {
+      relativenumber = false, -- show relative line numbers
+    },
   },
   -- default mappings
   mappings = {

--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -152,12 +152,14 @@ function Chat:open(config)
     self.winnr = vim.api.nvim_open_win(self.bufnr, false, win_opts)
   end
 
+  local wo = config.window.options
+
   vim.wo[self.winnr].wrap = true
   vim.wo[self.winnr].linebreak = true
   vim.wo[self.winnr].cursorline = true
   vim.wo[self.winnr].conceallevel = 2
   vim.wo[self.winnr].foldlevel = 99
-  vim.wo[self.winnr].relativenumber = false
+  vim.wo[self.winnr].relativenumber = wo.relativenumber
   if config.show_folds then
     vim.wo[self.winnr].foldcolumn = '1'
     vim.wo[self.winnr].foldmethod = 'expr'

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -21,6 +21,9 @@ local select = require('CopilotChat.select')
 ---@field mapping string?
 ---@field description string?
 
+---@class CopilotChat.config.window.options
+---@field relativenumber boolean?
+
 ---@class CopilotChat.config.window
 ---@field layout string?
 ---@field relative string?
@@ -32,6 +35,7 @@ local select = require('CopilotChat.select')
 ---@field title string?
 ---@field footer string?
 ---@field zindex number?
+---@field options CopilotChat.config.window.options?
 
 ---@class CopilotChat.config.mappings
 ---@field close string?
@@ -125,6 +129,9 @@ return {
     title = 'Copilot Chat', -- title of chat window
     footer = nil, -- footer of chat window
     zindex = 1, -- determines if window is on top or below other floating windows
+    options = {
+      relativenumber = false, -- show relative line numbers
+    },
   },
   -- default mappings
   mappings = {


### PR DESCRIPTION
Adds a window options field to the config that allows setting relative numbers for the chat window. 

```lua
  -- default window options
  window = {
    layout = 'vertical', -- 'vertical', 'horizontal', 'float'
    -- Options below only apply to floating windows
    relative = 'editor', -- 'editor', 'win', 'cursor', 'mouse'
    border = 'single', -- 'none', single', 'double', 'rounded', 'solid', 'shadow'
    width = 0.8, -- fractional width of parent
    height = 0.6, -- fractional height of parent
    row = nil, -- row position of the window, default is centered
    col = nil, -- column position of the window, default is centered
    title = 'Copilot Chat', -- title of chat window
    footer = nil, -- footer of chat window
    zindex = 1, -- determines if window is on top or below other floating windows
    options = {
      relativenumber = false, -- show relative line numbers
    },
  },
```
Resolves #187 
### How it looks
![Screenshot 2024-03-17 at 11 04 55 p m](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/65783495/223e2194-5b83-4757-a0f5-2e44e0ba1a90)
