### PR TITLE
Use gpt-4o by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Also see [here](/lua/CopilotChat/config.lua):
   allow_insecure = false, -- Allow insecure server connections
 
   system_prompt = prompts.COPILOT_INSTRUCTIONS, -- System prompt to use
-  model = 'gpt-4', -- GPT model to use, 'gpt-3.5-turbo' or 'gpt-4'
+  model = 'gpt-4o', -- GPT model to use, 'gpt-3.5-turbo', 'gpt-4', or 'gpt-4o'
   temperature = 0.1, -- GPT temperature
 
   question_header = '## User ', -- Header to use for user questions

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -83,7 +83,7 @@ return {
   allow_insecure = false, -- Allow insecure server connections
 
   system_prompt = prompts.COPILOT_INSTRUCTIONS, -- System prompt to use
-  model = 'gpt-4', -- GPT model to use, 'gpt-3.5-turbo' or 'gpt-4'
+  model = 'gpt-4o-2024-05-13', -- GPT model to use, 'gpt-3.5-turbo', 'gpt-4', or `gpt-4o-2024-05-13`
   temperature = 0.1, -- GPT temperature
 
   question_header = '## User ', -- Header to use for user questions

--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -353,7 +353,7 @@ function Copilot:ask(prompt, opts)
   local start_row = opts.start_row or 0
   local end_row = opts.end_row or 0
   local system_prompt = opts.system_prompt or prompts.COPILOT_INSTRUCTIONS
-  local model = opts.model or 'gpt-4'
+  local model = opts.model or 'gpt-4o-2024-05-13'
   local temperature = opts.temperature or 0.1
   local on_done = opts.on_done
   local on_progress = opts.on_progress

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -606,6 +606,9 @@ function M.setup(config)
   end
 
   M.config = vim.tbl_deep_extend('force', default_config, config or {})
+  if M.config.model == 'gpt-4o' then
+    M.config.model = 'gpt-4o-2024-05-13'
+  end
 
   if state.copilot then
     state.copilot:stop()

--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -22,7 +22,7 @@ end
 local function load_tiktoken_data(done, model)
   local tiktoken_url = 'https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken'
   -- If model is gpt-4o, use o200k_base.tiktoken
-  if model == 'gpt-4o-2024-05-13' then
+  if vim.startswith(model, 'gpt-4o') then
     tiktoken_url = 'https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken'
   end
   local async

--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -22,7 +22,7 @@ end
 local function load_tiktoken_data(done, model)
   local tiktoken_url = 'https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken'
   -- If model is gpt-4o, use o200k_base.tiktoken
-  if model == 'gpt-4o' then
+  if model == 'gpt-4o-2024-05-13' then
     tiktoken_url = 'https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken'
   end
   local async


### PR DESCRIPTION
Potentially debatable: automatically rewrite `gpt-4o` to `gpt-4o-2024-05-13` because the server doesn't do that for us despite allowing the short name for `gpt-4` and `gpt-4-turbo`.