### PR TITLE
feat: Set chat and overlay filetypes to their names

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -41,7 +41,7 @@ local Chat = class(function(self, mark_ns, help, on_buf_create)
   self.buf_create = function()
     local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_buf_set_name(bufnr, 'copilot-chat')
-    vim.bo[bufnr].filetype = 'markdown'
+    vim.bo[bufnr].filetype = 'copilot-chat'
     vim.bo[bufnr].syntax = 'markdown'
     local ok, parser = pcall(vim.treesitter.get_parser, bufnr, 'markdown')
     if ok and parser then

--- a/lua/CopilotChat/overlay.lua
+++ b/lua/CopilotChat/overlay.lua
@@ -18,6 +18,7 @@ local Overlay = class(function(self, name, mark_ns, hl_ns, help, on_buf_create)
 
   self.buf_create = function()
     local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.bo[bufnr].filetype = name
     vim.api.nvim_buf_set_name(bufnr, name)
     return bufnr
   end
@@ -41,7 +42,6 @@ end
 function Overlay:show(text, filetype, syntax, winnr)
   self:validate()
 
-  vim.bo[self.bufnr].filetype = filetype
   vim.api.nvim_win_set_buf(winnr, self.bufnr)
 
   vim.bo[self.bufnr].modifiable = true


### PR DESCRIPTION
This improves support for various integrations like nvim-cmp and edgy

Closes #228 