### PR TITLE
fix: consider 0.10 as stable and 0.11 as nightly

### DIFF
--- a/lua/CopilotChat/health.lua
+++ b/lua/CopilotChat/health.lua
@@ -41,11 +41,12 @@ end
 function M.check()
   start('CopilotChat.nvim [core]')
 
-  local is_nightly = vim.fn.has('nvim-0.11') == 1
-  local is_good_stable = vim.fn.has('nvim-0.9.5') == 1 or vim.fn.has('nvim-0.10') == 1
   local vim_version = vim.api.nvim_command_output('version')
-  if is_nightly then
-    local dev_number = tonumber(vim_version:match('dev%-(%d+)'))
+  local is_good_stable = vim.fn.has('nvim-0.9.5') == 1 or vim.fn.has('nvim-0.10.0') == 1
+
+  local dev_number = tonumber(vim_version:match('dev%-(%d+)'))
+
+  if dev_number then
     if dev_number >= 2500 then
       ok('nvim: ' .. vim_version)
     else

--- a/lua/CopilotChat/health.lua
+++ b/lua/CopilotChat/health.lua
@@ -41,8 +41,8 @@ end
 function M.check()
   start('CopilotChat.nvim [core]')
 
-  local is_nightly = vim.fn.has('nvim-0.10.0') == 1
-  local is_good_stable = vim.fn.has('nvim-0.9.5') == 1
+  local is_nightly = vim.fn.has('nvim-0.11') == 1
+  local is_good_stable = vim.fn.has('nvim-0.9.5') == 1 or vim.fn.has('nvim-0.10') == 1
   local vim_version = vim.api.nvim_command_output('version')
   if is_nightly then
     local dev_number = tonumber(vim_version:match('dev%-(%d+)'))


### PR DESCRIPTION
closes #321 

Let's consider 0.10 as stable version from now on. I suppose 0.9.5 still can be considered as stable for a few months until majority of people will migrate to 0.10