### PR TITLE
feat(CopilotChat): update chat formatting for user and AI prompts

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -356,11 +356,13 @@ function M.ask(prompt, config, source)
   end
 
   if state.copilot:stop() then
-    append('\n\n' .. config.separator .. '\n\n')
+    append('\n\n' .. config.separator)
   end
 
+  -- TODO: Add question_header, answer_header, error_header to, refer this discussion https://discord.com/channels/1200633211236122665/1209115196702859294/1221319239428866088
+  append('## User ' .. config.separator .. '\n\n')
   append(updated_prompt)
-  append('\n\n**' .. config.name .. '** ' .. config.separator .. '\n\n')
+  append('\n\n## ' .. config.name .. ' ' .. config.separator .. '\n\n')
   state.chat:follow()
 
   local selected_context = config.context


### PR DESCRIPTION
# What

Make the same style response with v1

<img width="952" alt="image" src="https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/870029/e696cc19-80b2-41fe-ad80-05b3bbe843d1">

# Usage

Here is my custom config for the above 

```lua

-- Change separator
opts = {
  separator = " ",            -- Separator to use in chat
  ...
},

```

[![Demo](https://i.gyazo.com/8660a4b6857ccf7e0e23306de609767d.gif)](https://gyazo.com/8660a4b6857ccf7e0e23306de609767d)