### PR TITLE
feat(copilot): load GitHub token from environment

### DIFF
--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -91,6 +91,13 @@ local function find_config_path()
 end
 
 local function get_cached_token()
+-- loading token from the environment
+  local token = os.getenv('GITHUB_TOKEN')
+  if token then
+    return token
+  end
+
+-- loading token from the file
   local config_path = find_config_path()
   if not config_path then
     return nil

--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -91,9 +91,10 @@ local function find_config_path()
 end
 
 local function get_cached_token()
-  -- loading token from the environment
+  -- loading token from the environment only in GitHub Codespaces
   local token = os.getenv('GITHUB_TOKEN')
-  if token then
+  local codespaces = os.getenv('CODESPACES')
+  if token and codespaces then
     return token
   end
 

--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -91,13 +91,13 @@ local function find_config_path()
 end
 
 local function get_cached_token()
--- loading token from the environment
+  -- loading token from the environment
   local token = os.getenv('GITHUB_TOKEN')
   if token then
     return token
   end
 
--- loading token from the file
+  -- loading token from the file
   local config_path = find_config_path()
   if not config_path then
     return nil


### PR DESCRIPTION
The copilot module now first tries to load the GitHub token from the environment variable 'GITHUB_TOKEN'. If the variable is not set, it falls back to loading the token from the file.