### PR TITLE
Revamp how diagnostics are handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,12 @@ Verify "[Copilot chat in the IDE](https://github.com/settings/copilot)" is enabl
 
 #### Commands coming from default prompts
 
-- `:CopilotChatExplain` - Write an explanation for the active selection as paragraphs of text
+- `:CopilotChatExplain` - Write an explanation for the active selection and diagnostics as paragraphs of text
 - `:CopilotChatReview` - Review the selected code
 - `:CopilotChatFix` - There is a problem in this code. Rewrite the code to show it with the bug fixed
 - `:CopilotChatOptimize` - Optimize the selected code to improve performance and readability
 - `:CopilotChatDocs` - Please add documentation comment for the selection
 - `:CopilotChatTests` - Please generate tests for my code
-- `:CopilotChatFixDiagnostic` - Please assist with the following diagnostic issue in file
 - `:CopilotChatCommit` - Write commit message for the change with commitizen convention
 - `:CopilotChatCommitStaged` - Write commit message for the change with commitizen convention
 
@@ -181,9 +180,6 @@ local response = chat.response()
 -- Pick a prompt using vim.ui.select
 local actions = require("CopilotChat.actions")
 
--- Pick help actions
-actions.pick(actions.help_actions())
-
 -- Pick prompt actions
 actions.pick(actions.prompt_actions({
     selection = require("CopilotChat.select").visual,
@@ -227,15 +223,15 @@ Also see [here](/lua/CopilotChat/config.lua):
   history_path = vim.fn.stdpath('data') .. '/copilotchat_history', -- Default path to stored history
   callback = nil, -- Callback to use when ask response is received
 
-  -- default selection (visual or line)
+  -- default selection
   selection = function(source)
-    return select.visual(source) or select.line(source)
+    return select.visual(source) or select.buffer(source)
   end,
 
   -- default prompts
   prompts = {
     Explain = {
-      prompt = '/COPILOT_EXPLAIN Write an explanation for the active selection as paragraphs of text.',
+      prompt = '/COPILOT_EXPLAIN Write an explanation for the active selection and diagnostics as paragraphs of text.',
     },
     Review = {
       prompt = '/COPILOT_REVIEW Review the selected code.',
@@ -254,10 +250,6 @@ Also see [here](/lua/CopilotChat/config.lua):
     },
     Tests = {
       prompt = '/COPILOT_GENERATE Please generate tests for my code.',
-    },
-    FixDiagnostic = {
-      prompt = 'Please assist with the following diagnostic issue in file:',
-      selection = select.diagnostics,
     },
     Commit = {
       prompt = 'Write commit message for the change with commitizen convention. Make sure the title has maximum 50 characters and message is wrapped at 72 characters. Wrap the whole message in code block with language gitcommit.',
@@ -462,15 +454,6 @@ Requires [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) plug
 ```lua
 -- lazy.nvim keys
 
-  -- Show help actions with telescope
-  {
-    "<leader>cch",
-    function()
-      local actions = require("CopilotChat.actions")
-      require("CopilotChat.integrations.telescope").pick(actions.help_actions())
-    end,
-    desc = "CopilotChat - Help actions",
-  },
   -- Show prompts actions with telescope
   {
     "<leader>ccp",
@@ -494,15 +477,6 @@ Requires [fzf-lua](https://github.com/ibhagwan/fzf-lua) plugin to be installed.
 ```lua
 -- lazy.nvim keys
 
-  -- Show help actions with fzf-lua
-  {
-    "<leader>cch",
-    function()
-      local actions = require("CopilotChat.actions")
-      require("CopilotChat.integrations.fzflua").pick(actions.help_actions())
-    end,
-    desc = "CopilotChat - Help actions",
-  },
   -- Show prompts actions with fzf-lua
   {
     "<leader>ccp",

--- a/lua/CopilotChat/actions.lua
+++ b/lua/CopilotChat/actions.lua
@@ -2,37 +2,14 @@
 ---@field prompt string: The prompt to display
 ---@field actions table<string, CopilotChat.config.prompt>: A table with the actions to pick from
 
-local select = require('CopilotChat.select')
 local chat = require('CopilotChat')
+local utils = require('CopilotChat.utils')
 
 local M = {}
 
---- Diagnostic help actions
----@param config CopilotChat.config?: The chat configuration
----@return CopilotChat.integrations.actions?: The help actions
-function M.help_actions(config)
-  local bufnr = vim.api.nvim_get_current_buf()
-  local winnr = vim.api.nvim_get_current_win()
-  local cursor = vim.api.nvim_win_get_cursor(winnr)
-  local line_diagnostics = vim.diagnostic.get(bufnr, { lnum = cursor[1] - 1 })
-
-  if #line_diagnostics == 0 then
-    return nil
-  end
-
-  return {
-    prompt = 'Copilot Chat Help Actions',
-    actions = {
-      ['Fix diagnostic'] = vim.tbl_extend('keep', {
-        prompt = 'Please assist with fixing the following diagnostic issue in file:',
-        selection = select.diagnostics,
-      }, config or {}),
-      ['Explain diagnostic'] = vim.tbl_extend('keep', {
-        prompt = 'Please explain the following diagnostic issue in file:',
-        selection = select.diagnostics,
-      }, config or {}),
-    },
-  }
+function M.help_actions()
+  utils.deprecate('help_actions()', 'prompt_actions()')
+  return M.prompt_actions()
 end
 
 --- User prompt actions

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -5,15 +5,23 @@ local select = require('CopilotChat.select')
 --- @field bufnr number
 --- @field winnr number
 
+---@class CopilotChat.config.selection.diagnostic
+---@field message string
+---@field severity string
+---@field start_row number
+---@field start_col number
+---@field end_row number
+---@field end_col number
+
 ---@class CopilotChat.config.selection
 ---@field lines string
+---@field diagnostics table<CopilotChat.config.selection.diagnostic>?
 ---@field filename string?
 ---@field filetype string?
 ---@field start_row number?
 ---@field start_col number?
 ---@field end_row number?
 ---@field end_col number?
----@field prompt_extra string?
 
 ---@class CopilotChat.config.prompt
 ---@field prompt string?
@@ -106,15 +114,15 @@ return {
   history_path = vim.fn.stdpath('data') .. '/copilotchat_history', -- Default path to stored history
   callback = nil, -- Callback to use when ask response is received
 
-  -- default selection (visual or line)
+  -- default selection
   selection = function(source)
-    return select.visual(source) or select.line(source)
+    return select.visual(source) or select.buffer(source)
   end,
 
   -- default prompts
   prompts = {
     Explain = {
-      prompt = '/COPILOT_EXPLAIN Write an explanation for the active selection as paragraphs of text.',
+      prompt = '/COPILOT_EXPLAIN Write an explanation for the active selection and diagnostics as paragraphs of text.',
     },
     Review = {
       prompt = '/COPILOT_REVIEW Review the selected code.',
@@ -169,10 +177,6 @@ return {
     },
     Tests = {
       prompt = '/COPILOT_GENERATE Please generate tests for my code.',
-    },
-    FixDiagnostic = {
-      prompt = 'Please assist with the following diagnostic issue in file:',
-      selection = select.diagnostics,
     },
     Commit = {
       prompt = 'Write commit message for the change with commitizen convention. Make sure the title has maximum 50 characters and message is wrapped at 72 characters. Wrap the whole message in code block with language gitcommit.',

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -90,4 +90,8 @@ function M.return_to_normal_mode()
   end
 end
 
+function M.deprecate(old, new)
+  vim.deprecate(old, new, '3.0.0', 'CopilotChat.nvim', false)
+end
+
 return M


### PR DESCRIPTION
- Automatically include diagnostics in selections. This means that the chat will always know about them as well
- With diagnostics automatically included, CopilotChatFixDiagnostics is no longer necessary, CopilotChatFix is enough
- With diagnostics automatically included, actions.help_actions also no longer serves any purpose, CopilotChatExplain + CopilotChatFix is enough
- To better incorporate new workflow, also default to visual || buffer for selection (which was popular config adjustment in first place anyway)