### PR TITLE
docs: explain setting buffer options and remove default for relative number

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,19 @@ You can define custom system prompts by using `system_prompt` property when pass
 }
 ```
 
+### Customizing buffers
+
+You can set local options for the buffers that are created by this plugin: `copilot-diff`, `copilot-system-prompt`, `copilot-user-selection`, `copilot-chat`.
+
+```lua
+vim.api.nvim_create_autocmd('BufEnter', {
+    pattern = 'copilot-*',
+    callback = function()
+        vim.opt_local.relativenumber = true
+    end
+})
+```
+
 ## Tips
 
 <details>

--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -157,7 +157,6 @@ function Chat:open(config)
   vim.wo[self.winnr].cursorline = true
   vim.wo[self.winnr].conceallevel = 2
   vim.wo[self.winnr].foldlevel = 99
-  vim.wo[self.winnr].relativenumber = false
   if config.show_folds then
     vim.wo[self.winnr].foldcolumn = '1'
     vim.wo[self.winnr].foldmethod = 'expr'


### PR DESCRIPTION
Updates README.md with buffer names and autocommand to set local options for these buffers. Also removes overriding users relative number setting.

Referenced in this discussion: #196 

## Changes

In **README.md** > **Configuration**:


### Customizing buffers

You can set local options for the buffers that are created by this plugin: `copilot-diff`, `copilot-system-prompt`, `copilot-user-selection`, `copilot-chat`.

```lua
vim.api.nvim_create_autocmd('BufEnter', {
    pattern = 'copilot-*',
    callback = function()
        vim.opt_local.relativenumber = true
    end
})
```