### PR TITLE
feat: Normalize generation prompts, add Review prompt, use more vscode prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,12 @@ See @deathbeam for [configuration](https://github.com/deathbeam/dotfiles/blob/ma
 
 #### Commands coming from default prompts
 
-- `:CopilotChatExplain` - Explain how it works
-- `:CopilotChatTests` - Briefly explain how selected code works then generate unit tests
-- `:CopilotChatFix` - There is a problem in this code. Rewrite the code to show it with the bug fixed.
-- `:CopilotChatOptimize` - Optimize the selected code to improve performance and readablilty.
-- `:CopilotChatDocs` - Write documentation for the selected code. The reply should be a codeblock containing the original code with the documentation added as comments. Use the most appropriate documentation style for the programming language used (e.g. JSDoc for JavaScript, docstrings for Python etc.
+- `:CopilotChatExplain` - Write an explanation for the active selection as paragraphs of text
+- `:CopilotChatReview` - Review the selected code
+- `:CopilotChatFix` - There is a problem in this code. Rewrite the code to show it with the bug fixed
+- `:CopilotChatOptimize` - Optimize the selected code to improve performance and readablilty
+- `:CopilotChatDocs` - Please add documentation comment for the selection
+- `:CopilotChatTests` - Please generate tests for my code
 - `:CopilotChatFixDiagnostic` - Please assist with the following diagnostic issue in file
 - `:CopilotChatCommit` - Write commit message for the change with commitizen convention
 - `:CopilotChatCommitStaged` - Write commit message for the change with commitizen convention
@@ -221,19 +222,25 @@ Also see [here](/lua/CopilotChat/config.lua):
   -- default prompts
   prompts = {
     Explain = {
-      prompt = '/COPILOT_EXPLAIN Write an explanation for the code above as paragraphs of text.',
+      prompt = '/COPILOT_EXPLAIN Write an explanation for the active selection as paragraphs of text.',
     },
-    Tests = {
-      prompt = '/COPILOT_TESTS Write a set of detailed unit test functions for the code above.',
+    Review = {
+      prompt = '/COPILOT_REVIEW Review the selected code.',
+      callback = function(response, source)
+        -- see config.lua for implementation
+      end,
     },
     Fix = {
-      prompt = '/COPILOT_FIX There is a problem in this code. Rewrite the code to show it with the bug fixed.',
+      prompt = '/COPILOT_GENERATE There is a problem in this code. Rewrite the code to show it with the bug fixed.',
     },
     Optimize = {
-      prompt = '/COPILOT_REFACTOR Optimize the selected code to improve performance and readablilty.',
+      prompt = '/COPILOT_GENERATE Optimize the selected code to improve performance and readablilty.',
     },
     Docs = {
-      prompt = '/COPILOT_REFACTOR Write documentation for the selected code. The reply should be a codeblock containing the original code with the documentation added as comments. Use the most appropriate documentation style for the programming language used (e.g. JSDoc for JavaScript, docstrings for Python etc.',
+      prompt = '/COPILOT_GENERATE Please add documentation comment for the selection.',
+    },
+    Tests = {
+      prompt = '/COPILOT_GENERATE Please generate tests for my code.',
     },
     FixDiagnostic = {
       prompt = 'Please assist with the following diagnostic issue in file:',

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -108,19 +108,58 @@ return {
   -- default prompts
   prompts = {
     Explain = {
-      prompt = '/COPILOT_EXPLAIN Write an explanation for the code above as paragraphs of text.',
+      prompt = '/COPILOT_EXPLAIN Write an explanation for the active selection as paragraphs of text.',
     },
-    Tests = {
-      prompt = '/COPILOT_TESTS Write a set of detailed unit test functions for the code above.',
+    Review = {
+      prompt = '/COPILOT_REVIEW Review the selected code.',
+      callback = function(response, source)
+        local ns = vim.api.nvim_create_namespace('copilot_review')
+        local diagnostics = {}
+        for line in response:gmatch('[^\r\n]+') do
+          if line:find('^line=') then
+            local start_line = nil
+            local end_line = nil
+            local message = nil
+            local single_match, message_match = line:match('^line=(%d+): (.*)$')
+            if not single_match then
+              local start_match, end_match, m_message_match = line:match('^line=(%d+)-(%d+): (.*)$')
+              if start_match and end_match then
+                start_line = tonumber(start_match)
+                end_line = tonumber(end_match)
+                message = m_message_match
+              end
+            else
+              start_line = tonumber(single_match)
+              end_line = start_line
+              message = message_match
+            end
+
+            if start_line and end_line then
+              table.insert(diagnostics, {
+                lnum = start_line - 1,
+                end_lnum = end_line - 1,
+                col = 0,
+                message = message,
+                severity = vim.diagnostic.severity.WARN,
+                source = 'Copilot Review',
+              })
+            end
+          end
+        end
+        vim.diagnostic.set(ns, source.bufnr, diagnostics)
+      end,
     },
     Fix = {
-      prompt = '/COPILOT_FIX There is a problem in this code. Rewrite the code to show it with the bug fixed.',
+      prompt = '/COPILOT_GENERATE There is a problem in this code. Rewrite the code to show it with the bug fixed.',
     },
     Optimize = {
-      prompt = '/COPILOT_REFACTOR Optimize the selected code to improve performance and readablilty.',
+      prompt = '/COPILOT_GENERATE Optimize the selected code to improve performance and readablilty.',
     },
     Docs = {
-      prompt = '/COPILOT_REFACTOR Write documentation for the selected code. The reply should be a codeblock containing the original code with the documentation added as comments. Use the most appropriate documentation style for the programming language used (e.g. JSDoc for JavaScript, docstrings for Python etc.',
+      prompt = '/COPILOT_GENERATE Please add documentation comment for the selection.',
+    },
+    Tests = {
+      prompt = '/COPILOT_GENERATE Please generate tests for my code.',
     },
     FixDiagnostic = {
       prompt = 'Please assist with the following diagnostic issue in file:',

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -341,7 +341,8 @@ function M.ask(prompt, config, source)
   config = vim.tbl_deep_extend('force', M.config, config or {})
   prompt = prompt or ''
   local system_prompt, updated_prompt = update_prompts(prompt, config.system_prompt)
-  if vim.trim(updated_prompt) == '' then
+  updated_prompt = vim.trim(updated_prompt)
+  if updated_prompt == '' then
     M.open(config, source)
     return
   end

--- a/lua/CopilotChat/prompts.lua
+++ b/lua/CopilotChat/prompts.lua
@@ -67,7 +67,44 @@ Identify 'gotchas' or less obvious parts of the code that might trip up someone 
 Provide clear and relevant examples aligned with any provided context.
 ]]
 
-local preserve_style_rules = [[Additional Rules:
+M.COPILOT_REVIEW =
+  [[Your task is to review the provided code snippet, focusing specifically on its readability and maintainability.
+Identify any issues related to:
+- Naming conventions that are unclear, misleading or doesn't follow conventions for the language being used.
+- The presence of unnecessary comments, or the lack of necessary ones.
+- Overly complex expressions that could benefit from simplification.
+- High nesting levels that make the code difficult to follow.
+- The use of excessively long names for variables or functions.
+- Any inconsistencies in naming, formatting, or overall coding style.
+- Repetitive code patterns that could be more efficiently handled through abstraction or optimization.
+
+Your feedback must be concise, directly addressing each identified issue with:
+- The specific line number(s) where the issue is found.
+- A clear description of the problem.
+- A concrete suggestion for how to improve or correct the issue.
+  
+Format your feedback as follows:
+line=<line_number>: <issue_description>
+
+If the issue is related to a range of lines, use the following format:
+line=<start_line>-<end_line>: <issue_description>
+  
+If you find multiple issues on the same line, list each issue separately within the same feedback statement, using a semicolon to separate them.
+
+Example feedback:
+line=3: The variable name 'x' is unclear. Comment next to variable declaration is unnecessary.
+line=8: Expression is overly complex. Break down the expression into simpler components.
+line=10: Using camel case here is unconventional for lua. Use snake case instead.
+line=11-15: Excessive nesting makes the code hard to follow. Consider refactoring to reduce nesting levels.
+  
+If the code snippet has no readability issues, simply confirm that the code is clear and well-written as is.
+]]
+
+M.COPILOT_GENERATE = M.COPILOT_INSTRUCTIONS
+  .. [[
+You also specialize in being a highly skilled code generator. Given a description of what to do you can refactor, modify, enhance existing code or generate new code. Your task is help the Developer change their code according to their needs. Pay especially close attention to the selection context.
+
+Additional Rules:
 Markdown code blocks are used to denote code.
 If context is provided, try to match the style of the provided code as best as possible. This includes whitespace around the code, at beginning of lines, indentation, and comments.
 Preserve user's code comment blocks, do not exclude them when refactoring code.
@@ -76,27 +113,6 @@ Your code output should keep the same level of indentation as the user's code.
 You MUST add whitespace in the beginning of each line in code output as needed to match the user's code.
 Your code output is used for replacing user's code with it so following the above rules is absolutely necessary.
 ]]
-
-M.COPILOT_TESTS = M.COPILOT_INSTRUCTIONS
-  .. [[
-You also specialize in being a highly skilled test generator. Given a description of which test case should be generated, you can generate new test cases. Your task is to help the Developer generate tests. Pay especially close attention to the selection context. Do not use private properties or methods from other classes. Generate full test files.
-
-]]
-  .. preserve_style_rules
-
-M.COPILOT_FIX = M.COPILOT_INSTRUCTIONS
-  .. [[
-You also specialize in being a highly skilled code generator. Given a description of what to do you can refactor, modify or enhance existing code. Your task is help the Developer fix an issue. Pay especially close attention to the selection or exception context.
-
-]]
-  .. preserve_style_rules
-
-M.COPILOT_REFACTOR = M.COPILOT_INSTRUCTIONS
-  .. [[
-You also specialize in being a highly skilled code generator. Given a description of what to do you can refactor, modify or enhance existing code. Your task is help the Developer change their code according to their needs. Pay especially close attention to the selection context.
-
-]]
-  .. preserve_style_rules
 
 M.COPILOT_WORKSPACE =
   [[You are a software engineer with expert knowledge of the codebase the user has open in their workspace.


### PR DESCRIPTION
- Normalize different generation system prompts into one COPILOT_GENERATE
- Add COPILOT_REVIEW system prompt and CopilotChatReview that auto adds diagnostics based on response
- Use current VS Code prompts for generation of docs, tests and explanation

Example of Review command (adapted from #214 by @aweis89):

![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/5115805/43fc4354-cc17-43a7-bd01-cf431ee0d60e)
