### PR TITLE
chore: Pass namespaces around less, make help and spinner highlight configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Also see [here](/lua/CopilotChat/config.lua):
   question_header = '## User ', -- Header to use for user questions
   answer_header = '## Copilot ', -- Header to use for AI answers
   error_header = '## Error ', -- Header to use for errors
-  separator = '---', -- Separator to use in chat
+  separator = '───', -- Separator to use in chat
 
   show_folds = true, -- Shows folds for sections in chat
   show_help = true, -- Shows help message as virtual lines when waiting for user input

--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -21,7 +21,6 @@ local Spinner = require('CopilotChat.spinner')
 local utils = require('CopilotChat.utils')
 local is_stable = utils.is_stable
 local class = utils.class
-local show_virt_line = utils.show_virt_line
 
 function CopilotChatFoldExpr(lnum, separator)
   local line = vim.fn.getline(lnum)
@@ -32,8 +31,7 @@ function CopilotChatFoldExpr(lnum, separator)
   return '='
 end
 
-local Chat = class(function(self, mark_ns, help, on_buf_create)
-  self.mark_ns = mark_ns
+local Chat = class(function(self, help, on_buf_create)
   self.header_ns = vim.api.nvim_create_namespace('copilot-chat-headers')
   self.help = help
   self.on_buf_create = on_buf_create
@@ -54,7 +52,7 @@ local Chat = class(function(self, mark_ns, help, on_buf_create)
     end
 
     if not self.spinner then
-      self.spinner = Spinner(bufnr, mark_ns, 'copilot-chat')
+      self.spinner = Spinner(bufnr)
     else
       self.spinner.bufnr = bufnr
     end
@@ -254,12 +252,8 @@ function Chat:finish(msg)
   else
     msg = self.help
   end
-  msg = vim.trim(msg)
 
-  if msg and msg ~= '' then
-    local line = vim.api.nvim_buf_line_count(self.bufnr) - 2
-    show_virt_line(msg, math.max(0, line - 1), self.bufnr, self.mark_ns)
-  end
+  self:show_help(msg, -2)
 end
 
 return Chat

--- a/lua/CopilotChat/spinner.lua
+++ b/lua/CopilotChat/spinner.lua
@@ -20,10 +20,9 @@ local spinner_frames = {
   '⠏',
 }
 
-local Spinner = class(function(self, bufnr, ns, title)
-  self.ns = ns
+local Spinner = class(function(self, bufnr)
+  self.ns = vim.api.nvim_create_namespace('copilot-chat-help')
   self.bufnr = bufnr
-  self.title = title
   self.timer = nil
   self.index = 1
 end)
@@ -57,7 +56,7 @@ function Spinner:start()
           hl_mode = 'combine',
           priority = 100,
           virt_text = vim.tbl_map(function(t)
-            return { t, 'CursorColumn' }
+            return { t, 'CopilotChatSpinner' }
           end, vim.split(spinner_frames[self.index], '\n')),
         }
       )

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -62,26 +62,6 @@ function M.join(on_done, fns)
   end
 end
 
---- Show a virtual line
----@param text string The text to show
----@param line number The line number
----@param bufnr number The buffer number
----@param mark_ns number The namespace
-function M.show_virt_line(text, line, bufnr, mark_ns)
-  if not vim.api.nvim_buf_is_valid(bufnr) then
-    return
-  end
-
-  vim.api.nvim_buf_set_extmark(bufnr, mark_ns, math.max(0, line), 0, {
-    id = mark_ns,
-    hl_mode = 'combine',
-    priority = 100,
-    virt_lines = vim.tbl_map(function(t)
-      return { { t, 'DiagnosticInfo' } }
-    end, vim.split(text, '\n')),
-  })
-end
-
 --- Writes text to a temporary file and returns path
 ---@param text string The text to write
 ---@return string?


### PR DESCRIPTION
- As pointed out in recent PRs with highlight changes, create_namespace do not rly needs to be stored so we do not need to pass them around everywhere. This simplifies the code a bit
- To make the highlights consistent after recent highlight changes, make the remaining highlights configurable as well