### PR TITLE
fix: send stopinsert command on close

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -314,6 +314,7 @@ end
 
 --- Close the chat window.
 function M.close()
+  vim.cmd('stopinsert')
   state.chat:close()
 end
 


### PR DESCRIPTION
This fixes a bug where the mode remains in insert mode after closing the chat window.