### PR TITLE
feat(chat): improve auto follow cursor behavior

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -2,7 +2,6 @@
 ---@field bufnr number
 ---@field winnr number
 ---@field separator string
----@field auto_follow_cursor boolean
 ---@field spinner CopilotChat.Spinner
 ---@field valid fun(self: CopilotChat.Chat)
 ---@field visible fun(self: CopilotChat.Chat)
@@ -132,12 +131,11 @@ function Chat:append(str)
   end
 
   -- Decide if we should follow cursor after appending text.
-  -- Note that winnr may be nil if the chat window is not open yet.
   local should_follow_cursor = self.auto_follow_cursor
-  if self.auto_follow_cursor and self.winnr then
+  if self.auto_follow_cursor and self:visible() then
     local current_pos = vim.api.nvim_win_get_cursor(self.winnr)
     local line_count = vim.api.nvim_buf_line_count(self.bufnr)
-    -- If we are at the last line of the buffer, then we should follow cursor.
+    -- Follow only if the cursor is currently at the last line.
     should_follow_cursor = current_pos[1] == line_count
   end
 

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -155,13 +155,6 @@ local function update_prompts(prompt, system_prompt)
   return system_prompt, result
 end
 
---- Append a string to the chat window.
----@param str (string)
----@param config CopilotChat.config
-local function append(str, config)
-  state.chat:append(str)
-end
-
 local function get_selection()
   local bufnr = state.source.bufnr
   local winnr = state.source.winnr
@@ -469,9 +462,9 @@ function M.ask(prompt, config, source)
   local function on_error(err)
     log.error(vim.inspect(err))
     vim.schedule(function()
-      append('\n\n' .. config.error_header .. config.separator .. '\n\n', config)
-      append('```\n' .. get_error_message(err) .. '\n```', config)
-      append('\n\n' .. config.question_header .. config.separator .. '\n\n', config)
+      state.chat:append('\n\n' .. config.error_header .. config.separator .. '\n\n')
+      state.chat:append('```\n' .. get_error_message(err) .. '\n```')
+      state.chat:append('\n\n' .. config.question_header .. config.separator .. '\n\n')
       state.chat:finish()
     end)
   end
@@ -489,11 +482,11 @@ function M.ask(prompt, config, source)
   state.last_system_prompt = system_prompt
 
   if state.copilot:stop() then
-    append('\n\n' .. config.question_header .. config.separator .. '\n\n', config)
+    state.chat:append('\n\n' .. config.question_header .. config.separator .. '\n\n')
   end
 
-  append(updated_prompt, config)
-  append('\n\n' .. config.answer_header .. config.separator .. '\n\n', config)
+  state.chat:append(updated_prompt)
+  state.chat:append('\n\n' .. config.answer_header .. config.separator .. '\n\n')
 
   local selected_context = config.context
   if string.find(prompt, '#buffers') then
@@ -540,7 +533,7 @@ function M.ask(prompt, config, source)
         temperature = config.temperature,
         on_progress = function(token)
           vim.schedule(function()
-            append(token, config)
+            state.chat:append(token)
           end)
         end,
       })
@@ -557,7 +550,7 @@ function M.ask(prompt, config, source)
     state.response = response
 
     vim.schedule(function()
-      append('\n\n' .. config.question_header .. config.separator .. '\n\n', config)
+      state.chat:append('\n\n' .. config.question_header .. config.separator .. '\n\n')
       if token_count and token_max_count and token_count > 0 then
         state.chat:finish(token_count .. '/' .. token_max_count .. ' tokens used')
       else
@@ -588,9 +581,9 @@ function M.stop(reset, config)
     if reset then
       state.chat:clear()
     else
-      append('\n\n', config)
+      state.chat:append('\n\n')
     end
-    append(M.config.question_header .. M.config.separator .. '\n\n', config)
+    state.chat:append(M.config.question_header .. M.config.separator .. '\n\n')
     state.chat:finish()
   end)
 end
@@ -639,20 +632,20 @@ function M.load(name, history_path)
   for i, message in ipairs(history) do
     if message.role == 'user' then
       if i > 1 then
-        append('\n\n', state.config)
+        state.chat:append('\n\n')
       end
-      append(M.config.question_header .. M.config.separator .. '\n\n', state.config)
-      append(message.content, state.config)
+      state.chat:append(M.config.question_header .. M.config.separator .. '\n\n')
+      state.chat:append(message.content)
     elseif message.role == 'assistant' then
-      append('\n\n' .. M.config.answer_header .. M.config.separator .. '\n\n', state.config)
-      append(message.content, state.config)
+      state.chat:append('\n\n' .. M.config.answer_header .. M.config.separator .. '\n\n')
+      state.chat:append(message.content)
     end
   end
 
   if #history > 0 then
-    append('\n\n', state.config)
+    state.chat:append('\n\n')
   end
-  append(M.config.question_header .. M.config.separator .. '\n\n', state.config)
+  state.chat:append(M.config.question_header .. M.config.separator .. '\n\n')
 
   state.chat:finish()
   M.open()
@@ -1003,7 +996,7 @@ function M.setup(config)
         })
       end
 
-      append(M.config.question_header .. M.config.separator .. '\n\n', M.config)
+      state.chat:append(M.config.question_header .. M.config.separator .. '\n\n')
       state.chat:finish()
     end
   )

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -160,9 +160,6 @@ end
 ---@param config CopilotChat.config
 local function append(str, config)
   state.chat:append(str)
-  if config and config.auto_follow_cursor then
-    state.chat:follow()
-  end
 end
 
 local function get_selection()


### PR DESCRIPTION
Auto follow cursor is generally a convenient and desirable feature. However, it gets annoying when the model is streaming a very long response spanning more vertical space than the chat window has. In such cases the user might want to read the response from the beginning at a human pace, yet auto follow keeps pushing forward at robot speed.

This PR improves auto follow cursor behavior by conditioning it on the current cursor position. If it is at the last line, auto-following happens. Otherwise, the cursor stays where it is. Effectively, this means that the user can prevent auto-following from happening by simply moving the cursor up.