### PR TITLE
Use cwd for selection.gitdiff

### DIFF
--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -161,7 +161,8 @@ function M.gitdiff(source, staged)
     return nil
   end
 
-  local cmd = 'git diff --no-color --no-ext-diff' .. (staged and ' --staged' or '')
+  local dir = vim.fn.getcwd()
+  local cmd = 'git -C ' .. dir .. ' diff --no-color --no-ext-diff' .. (staged and ' --staged' or '')
   local handle = io.popen(cmd)
   if not handle then
     return nil


### PR DESCRIPTION
This fixes issue with switching directories after opening neovim.

Closes #387