### PR TITLE
fix: tiktoken download fail if cache folder doesn't exist

### DIFF
--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -5,6 +5,7 @@ local tiktoken_core = nil
 ---@param fname string
 ---@return string
 local function get_cache_path(fname)
+  vim.fn.mkdir(vim.fn.stdpath('cache'), 'p')
   return vim.fn.stdpath('cache') .. '/' .. fname
 end
 


### PR DESCRIPTION
implemented suggestion from #418 

Closes #418 