### PR TITLE
Add support for overriding the default yank_diff register

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Also see [here](/lua/CopilotChat/config.lua):
   proxy = nil, -- [protocol://]host[:port] Use this proxy
   allow_insecure = false, -- Allow insecure server connections
 
+  yank_diff_register = '"', -- Allow overriding the register for yanking diffs
+
   system_prompt = prompts.COPILOT_INSTRUCTIONS, -- System prompt to use
   model = 'gpt-4o', -- GPT model to use, 'gpt-3.5-turbo', 'gpt-4', or 'gpt-4o'
   temperature = 0.1, -- GPT temperature

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -58,6 +58,7 @@ local select = require('CopilotChat.select')
 ---@field proxy string?
 ---@field allow_insecure boolean?
 ---@field system_prompt string?
+---@field yank_diff_register string?
 ---@field model string?
 ---@field temperature number?
 ---@field question_header string?
@@ -81,6 +82,8 @@ return {
   debug = false, -- Enable debug logging
   proxy = nil, -- [protocol://]host[:port] Use this proxy
   allow_insecure = false, -- Allow insecure server connections
+
+  yank_diff_register = '"', -- Allows overriding the register for yanking diffs
 
   system_prompt = prompts.COPILOT_INSTRUCTIONS, -- System prompt to use
   model = 'gpt-4o-2024-05-13', -- GPT model to use, 'gpt-3.5-turbo', 'gpt-4', or `gpt-4o-2024-05-13`

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -774,7 +774,7 @@ function M.setup(config)
       local lines = find_lines_between_separator(section_lines, '^```%w*$', true)
       if #lines > 0 then
         local content = table.concat(lines, '\n')
-        vim.fn.setreg('"', content)
+        vim.fn.setreg(M.config.yank_diff_register, content)
       end
     end)
 


### PR DESCRIPTION
## Description
The following PR adds a config option to override the default `yank_diff` register. Currently, the default is set to `"`, and it can conflict with configuration settings that set the system clipboard to the unnamed register. This override enables me to set the `yank_diff_register` to the `+` register and maintain my current system clipboard setting of `vim.o.clipboard = 'unnamedplus'`

The default would remain the same, but it would allow this to be changed as needed.

This could address issue #364 