### PR TITLE
fix: Remap bindings to not conflict with terminal

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -169,7 +169,7 @@ return {
     },
     submit_prompt = {
       normal = '<CR>',
-      insert = '<C-m>',
+      insert = '<C-s>',
     },
     accept_diff = {
       normal = '<C-y>',


### PR DESCRIPTION
C-m is same as CR on a lot of terminals, remap to C-s

Closes #246 