### PR TITLE
Add support for copilot extension agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Verify "[Copilot chat in the IDE](https://github.com/settings/copilot)" is enabl
 - `:CopilotChatLoad <name>?` - Load chat history from file
 - `:CopilotChatDebugInfo` - Show debug information
 - `:CopilotChatModels` - View and select available models. This is reset when a new instance is made. Please set your model in `init.lua` for persistence.
-- `:CopilotChatModel` - View the currently selected model.
+- `:CopilotChatAgents` - View and select available agents. This is reset when a new instance is made. Please set your agent in `init.lua` for persistence.
 
 #### Commands coming from default prompts
 
@@ -121,6 +121,39 @@ Verify "[Copilot chat in the IDE](https://github.com/settings/copilot)" is enabl
 - `:CopilotChatDocs` - Please add documentation comment for the selection
 - `:CopilotChatTests` - Please generate tests for my code
 - `:CopilotChatCommit` - Write commit message for the change with commitizen convention
+
+### Models, Agents and Contexts
+
+#### Models
+
+You can list available models with `:CopilotChatModels` command. Model determines the AI model used for the chat.  
+Default models are:
+
+- `gpt-4o` - This is the default Copilot Chat model. It is a versatile, multimodal model that excels in both text and image processing and is designed to provide fast, reliable responses. It also has superior performance in non-English languages. Gpt-4o is hosted on Azure.
+- `claude-3.5-sonnet` - This model excels at coding tasks across the entire software development lifecycle, from initial design to bug fixes, maintenance to optimizations. GitHub Copilot uses Claude 3.5 Sonnet hosted on Amazon Web Services.
+- `o1-preview` - This model is focused on advanced reasoning and solving complex problems, in particular in math and science. It responds more slowly than the gpt-4o model. You can make 10 requests to this model per day. o1-preview is hosted on Azure.
+- `o1-mini` - This is the faster version of the o1-preview model, balancing the use of complex reasoning with the need for faster responses. It is best suited for code generation and small context operations. You can make 50 requests to this model per day. o1-mini is hosted on Azure.
+
+For more information about models, see [here](https://docs.github.com/en/copilot/using-github-copilot/asking-github-copilot-questions-in-your-ide#ai-models-for-copilot-chat)  
+You can use more models from [here](https://github.com/marketplace/models) by using `@models` agent from [here](https://github.com/marketplace/models-github) (example: `@models Using Mistral-small, what is 1 + 11`)
+
+#### Agents
+
+Agents are used to determine the AI agent used for the chat. You can list available agents with `:CopilotChatAgents` command.  
+You can set the agent in the prompt by using `@` followed by the agent name.  
+Default "noop" agent is `copilot`.
+
+For more information about extension agents, see [here](https://docs.github.com/en/copilot/using-github-copilot/using-extensions-to-integrate-external-tools-with-copilot-chat)  
+You can install more agents from [here](https://github.com/marketplace?type=apps&copilot_app=true)
+
+#### Contexts
+
+Contexts are used to determine the context of the chat.  
+You can set the context in the prompt by using `#` followed by the context name.  
+Supported contexts are:
+
+- `buffers` - Includes all open buffers in chat context
+- `buffer` - Includes only the current buffer in chat context
 
 ### API
 
@@ -202,8 +235,10 @@ Also see [here](/lua/CopilotChat/config.lua):
   allow_insecure = false, -- Allow insecure server connections
 
   system_prompt = prompts.COPILOT_INSTRUCTIONS, -- System prompt to use
-  model = 'gpt-4o', -- GPT model to use, see ':CopilotChatModels' for available models
-  temperature = 0.1, -- GPT temperature
+  model = 'gpt-4o', -- Default model to use, see ':CopilotChatModels' for available models
+  agent = 'copilot', -- Default agent to use, see ':CopilotChatAgents' for available agents (can be specified manually in prompt via @).
+  context = nil, -- Default context to use, 'buffers', 'buffer' or none (can be specified manually in prompt via #).
+  temperature = 0.1, -- GPT result temperature
 
   question_header = '## User ', -- Header to use for user questions
   answer_header = '## Copilot ', -- Header to use for AI answers
@@ -218,7 +253,6 @@ Also see [here](/lua/CopilotChat/config.lua):
   clear_chat_on_new_prompt = false, -- Clears chat on every new prompt
   highlight_selection = true, -- Highlight selection in the source buffer when in the chat window
 
-  context = nil, -- Default context to use, 'buffers', 'buffer' or none (can be specified manually in prompt via @).
   history_path = vim.fn.stdpath('data') .. '/copilotchat_history', -- Default path to stored history
   callback = nil, -- Callback to use when ask response is received
 

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -69,6 +69,8 @@ local select = require('CopilotChat.select')
 ---@field allow_insecure boolean?
 ---@field system_prompt string?
 ---@field model string?
+---@field agent string?
+---@field context string?
 ---@field temperature number?
 ---@field question_header string?
 ---@field answer_header string?
@@ -80,7 +82,6 @@ local select = require('CopilotChat.select')
 ---@field auto_insert_mode boolean?
 ---@field clear_chat_on_new_prompt boolean?
 ---@field highlight_selection boolean?
----@field context string?
 ---@field history_path string?
 ---@field callback fun(response: string, source: CopilotChat.config.source)?
 ---@field selection nil|fun(source: CopilotChat.config.source):CopilotChat.config.selection?
@@ -94,8 +95,10 @@ return {
   allow_insecure = false, -- Allow insecure server connections
 
   system_prompt = prompts.COPILOT_INSTRUCTIONS, -- System prompt to use
-  model = 'gpt-4o', -- GPT model to use, see ':CopilotChatModels' for available models
-  temperature = 0.1, -- GPT temperature
+  model = 'gpt-4o', -- Default model to use, see ':CopilotChatModels' for available models
+  agent = 'copilot', -- Default agent to use, see ':CopilotChatAgents' for available agents (can be specified manually in prompt via @).
+  context = nil, -- Default context to use, 'buffers', 'buffer' or none (can be specified manually in prompt via #).
+  temperature = 0.1, -- GPT result temperature
 
   question_header = '## User ', -- Header to use for user questions
   answer_header = '## Copilot ', -- Header to use for AI answers
@@ -110,7 +113,6 @@ return {
   clear_chat_on_new_prompt = false, -- Clears chat on every new prompt
   highlight_selection = true, -- Highlight selection
 
-  context = nil, -- Default context to use, 'buffers', 'buffer' or none (can be specified manually in prompt via @).
   history_path = vim.fn.stdpath('data') .. '/copilotchat_history', -- Default path to stored history
   callback = nil, -- Callback to use when ask response is received
 

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -60,30 +60,13 @@ local function blend_color_with_neovim_bg(color_name, blend)
   return string.format('#%02x%02x%02x', r, g, b)
 end
 
-local function dedupe_strings(str)
-  if not str then
-    return str
-  end
-  local seen = {}
-  local result = {}
-  for s in str:gmatch('[^%s,]+') do
-    if not seen[s] then
-      seen[s] = true
-      table.insert(result, s)
-    end
-  end
-  return table.concat(result, ' ')
-end
-
 local function get_error_message(err)
   if type(err) == 'string' then
-    -- Match first occurrence of :something: and capture rest
     local message = err:match('^[^:]+:[^:]+:(.+)') or err
-    -- Trim whitespace
-    message = message:match('^%s*(.-)%s*$')
-    return dedupe_strings(message)
+    message = message:gsub('^%s*', '')
+    return message
   end
-  return dedupe_strings(vim.inspect(err))
+  return vim.inspect(err)
 end
 
 local function find_lines_between_separator(lines, pattern, at_least_one)
@@ -158,58 +141,6 @@ local function append(str, config)
   end
 end
 
-local function complete()
-  local line = vim.api.nvim_get_current_line()
-  local col = vim.api.nvim_win_get_cursor(0)[2]
-  if col == 0 or #line == 0 then
-    return
-  end
-
-  local prefix, cmp_start = unpack(vim.fn.matchstrpos(line:sub(1, col), [[\(/\|@\)\k*$]]))
-  if not prefix then
-    return
-  end
-
-  local items = {}
-  local prompts_to_use = M.prompts()
-
-  for name, prompt in pairs(prompts_to_use) do
-    items[#items + 1] = {
-      word = '/' .. name,
-      kind = prompt.kind,
-      info = prompt.prompt,
-      menu = prompt.description or '',
-      icase = 1,
-      dup = 0,
-      empty = 0,
-    }
-  end
-
-  items[#items + 1] = {
-    word = '@buffers',
-    kind = 'context',
-    menu = 'Use all loaded buffers as context',
-    icase = 1,
-    dup = 0,
-    empty = 0,
-  }
-
-  items[#items + 1] = {
-    word = '@buffer',
-    kind = 'context',
-    menu = 'Use the current buffer as context',
-    icase = 1,
-    dup = 0,
-    empty = 0,
-  }
-
-  items = vim.tbl_filter(function(item)
-    return vim.startswith(item.word:lower(), prefix:lower())
-  end, items)
-
-  vim.fn.complete(cmp_start + 1, items)
-end
-
 local function get_selection()
   local bufnr = state.source.bufnr
   local winnr = state.source.winnr
@@ -276,6 +207,70 @@ local function key_to_info(name, key, surround)
   end
 
   return out
+end
+
+--- Get the completion info for the chat window, for use with custom completion providers
+---@return table
+function M.complete_info()
+  return {
+    triggers = { '@', '/', '#' },
+    pattern = [[\%(@\|/\|#\)\k*]],
+  }
+end
+
+--- Get the completion items for the chat window, for use with custom completion providers
+---@param callback function(table)
+function M.complete_items(callback)
+  async.run(function()
+    local agents = state.copilot:list_agents()
+    local items = {}
+    local prompts_to_use = M.prompts()
+
+    for name, prompt in pairs(prompts_to_use) do
+      items[#items + 1] = {
+        word = '/' .. name,
+        kind = prompt.kind,
+        info = prompt.prompt,
+        menu = prompt.description or '',
+        icase = 1,
+        dup = 0,
+        empty = 0,
+      }
+    end
+
+    for _, agent in ipairs(agents) do
+      items[#items + 1] = {
+        word = '@' .. agent,
+        kind = 'agent',
+        menu = 'Use the specified agent',
+        icase = 1,
+        dup = 0,
+        empty = 0,
+      }
+    end
+
+    items[#items + 1] = {
+      word = '#buffers',
+      kind = 'context',
+      menu = 'Include all loaded buffers in context',
+      icase = 1,
+      dup = 0,
+      empty = 0,
+    }
+
+    items[#items + 1] = {
+      word = '#buffer',
+      kind = 'context',
+      menu = 'Include the specified buffer in context',
+      icase = 1,
+      dup = 0,
+      empty = 0,
+    }
+
+    vim.schedule(function()
+      callback(items)
+    end)
+  end)
 end
 
 --- Get the prompts to use.
@@ -384,13 +379,44 @@ end
 function M.select_model()
   async.run(function()
     local models = state.copilot:list_models()
+    models = vim.tbl_map(function(model)
+      if model == M.config.model then
+        return model .. ' (selected)'
+      end
+
+      return model
+    end, models)
 
     vim.schedule(function()
       vim.ui.select(models, {
         prompt = 'Select a model',
       }, function(choice)
         if choice then
-          M.config.model = choice
+          M.config.model = choice:gsub(' %(selected%)', '')
+        end
+      end)
+    end)
+  end)
+end
+
+--- Select a Copilot agent.
+function M.select_agent()
+  async.run(function()
+    local agents = state.copilot:list_agents()
+    agents = vim.tbl_map(function(agent)
+      if agent == M.config.agent then
+        return agent .. ' (selected)'
+      end
+
+      return agent
+    end, agents)
+
+    vim.schedule(function()
+      vim.ui.select(agents, {
+        prompt = 'Select an agent',
+      }, function(choice)
+        if choice then
+          M.config.agent = choice:gsub(' %(selected%)', '')
         end
       end)
     end)
@@ -449,14 +475,24 @@ function M.ask(prompt, config, source)
   append('\n\n' .. config.answer_header .. config.separator .. '\n\n', config)
 
   local selected_context = config.context
-  if string.find(prompt, '@buffers') then
+  if string.find(prompt, '#buffers') then
     selected_context = 'buffers'
-  elseif string.find(prompt, '@buffer') then
+  elseif string.find(prompt, '#buffer') then
     selected_context = 'buffer'
   end
-  updated_prompt = string.gsub(updated_prompt, '@buffers?%s*', '')
+  updated_prompt = string.gsub(updated_prompt, '#buffers?%s*', '')
 
   async.run(function()
+    local agents = state.copilot:list_agents()
+    local current_agent = config.agent
+
+    for agent in updated_prompt:gmatch('@([%w_-]+)') do
+      if vim.tbl_contains(agents, agent) then
+        current_agent = agent
+        updated_prompt = updated_prompt:gsub('@' .. agent .. '%s*', '')
+      end
+    end
+
     local query_ok, embeddings = pcall(context.find_for_query, state.copilot, {
       context = selected_context,
       prompt = updated_prompt,
@@ -479,6 +515,7 @@ function M.ask(prompt, config, source)
         filetype = filetype,
         system_prompt = system_prompt,
         model = config.model,
+        agent = current_agent,
         temperature = config.temperature,
         on_progress = function(token)
           vim.schedule(function()
@@ -784,9 +821,31 @@ function M.setup(config)
         state.help:show(chat_help, 'markdown', 'markdown', state.chat.winnr)
       end)
 
-      map_key(M.config.mappings.complete, bufnr, complete)
       map_key(M.config.mappings.reset, bufnr, M.reset)
       map_key(M.config.mappings.close, bufnr, M.close)
+
+      map_key(M.config.mappings.complete, bufnr, function()
+        local info = M.complete_info()
+        local line = vim.api.nvim_get_current_line()
+        local col = vim.api.nvim_win_get_cursor(0)[2]
+        if col == 0 or #line == 0 then
+          return
+        end
+
+        local prefix, cmp_start = unpack(vim.fn.matchstrpos(line:sub(1, col), info.pattern))
+        if not prefix then
+          return
+        end
+
+        M.complete_items(function(items)
+          vim.fn.complete(
+            cmp_start + 1,
+            vim.tbl_filter(function(item)
+              return vim.startswith(item.word:lower(), prefix:lower())
+            end, items)
+          )
+        end)
+      end)
 
       map_key(M.config.mappings.submit_prompt, bufnr, function()
         local chat_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
@@ -954,14 +1013,12 @@ function M.setup(config)
     range = true,
   })
 
-  vim.api.nvim_create_user_command('CopilotChatModel', function()
-    vim.notify('Using model: ' .. M.config.model, vim.log.levels.INFO)
-  end, { force = true })
-
   vim.api.nvim_create_user_command('CopilotChatModels', function()
     M.select_model()
   end, { force = true })
-
+  vim.api.nvim_create_user_command('CopilotChatAgents', function()
+    M.select_agent()
+  end, { force = true })
   vim.api.nvim_create_user_command('CopilotChatOpen', function()
     M.open()
   end, { force = true })


### PR DESCRIPTION
https://docs.github.com/en/copilot/building-copilot-extensions/about-building-copilot-extensions

- Change @buffer and @buffers to #buffer and #buffers
- Add support for @agent agent selection
- Add support for config.agent for specifying default agent
- Add :CopilotChatAgents for listing agents (and showing selected agent)
- Remove :CopilotChatModel, instead show which model is selected in :CopilotChatModels
- Remove early errors from curl so we can actually get response body for the error
- Add info to README about models, agents and contexts

Closes #466

![image](https://github.com/user-attachments/assets/5696643e-cc76-4430-a796-9ad1447a0e21)