### PR TITLE
fix: Improve regexp for command completion in chat

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -135,7 +135,7 @@ local function complete()
     return
   end
 
-  local prefix, cmp_start = unpack(vim.fn.matchstrpos(line:sub(1, col), '\\/\\|@\\k*$'))
+  local prefix, cmp_start = unpack(vim.fn.matchstrpos(line:sub(1, col), [[\(/\|@\)\k*$]]))
   if not prefix then
     return
   end


### PR DESCRIPTION
Hi! 

This MR fixes this bug:

When user types `/Fi` in chat and then presses `<TAB>`
Expected: only `Fix` and `FixDiagnostic` are shown
Result: all actions are shown

Reference: https://neovim.io/doc/user/pattern.html#search-pattern