### PR TITLE
Fix telescope preview if prompt contains newlines

### DIFF
--- a/lua/CopilotChat/integrations/telescope.lua
+++ b/lua/CopilotChat/integrations/telescope.lua
@@ -32,7 +32,7 @@ function M.pick(pick_actions, opts)
             0,
             -1,
             false,
-            { pick_actions.actions[entry[1]].prompt }
+            vim.split(pick_actions.actions[entry[1]].prompt, '\n')
           )
         end,
       }),


### PR DESCRIPTION
If the prompt contains newlines, the error
`'replacement string' item contains newlines` will occur when previewing the Telescope integration. This is because `nvim_buf_set_lines` prohibits newlines from being included in the content it sets. Instead, this function takes a list of strings as arguments.

In this commit, vim.split splits strings with newlines. With this fix, Telescope preview will work correctly even when the prompt contains newlines.