### PR TITLE
Improve completion of Copilot keywords

### DIFF
--- a/lua/CopilotChat/integrations/cmp.lua
+++ b/lua/CopilotChat/integrations/cmp.lua
@@ -7,25 +7,29 @@ function Source:get_trigger_characters()
   return { '@', '/' }
 end
 
+function Source:get_keyword_pattern()
+  return [[\%(@\|/\)\k*]]
+end
+
 function Source:complete(params, callback)
   local items = {}
   local prompts_to_use = chat.prompts()
 
-  if params.completion_context.triggerCharacter == '/' then
-    for name, _ in pairs(prompts_to_use) do
+  local prefix = string.lower(params.context.cursor_before_line:sub(params.offset))
+  local prefix_len = #prefix
+  local checkAdd = function(word)
+    if word:lower():sub(1, prefix_len) == prefix then
       items[#items + 1] = {
-        label = '/' .. name,
+        label = word,
+        kind = cmp.lsp.CompletionItemKind.Keyword,
       }
     end
-  else
-    items[#items + 1] = {
-      label = '@buffers',
-    }
-
-    items[#items + 1] = {
-      label = '@buffer',
-    }
   end
+  for name, _ in pairs(prompts_to_use) do
+    checkAdd('/' .. name)
+  end
+  checkAdd("@buffers")
+  checkAdd("@buffer")
 
   callback({ items = items })
 end

--- a/lua/CopilotChat/integrations/cmp.lua
+++ b/lua/CopilotChat/integrations/cmp.lua
@@ -28,8 +28,8 @@ function Source:complete(params, callback)
   for name, _ in pairs(prompts_to_use) do
     checkAdd('/' .. name)
   end
-  checkAdd("@buffers")
-  checkAdd("@buffer")
+  checkAdd('@buffers')
+  checkAdd('@buffer')
 
   callback({ items = items })
 end


### PR DESCRIPTION
Previously, completion in nvim-cmp would only happen when typing the `@` or `/` character. There
was no way to type a partial command (e.g. `/COPILOT_G`) and then autocomplete.

This PR adds a keyword pattern to allow this sort of completion in a case-insensitive way.

If the previous behavior was an intentional design decision, feel free to close this PR. (I changed
it for my own usage, but figured other people might like it as well.)