### PR TITLE
Remove private fields from chat class type definition

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -1,8 +1,6 @@
 ---@class CopilotChat.Chat
 ---@field bufnr number
 ---@field winnr number
----@field separator string
----@field spinner CopilotChat.Spinner
 ---@field valid fun(self: CopilotChat.Chat)
 ---@field visible fun(self: CopilotChat.Chat)
 ---@field active fun(self: CopilotChat.Chat)


### PR DESCRIPTION
These fields are not meant to be used from outside so dont expose them.