### PR TITLE
fix: Use prompt selection when picking prompts

### DIFF
--- a/lua/CopilotChat/actions.lua
+++ b/lua/CopilotChat/actions.lua
@@ -1,7 +1,6 @@
 ---@class CopilotChat.integrations.actions
 ---@field prompt string: The prompt to display
----@field selection fun(source: CopilotChat.config.source):CopilotChat.config.selection?
----@field actions table<string, string>: A table with the actions to pick from
+---@field actions table<string, CopilotChat.config.prompt>: A table with the actions to pick from
 
 local select = require('CopilotChat.select')
 local chat = require('CopilotChat')
@@ -11,22 +10,26 @@ local M = {}
 --- Diagnostic help actions
 ---@return CopilotChat.integrations.actions?: The help actions
 function M.help_actions()
-  local diagnostic = select.diagnostics({
-    bufnr = vim.api.nvim_get_current_buf(),
-    winnr = vim.api.nvim_get_current_win(),
-  })
-  if not diagnostic then
-    return
+  local bufnr = vim.api.nvim_get_current_buf()
+  local winnr = vim.api.nvim_get_current_win()
+  local cursor = vim.api.nvim_win_get_cursor(winnr)
+  local line_diagnostics = vim.lsp.diagnostic.get_line_diagnostics(bufnr, cursor[1] - 1)
+
+  if #line_diagnostics == 0 then
+    return nil
   end
 
   return {
     prompt = 'Copilot Chat Help Actions',
-    selection = select.buffer,
     actions = {
-      ['Fix diagnostic'] = 'Please assist with fixing the following diagnostic issue in file: "'
-        .. diagnostic.prompt_extra,
-      ['Explain diagnostic'] = 'Please explain the following diagnostic issue in file: "'
-        .. diagnostic.prompt_extra,
+      ['Fix diagnostic'] = {
+        prompt = 'Please assist with fixing the following diagnostic issue in file: "',
+        selection = select.diagnostics,
+      },
+      ['Explain diagnostic'] = {
+        prompt = 'Please explain the following diagnostic issue in file: "',
+        selection = select.diagnostics,
+      },
     },
   }
 end
@@ -36,27 +39,21 @@ end
 function M.prompt_actions()
   local actions = {}
   for name, prompt in pairs(chat.prompts(true)) do
-    actions[name] = prompt.prompt
+    actions[name] = prompt
   end
   return {
     prompt = 'Copilot Chat Prompt Actions',
-    selection = select.visual,
     actions = actions,
   }
 end
 
 --- Pick an action from a list of actions
 ---@param pick_actions CopilotChat.integrations.actions?: A table with the actions to pick from
----@param config CopilotChat.config?: The chat configuration
 ---@param opts table?: vim.ui.select options
-function M.pick(pick_actions, config, opts)
+function M.pick(pick_actions, opts)
   if not pick_actions or not pick_actions.actions or vim.tbl_isempty(pick_actions.actions) then
     return
   end
-
-  config = vim.tbl_extend('force', {
-    selection = pick_actions.selection,
-  }, config or {})
 
   opts = vim.tbl_extend('force', {
     prompt = pick_actions.prompt .. '> ',
@@ -67,7 +64,7 @@ function M.pick(pick_actions, config, opts)
       return
     end
     vim.defer_fn(function()
-      chat.ask(pick_actions.actions[selected], config)
+      chat.ask(pick_actions.actions[selected].prompt, pick_actions.actions[selected])
     end, 100)
   end)
 end

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -17,9 +17,12 @@ local select = require('CopilotChat.select')
 
 ---@class CopilotChat.config.prompt
 ---@field prompt string?
----@field selection nil|fun(source: CopilotChat.config.source):CopilotChat.config.selection?
----@field mapping string?
 ---@field description string?
+---@field kind string?
+---@field mapping string?
+---@field system_prompt string?
+---@field callback fun(response: string)?
+---@field selection nil|fun(source: CopilotChat.config.source):CopilotChat.config.selection?
 
 ---@class CopilotChat.config.window
 ---@field layout string?

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -94,7 +94,7 @@ local function update_prompts(prompt, system_prompt)
     if found then
       if found.kind == 'user' then
         local out = found.prompt
-        if string.match(out, [[/[%w_]+]]) then
+        if out and string.match(out, [[/[%w_]+]]) then
           try_again = true
         end
         return out
@@ -191,6 +191,7 @@ end
 
 --- Get the prompts to use.
 ---@param skip_system boolean|nil
+---@return table<string, CopilotChat.config.prompt>
 function M.prompts(skip_system)
   local function get_prompt_kind(name)
     return vim.startswith(name, 'COPILOT_') and 'system' or 'user'
@@ -225,7 +226,7 @@ function M.prompts(skip_system)
 end
 
 --- Open the chat window.
----@param config CopilotChat.config?
+---@param config CopilotChat.config|CopilotChat.config.prompt|nil
 ---@param source CopilotChat.config.source?
 function M.open(config, source, no_focus)
   local should_reset = config and config.window ~= nil and not vim.tbl_isempty(config.window)
@@ -270,7 +271,7 @@ end
 
 --- Ask a question to the Copilot model.
 ---@param prompt string
----@param config CopilotChat.config|nil
+---@param config CopilotChat.config|CopilotChat.config.prompt|nil
 ---@param source CopilotChat.config.source?
 function M.ask(prompt, config, source)
   M.open(config, source, true)
@@ -383,7 +384,9 @@ function M.save(name, history_path)
   end
 
   history_path = history_path or M.config.history_path
-  state.copilot:save(name, history_path)
+  if history_path then
+    state.copilot:save(name, history_path)
+  end
 end
 
 --- Load the chat history from a file.
@@ -397,6 +400,10 @@ function M.load(name, history_path)
   end
 
   history_path = history_path or M.config.history_path
+  if not history_path then
+    return
+  end
+
   state.copilot:reset()
   state.chat:clear()
 
@@ -677,7 +684,9 @@ function M.setup(config)
       if args.args and vim.trim(args.args) ~= '' then
         input = input .. ' ' .. args.args
       end
-      M.ask(input, prompt)
+      if input then
+        M.ask(input, prompt)
+      end
     end, {
       nargs = '*',
       force = true,

--- a/lua/CopilotChat/integrations/fzflua.lua
+++ b/lua/CopilotChat/integrations/fzflua.lua
@@ -5,21 +5,16 @@ local M = {}
 
 --- Pick an action from a list of actions
 ---@param pick_actions CopilotChat.integrations.actions?: A table with the actions to pick from
----@param config CopilotChat.config?: The chat configuration
 ---@param opts table?: fzf-lua options
-function M.pick(pick_actions, config, opts)
+function M.pick(pick_actions, opts)
   if not pick_actions or not pick_actions.actions or vim.tbl_isempty(pick_actions.actions) then
     return
   end
 
-  config = vim.tbl_extend('force', {
-    selection = pick_actions.selection,
-  }, config or {})
-
   opts = vim.tbl_extend('force', {
     prompt = pick_actions.prompt .. '> ',
     preview = fzflua.shell.raw_preview_action_cmd(function(items)
-      return string.format('echo "%s"', pick_actions.actions[items[1]])
+      return string.format('echo "%s"', pick_actions.actions[items[1]].prompt)
     end),
     actions = {
       ['default'] = function(selected)
@@ -27,7 +22,7 @@ function M.pick(pick_actions, config, opts)
           return
         end
         vim.defer_fn(function()
-          chat.ask(pick_actions.actions[selected[1]], config)
+          chat.ask(pick_actions.actions[selected[1]].prompt, pick_actions.actions[selected[1]])
         end, 100)
       end,
     },

--- a/lua/CopilotChat/integrations/telescope.lua
+++ b/lua/CopilotChat/integrations/telescope.lua
@@ -11,16 +11,11 @@ local M = {}
 
 --- Pick an action from a list of actions
 ---@param pick_actions CopilotChat.integrations.actions?: A table with the actions to pick from
----@param config CopilotChat.config?: The chat configuration
 ---@param opts table?: Telescope options
-function M.pick(pick_actions, config, opts)
+function M.pick(pick_actions, opts)
   if not pick_actions or not pick_actions.actions or vim.tbl_isempty(pick_actions.actions) then
     return
   end
-
-  config = vim.tbl_extend('force', {
-    selection = pick_actions.selection,
-  }, config or {})
 
   opts = themes.get_dropdown(opts or {})
   pickers
@@ -37,7 +32,7 @@ function M.pick(pick_actions, config, opts)
             0,
             -1,
             false,
-            { pick_actions.actions[entry[1]] }
+            { pick_actions.actions[entry[1]].prompt }
           )
         end,
       }),
@@ -49,7 +44,10 @@ function M.pick(pick_actions, config, opts)
           if not selected or vim.tbl_isempty(selected) then
             return
           end
-          chat.ask(pick_actions.actions[selected[1]], config)
+
+          vim.defer_fn(function()
+            chat.ask(pick_actions.actions[selected[1]].prompt, pick_actions.actions[selected[1]])
+          end, 100)
         end)
         return true
       end,


### PR DESCRIPTION
Instead of definining the selection when generating actions and hardcoding it, use prompt configuration for grabbing selection.

Closes #206 