### PR TITLE
refactor(commit): consolidate commit commands into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Verify "[Copilot chat in the IDE](https://github.com/settings/copilot)" is enabl
 - `:CopilotChatDocs` - Please add documentation comment for the selection
 - `:CopilotChatTests` - Please generate tests for my code
 - `:CopilotChatCommit` - Write commit message for the change with commitizen convention
-- `:CopilotChatCommitStaged` - Write commit message for the change with commitizen convention
 
 ### API
 
@@ -254,12 +253,6 @@ Also see [here](/lua/CopilotChat/config.lua):
     Commit = {
       prompt = 'Write commit message for the change with commitizen convention. Make sure the title has maximum 50 characters and message is wrapped at 72 characters. Wrap the whole message in code block with language gitcommit.',
       selection = select.gitdiff,
-    },
-    CommitStaged = {
-      prompt = 'Write commit message for the change with commitizen convention. Make sure the title has maximum 50 characters and message is wrapped at 72 characters. Wrap the whole message in code block with language gitcommit.',
-      selection = function(source)
-        return select.gitdiff(source, true)
-      end,
     },
   },
 

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -182,12 +182,6 @@ return {
       prompt = 'Write commit message for the change with commitizen convention. Make sure the title has maximum 50 characters and message is wrapped at 72 characters. Wrap the whole message in code block with language gitcommit.',
       selection = select.gitdiff,
     },
-    CommitStaged = {
-      prompt = 'Write commit message for the change with commitizen convention. Make sure the title has maximum 50 characters and message is wrapped at 72 characters. Wrap the whole message in code block with language gitcommit.',
-      selection = function(source)
-        return select.gitdiff(source, true)
-      end,
-    },
   },
 
   -- default window options

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -630,6 +630,10 @@ function M.setup(config)
     utils.deprecate('CopilotChatFixDiagnostic', 'CopilotChatFix')
     M.ask('/Fix')
   end, { force = true })
+  vim.api.nvim_create_user_command('CopilotChatCommitStaged', function()
+    utils.deprecate('CopilotChatCommitStaged', 'CopilotChatCommit')
+    M.ask('/Commit')
+  end, { force = true })
 
   M.config = vim.tbl_deep_extend('force', default_config, config or {})
   if M.config.model == 'gpt-4o' then

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -173,9 +173,8 @@ end
 
 --- Select and process current git diff
 --- @param source CopilotChat.config.source
---- @param staged boolean @If true, it will return the staged changes
 --- @return CopilotChat.config.selection|nil
-function M.gitdiff(source, staged)
+function M.gitdiff(source)
   local select_buffer = M.buffer(source)
   if not select_buffer then
     return nil
@@ -189,7 +188,7 @@ function M.gitdiff(source, staged)
   end
   dir = dir:gsub('.git$', '')
 
-  local cmd = 'git -C ' .. dir .. ' diff --no-color --no-ext-diff' .. (staged and ' --staged' or '')
+  local cmd = 'git -C ' .. dir .. ' diff --no-color --no-ext-diff --staged'
   local handle = io.popen(cmd)
   if not handle then
     return nil


### PR DESCRIPTION
Simplifies the commit command functionality by making staged changes the default behavior. Removes separate command and configuration for staged changes in favor of a single unified approach.

- Removes CopilotChatCommitStaged command configuration
- Makes staged changes the default in gitdiff function
- Adds deprecated command handler for backward compatibility

This message is generated with CopilotChatCommit