### PR TITLE
fix: Fix fold levels

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -23,11 +23,12 @@ local is_stable = utils.is_stable
 local class = utils.class
 
 function CopilotChatFoldExpr(lnum, separator)
-  local line = vim.fn.getline(lnum)
-  if string.match(line, separator .. '$') then
-    return '>1'
+  local to_match = separator .. '$'
+  if string.match(vim.fn.getline(lnum), to_match) then
+    return '1'
+  elseif string.match(vim.fn.getline(lnum + 1), to_match) then
+    return '0'
   end
-
   return '='
 end
 


### PR DESCRIPTION
Currently the fold is pretty much never reset to 0 so if you use fold levels for determining if there is fold or not you cant tell. Vim somehow can by default but any custom logic (for example custom statuscolumn) cant.