### PR TITLE
fix: check if buffer is in chat window to validate chat being visible

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -61,7 +61,7 @@ local Chat = class(function(self, mark_ns, help, on_buf_create)
 end, Overlay)
 
 function Chat:visible()
-  return self.winnr and vim.api.nvim_win_is_valid(self.winnr)
+  return self.winnr and vim.api.nvim_win_is_valid(self.winnr) and vim.api.nvim_win_get_buf(self.winnr) == self.bufnr
 end
 
 function Chat:active()

--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -61,7 +61,9 @@ local Chat = class(function(self, mark_ns, help, on_buf_create)
 end, Overlay)
 
 function Chat:visible()
-  return self.winnr and vim.api.nvim_win_is_valid(self.winnr) and vim.api.nvim_win_get_buf(self.winnr) == self.bufnr
+  return self.winnr
+    and vim.api.nvim_win_is_valid(self.winnr)
+    and vim.api.nvim_win_get_buf(self.winnr) == self.bufnr
 end
 
 function Chat:active()


### PR DESCRIPTION
This prevents someone replacing buffer in copilot chat window with other buffer and chat not being able to recover