### PR TITLE
fix: Handle error responses from copilot properly

### DIFF
--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -402,8 +402,8 @@ function Copilot:ask(prompt, opts)
             return
           end
 
-          if err then
-            err = 'Failed to get response: ' .. vim.inspect(err)
+          if err or vim.startswith(line, '{"error"') then
+            err = 'Failed to get response: ' .. (err and vim.inspect(err) or line)
             errored = true
             log.error(err)
             if self.current_job and on_error then


### PR DESCRIPTION
Copilot api can return error off-topic for example, when you try something like this:

`Why weren't I invited when my parents got married?`