### PR TITLE
fix: "Unterminated quoted string" in fzflua; extra quotes in actions prompts

### DIFF
--- a/lua/CopilotChat/actions.lua
+++ b/lua/CopilotChat/actions.lua
@@ -24,11 +24,11 @@ function M.help_actions(config)
     prompt = 'Copilot Chat Help Actions',
     actions = {
       ['Fix diagnostic'] = vim.tbl_extend('keep', {
-        prompt = 'Please assist with fixing the following diagnostic issue in file: "',
+        prompt = 'Please assist with fixing the following diagnostic issue in file:',
         selection = select.diagnostics,
       }, config or {}),
       ['Explain diagnostic'] = vim.tbl_extend('keep', {
-        prompt = 'Please explain the following diagnostic issue in file: "',
+        prompt = 'Please explain the following diagnostic issue in file:',
         selection = select.diagnostics,
       }, config or {}),
     },

--- a/lua/CopilotChat/integrations/fzflua.lua
+++ b/lua/CopilotChat/integrations/fzflua.lua
@@ -15,9 +15,9 @@ function M.pick(pick_actions, opts)
   utils.return_to_normal_mode()
   opts = vim.tbl_extend('force', {
     prompt = pick_actions.prompt .. '> ',
-    preview = fzflua.shell.raw_preview_action_cmd(function(items)
-      return string.format('echo "%s"', pick_actions.actions[items[1]].prompt)
-    end),
+    preview = function(items)
+      return pick_actions.actions[items[1]].prompt
+    end,
     actions = {
       ['default'] = function(selected)
         if not selected or vim.tbl_isempty(selected) then

--- a/lua/CopilotChat/integrations/fzflua.lua
+++ b/lua/CopilotChat/integrations/fzflua.lua
@@ -18,6 +18,11 @@ function M.pick(pick_actions, opts)
     preview = function(items)
       return pick_actions.actions[items[1]].prompt
     end,
+    winopts = {
+      preview = {
+        wrap = 'wrap',
+      },
+    },
     actions = {
       ['default'] = function(selected)
         if not selected or vim.tbl_isempty(selected) then


### PR DESCRIPTION
#### [fix(fzflua): Syntax error: Unterminated quoted string](../commit/519a654b1eb185505092c488b6271d68d02e7065)

The help_actions prompts end with a double quote, and passing that to
shell unescaped explodes with

    sh: 1: Syntax error: Unterminated quoted string

We could escape it using fzf-lua.libuv.shellescape, but it's easier to
just let fzf-lua do the right thing itself:
https://github.com/ibhagwan/fzf-lua/blob/052491ee887b04e231787515a81aa3f358a68147/lua/fzf-lua/core.lua#L645-L646

#### [fix(actions): Drop unmatched double quotes from prompts](../commit/4d087d39518a829bf8761f200f3322fbfd425904)

There's no point having a quote at the end of the prompt if it's never
getting closed (and it isn't indeed). Also, the prompt used for
CopilotChatFixDiagnostic doesn't have any quotes either, so to be
consistent let's just remove them from actions prompts as well.

#### [fix(fzflua): Wrap long lines in preview](../commit/f6cc7149cbb87a42b8c85726b9ffabeb20f7178e)
