### PR TITLE
feat: Add 'replace' layout that replaces current buffer in window

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Also see [here](/lua/CopilotChat/config.lua):
 
   -- default window options
   window = {
-    layout = 'vertical', -- 'vertical', 'horizontal', 'float'
+    layout = 'vertical', -- 'vertical', 'horizontal', 'float', 'replace'
     width = 0.5, -- fractional width of parent, or absolute width in columns when > 1
     height = 0.5, -- fractional height of parent, or absolute height in rows when > 1
     -- Options below only apply to floating windows

--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -153,6 +153,9 @@ function Chat:open(config)
     self.winnr = vim.api.nvim_get_current_win()
     vim.api.nvim_win_set_buf(self.winnr, self.bufnr)
     vim.api.nvim_set_current_win(orig)
+  elseif layout == 'replace' then
+    self.winnr = vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_buf(self.winnr, self.bufnr)
   end
 
   vim.wo[self.winnr].wrap = true

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -179,7 +179,7 @@ return {
 
   -- default window options
   window = {
-    layout = 'vertical', -- 'vertical', 'horizontal', 'float'
+    layout = 'vertical', -- 'vertical', 'horizontal', 'float', 'replace'
     width = 0.5, -- fractional width of parent, or absolute width in columns when > 1
     height = 0.5, -- fractional height of parent, or absolute height in rows when > 1
     -- Options below only apply to floating windows


### PR DESCRIPTION
Instead of opening horizontal/vertical split this new option replaces current buffer with chat buffer in current window