### PR TITLE
fix(cmp): unlist copilot-chat buffer after cmp item acceptance

### DIFF
--- a/lua/CopilotChat/integrations/cmp.lua
+++ b/lua/CopilotChat/integrations/cmp.lua
@@ -30,6 +30,13 @@ function Source:complete(params, callback)
   callback({ items = items })
 end
 
+---@param completion_item lsp.CompletionItem
+---@param callback fun(completion_item: lsp.CompletionItem|nil)
+function Source:execute(completion_item, callback)
+  callback(completion_item)
+  vim.api.nvim_set_option_value('buflisted', false, { buf = 0 })
+end
+
 local M = {}
 
 --- Setup the nvim-cmp source for copilot-chat window


### PR DESCRIPTION
Need to reset copilot-chat buffer to unlisted after accepting any nvim-cmp item as nvim-cmp for some reason sets the buffer as listed internally.

See discussion here: https://github.com/CopilotC-Nvim/CopilotChat.nvim/pull/345#issuecomment-2140483687