### PR TITLE
feat: highlight the selection in the source buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Also see [here](/lua/CopilotChat/config.lua):
   auto_follow_cursor = true, -- Auto-follow cursor in chat
   auto_insert_mode = false, -- Automatically enter insert mode when opening window and if auto follow cursor is enabled on new prompt
   clear_chat_on_new_prompt = false, -- Clears chat on every new prompt
+  highlight_selection = true, -- Highlight selection in the source buffer when in the chat window
 
   context = nil, -- Default context to use, 'buffers', 'buffer' or none (can be specified manually in prompt via @).
   history_path = vim.fn.stdpath('data') .. '/copilotchat_history', -- Default path to stored history

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -69,6 +69,7 @@ local select = require('CopilotChat.select')
 ---@field auto_follow_cursor boolean?
 ---@field auto_insert_mode boolean?
 ---@field clear_chat_on_new_prompt boolean?
+---@field highlight_selection boolean?
 ---@field context string?
 ---@field history_path string?
 ---@field callback fun(response: string, source: CopilotChat.config.source)?
@@ -95,6 +96,7 @@ return {
   auto_follow_cursor = true, -- Auto-follow cursor in chat
   auto_insert_mode = false, -- Automatically enter insert mode when opening window and if auto follow cursor is enabled on new prompt
   clear_chat_on_new_prompt = false, -- Clears chat on every new prompt
+  highlight_selection = true, -- Highlight selection
 
   context = nil, -- Default context to use, 'buffers', 'buffer' or none (can be specified manually in prompt via @).
   history_path = vim.fn.stdpath('data') .. '/copilotchat_history', -- Default path to stored history


### PR DESCRIPTION
I added a new option `highlight_selection`, that highlights the selection in the source buffer when in the chat window.
The highlight is only visible when the chat window is focused.

The hl group for the selection is `CopilotChatSelection` and is linked to `Visual` by default.

The option is enabled by default.

Let me know what you think!

![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/292349/92736e1c-c8c9-4b4d-b06a-743d64cc0a32)
