### PR TITLE
feat: enhanced header rendering in the chat window

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -89,7 +89,7 @@ return {
   question_header = '## User ', -- Header to use for user questions
   answer_header = '## Copilot ', -- Header to use for AI answers
   error_header = '## Error ', -- Header to use for errors
-  separator = '---', -- Separator to use in chat
+  separator = '───', -- Separator to use in chat
 
   show_folds = true, -- Shows folds for sections in chat
   show_help = true, -- Shows help message as virtual lines when waiting for user input

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -613,6 +613,14 @@ function M.setup(config)
   vim.api.nvim_set_hl(hl_ns, '@diff.minus', { bg = blend_color_with_neovim_bg('DiffDelete', 20) })
   vim.api.nvim_set_hl(hl_ns, '@diff.delta', { bg = blend_color_with_neovim_bg('DiffChange', 20) })
   vim.api.nvim_set_hl(0, 'CopilotChatSelection', { link = 'Visual', default = true })
+  vim.api.nvim_set_hl(0, 'CopilotChatHeader', {
+    link = '@markup.heading.2.markdown',
+    default = true,
+  })
+  vim.api.nvim_set_hl(0, 'CopilotChatSeparator', {
+    link = '@punctuation.special.markdown',
+    default = true,
+  })
 
   local overlay_help = ''
   if M.config.mappings.close then


### PR DESCRIPTION
As discussed, the separator is now repeated in a virtual line and has hl group `CopilotChatSeparator`.

The headers have `hl_group` `CopilotChatHeader`.

I didn't change the default header strings, so they still have `##`, but that's no longer needed to get the same styling.
 
![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/292349/a180cf4d-1739-4c47-b196-56cce581dc4e)

With custom header strings:

![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/292349/9ea1e3b3-2725-435f-bbfc-f9a958db74ba)


Closes #334 