### PR TITLE
fix: Warn users about configuration cchange and do not break plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         uses: kdheepak/panvimdoc@main
         with:
           vimdoc: CopilotChat
+          dedupsubheadings: false
           treesitter: true
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -528,6 +528,25 @@ end
 --- Set up the plugin
 ---@param config CopilotChat.config|nil
 function M.setup(config)
+  -- Handle old mapping format and show error
+  local found_old_format = false
+  if config and config.mappings then
+    for name, key in pairs(config.mappings) do
+      if type(key) == 'string' then
+        vim.notify(
+          'config.mappings.'
+            .. name
+            .. ": 'mappings' format have changed, please update your configuration, for now revering to default settings. See ':help CopilotChat-configuration' for current format",
+          vim.log.levels.ERROR
+        )
+        found_old_format = true
+      end
+    end
+  end
+  if found_old_format then
+    config.mappings = nil
+  end
+
   M.config = vim.tbl_deep_extend('force', default_config, config or {})
   state.copilot = Copilot(M.config.proxy, M.config.allow_insecure)
   local mark_ns = vim.api.nvim_create_namespace('copilot-chat-marks')


### PR DESCRIPTION
![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/5115805/e69a8c66-8429-4a1e-9348-b140a369a87b)


This also fixes issue with panvimdoc generating CopilotChat-copilot-chat-for-neovim- as prefix for everything, now its just CopilotChat-