### PR TITLE
refactor: migrate deprecated get_line_diagnostics to vim.diagnostic.get

### DIFF
--- a/lua/CopilotChat/actions.lua
+++ b/lua/CopilotChat/actions.lua
@@ -14,7 +14,7 @@ function M.help_actions(config)
   local bufnr = vim.api.nvim_get_current_buf()
   local winnr = vim.api.nvim_get_current_win()
   local cursor = vim.api.nvim_win_get_cursor(winnr)
-  local line_diagnostics = vim.lsp.diagnostic.get_line_diagnostics(bufnr, cursor[1] - 1)
+  local line_diagnostics = vim.diagnostic.get(bufnr, { lnum = cursor[1] - 1 })
 
   if #line_diagnostics == 0 then
     return nil

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -132,7 +132,7 @@ function M.diagnostics(source)
   end
 
   local cursor = vim.api.nvim_win_get_cursor(winnr)
-  local line_diagnostics = vim.lsp.diagnostic.get_line_diagnostics(bufnr, cursor[1] - 1)
+  local line_diagnostics = vim.diagnostic.get(bufnr, { lnum = cursor[1] - 1 })
 
   if #line_diagnostics == 0 then
     return nil


### PR DESCRIPTION
Replaced `vim.lsp.diagnostic.get_line_diagnostics` with `vim.diagnostic.get` to align with the updated Neovim API.

```
- WARNING vim.lsp.diagnostic.get_line_diagnostics is deprecated. Feature will be removed in Nvim 0.12
  - ADVICE:
    - use vim.diagnostic.get instead.
    - stack traceback:
        /Users/radwo/.local/share/nvim/lazy/CopilotChat.nvim/lua/CopilotChat/actions.lua:17
        /Users/radwo/.config/nvim/lua/radwo/plugins/copilot.lua:20
```
