### PR TITLE
Fix indexing nil `config`

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -127,7 +127,7 @@ end
 ---@param config CopilotChat.config
 local function append(str, config)
   state.chat:append(str)
-  if config.auto_follow_cursor then
+  if config and config.auto_follow_cursor then
     state.chat:follow()
   end
 end


### PR DESCRIPTION
Fix issue that running `:CopilotChatLoad <name>?` without opening any panel before will result in error of indexing nil `config`.