### PR TITLE
feat: Add source parameter to callback function

### DIFF
--- a/doc/CopilotChat.txt
+++ b/doc/CopilotChat.txt
@@ -200,7 +200,9 @@ API ~
     actions.pick(actions.help_actions())
     
     -- Pick prompt actions
-    actions.pick(actions.prompt_actions())
+    actions.pick(actions.prompt_actions({
+        selection = require("CopilotChat.select").visual,
+    }))
 <
 
 

--- a/doc/CopilotChat.txt
+++ b/doc/CopilotChat.txt
@@ -182,10 +182,8 @@ API ~
     
     -- Ask a question and do something with the response
     chat.ask("Show me something interesting", {
-      callback = function(response, source)
+      callback = function(response)
         print("Response:", response)
-        print("Bufnr:", source.bufnr)
-        print("Winnr:", source.winnr)
       end,
     })
     

--- a/doc/CopilotChat.txt
+++ b/doc/CopilotChat.txt
@@ -182,8 +182,10 @@ API ~
     
     -- Ask a question and do something with the response
     chat.ask("Show me something interesting", {
-      callback = function(response)
+      callback = function(response, source)
         print("Response:", response)
+        print("Bufnr:", source.bufnr)
+        print("Winnr:", source.winnr)
       end,
     })
     

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -21,7 +21,7 @@ local select = require('CopilotChat.select')
 ---@field kind string?
 ---@field mapping string?
 ---@field system_prompt string?
----@field callback fun(response: string)?
+---@field callback fun(response: string, source: CopilotChat.config.source)?
 ---@field selection nil|fun(source: CopilotChat.config.source):CopilotChat.config.selection?
 
 ---@class CopilotChat.config.window
@@ -63,7 +63,7 @@ local select = require('CopilotChat.select')
 ---@field clear_chat_on_new_prompt boolean?
 ---@field context string?
 ---@field history_path string?
----@field callback fun(response: string)?
+---@field callback fun(response: string, source: CopilotChat.config.source)?
 ---@field selection nil|fun(source: CopilotChat.config.source):CopilotChat.config.selection?
 ---@field prompts table<string, CopilotChat.config.prompt|string>?
 ---@field window CopilotChat.config.window?

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -375,7 +375,7 @@ function M.ask(prompt, config, source)
               end)
             end
             if config.callback then
-              config.callback(response)
+              config.callback(response, state.source)
             end
           end)
         end,


### PR DESCRIPTION
Closes #218

The callback function in both the 'ask' and 'config' methods now receives the 'source' parameter. This allows users to access information about the source of the response, such as the buffer number and window number. This change enhances the flexibility and usability of the callback function.