### PR TITLE
feat(select): prepend line numbers to buffer lines

### DIFF
--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -74,6 +74,11 @@ function M.buffer(source)
     return nil
   end
 
+  -- Prepend line numbers to each line
+  for i, line in ipairs(lines) do
+    lines[i] = string.format('%d: %s', i, line)
+  end
+
   return {
     lines = table.concat(lines, '\n'),
     start_row = 1,


### PR DESCRIPTION
Closes #214. This change modifies the 'buffer' function in the 'select.lua' file to prepend line numbers to each line in the buffer. This will provide a clearer context when viewing the buffer content.