### PR TITLE
feat: Show token count as virtual line instead of in buffer

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -11,7 +11,7 @@
 ---@field close fun(self: CopilotChat.Chat)
 ---@field focus fun(self: CopilotChat.Chat)
 ---@field follow fun(self: CopilotChat.Chat)
----@field finish fun(self: CopilotChat.Chat)
+---@field finish fun(self: CopilotChat.Chat, msg: string?)
 
 local Overlay = require('CopilotChat.overlay')
 local Spinner = require('CopilotChat.spinner')
@@ -196,15 +196,24 @@ function Chat:follow()
   vim.api.nvim_win_set_cursor(self.winnr, { last_line + 1, last_column })
 end
 
-function Chat:finish()
+function Chat:finish(msg)
   if not self.spinner then
     return
   end
 
   self.spinner:finish()
-  if self.help and self.help ~= '' then
+
+  if msg and msg ~= '' then
+    if self.help and self.help ~= '' then
+      msg = msg .. '\n' .. self.help
+    end
+  else
+    msg = self.help
+  end
+
+  if msg and msg ~= '' then
     local line = vim.api.nvim_buf_line_count(self.bufnr) - 1
-    show_virt_line(self.help, math.max(0, line - 1), self.bufnr, self.mark_ns)
+    show_virt_line(msg, math.max(0, line - 1), self.bufnr, self.mark_ns)
   end
 end
 

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -341,11 +341,12 @@ function M.ask(prompt, config, source)
         on_error = on_error,
         on_done = function(response, token_count)
           vim.schedule(function()
-            if tiktoken.available() and token_count and token_count > 0 then
-              append('\n\n' .. token_count .. ' tokens used')
-            end
             append('\n\n' .. config.separator .. '\n\n')
-            state.chat:finish()
+            if tiktoken.available() and token_count and token_count > 0 then
+              state.chat:finish(token_count .. ' tokens used')
+            else
+              state.chat:finish()
+            end
             if config.callback then
               config.callback(response)
             end


### PR DESCRIPTION
No reason to write out the tokens to buffer,and it also messes up the history when saving chats so just show it as virtual line instead

![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/5115805/c9b8c39a-8068-4a8f-bf50-63b275bdfd8f)
