### PR TITLE
Add support for sticky prompt section with `> `

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,19 +108,49 @@ Verify "[Copilot chat in the IDE](https://github.com/settings/copilot)" is enabl
 - `:CopilotChatModels` - View and select available models. This is reset when a new instance is made. Please set your model in `init.lua` for persistence.
 - `:CopilotChatAgents` - View and select available agents. This is reset when a new instance is made. Please set your agent in `init.lua` for persistence.
 
-#### Commands coming from default prompts
+### Prompts
 
-- `:CopilotChatExplain` - Write an explanation for the selected code and diagnostics as paragraphs of text
-- `:CopilotChatReview` - Review the selected code
-- `:CopilotChatFix` - There is a problem in this code. Rewrite the code to show it with the bug fixed
-- `:CopilotChatOptimize` - Optimize the selected code to improve performance and readability
-- `:CopilotChatDocs` - Please add documentation comments to the selected code
-- `:CopilotChatTests` - Please generate tests for my code
-- `:CopilotChatCommit` - Write commit message for the change with commitizen convention
+You can ask Copilot to do various tasks with prompts. You can reference prompts with `/PromptName` in chat or call with command `:CopilotChat<PromptName>`.  
+Default prompts are:
 
-### Models, Agents and Contexts
+- `Explain` - Write an explanation for the selected code and diagnostics as paragraphs of text
+- `Review` - Review the selected code
+- `Fix` - There is a problem in this code. Rewrite the code to show it with the bug fixed
+- `Optimize` - Optimize the selected code to improve performance and readability
+- `Docs` - Please add documentation comments to the selected code
+- `Tests` - Please generate tests for my code
+- `Commit` - Write commit message for the change with commitizen convention
 
-#### Models
+### System Prompts
+
+System prompts specify the behavior of the AI model. You can reference system prompts with `/PROMPT_NAME` in chat.
+Default system prompts are:
+
+- `COPILOT_INSTRUCTIONS` - Base GitHub Copilot instructions
+- `COPILOT_EXPLAIN` - On top of the base instructions adds coding tutor behavior
+- `COPILOT_REVIEW` - On top of the base instructions adds code review behavior with instructions on how to generate diagnostics
+- `COPILOT_GENERATE` - On top of the base instructions adds code generation behavior, with predefined formatting and generation rules
+
+### Sticky Prompts
+
+You can set sticky prompt in chat by prefixing the text with `> ` using markdown blockquote syntax.  
+The sticky prompt will be copied at start of every new prompt in chat window. You can freely edit the sticky prompt, only rule is `> ` prefix at beginning of line.  
+This is useful for preserving stuff like context and agent selection (see below).  
+Example usage:
+
+```markdown
+> #files
+
+List all files in the workspace
+```
+
+```markdown
+> @models Using Mistral-small
+
+What is 1 + 11
+```
+
+### Models
 
 You can list available models with `:CopilotChatModels` command. Model determines the AI model used for the chat.  
 Default models are:
@@ -133,7 +163,7 @@ Default models are:
 For more information about models, see [here](https://docs.github.com/en/copilot/using-github-copilot/asking-github-copilot-questions-in-your-ide#ai-models-for-copilot-chat)  
 You can use more models from [here](https://github.com/marketplace/models) by using `@models` agent from [here](https://github.com/marketplace/models-github) (example: `@models Using Mistral-small, what is 1 + 11`)
 
-#### Agents
+### Agents
 
 Agents are used to determine the AI agent used for the chat. You can list available agents with `:CopilotChatAgents` command.  
 You can set the agent in the prompt by using `@` followed by the agent name.  
@@ -142,7 +172,7 @@ Default "noop" agent is `copilot`.
 For more information about extension agents, see [here](https://docs.github.com/en/copilot/using-github-copilot/using-extensions-to-integrate-external-tools-with-copilot-chat)  
 You can install more agents from [here](https://github.com/marketplace?type=apps&copilot_app=true)
 
-#### Contexts
+### Contexts
 
 Contexts are used to determine the context of the chat.  
 You can set the context in the prompt by using `#` followed by the context name.  
@@ -262,25 +292,25 @@ Also see [here](/lua/CopilotChat/config.lua):
   -- default prompts
   prompts = {
     Explain = {
-      prompt = '/COPILOT_EXPLAIN Write an explanation for the selected code and diagnostics as paragraphs of text.',
+      prompt = '> /COPILOT_EXPLAIN\n\nWrite an explanation for the selected code and diagnostics as paragraphs of text.',
     },
     Review = {
-      prompt = '/COPILOT_REVIEW Review the selected code.',
+      prompt = '> /COPILOT_REVIEW\n\nReview the selected code.',
       callback = function(response, source)
         -- see config.lua for implementation
       end,
     },
     Fix = {
-      prompt = '/COPILOT_GENERATE There is a problem in this code. Rewrite the code to show it with the bug fixed.',
+      prompt = '> /COPILOT_GENERATE\n\nThere is a problem in this code. Rewrite the code to show it with the bug fixed.',
     },
     Optimize = {
-      prompt = '/COPILOT_GENERATE Optimize the selected code to improve performance and readability.',
+      prompt = '> /COPILOT_GENERATE\n\nOptimize the selected code to improve performance and readability.',
     },
     Docs = {
-      prompt = '/COPILOT_GENERATE Please add documentation comments to the selected code.',
+      prompt = '> /COPILOT_GENERATE\n\nPlease add documentation comments to the selected code.',
     },
     Tests = {
-      prompt = '/COPILOT_GENERATE Please generate tests for my code.',
+      prompt = '> /COPILOT_GENERATE\n\nPlease generate tests for my code.',
     },
     Commit = {
       prompt = 'Write commit message for the change with commitizen convention. Make sure the title has maximum 50 characters and message is wrapped at 72 characters. Wrap the whole message in code block with language gitcommit.',
@@ -320,6 +350,10 @@ Also see [here](/lua/CopilotChat/config.lua):
     submit_prompt = {
       normal = '<CR>',
       insert = '<C-s>'
+    },
+    toggle_sticky = {
+      detail = 'Makes line under cursor sticky or deletes sticky line.',
+      normal = 'gr',
     },
     accept_diff = {
       normal = '<C-y>',

--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -11,7 +11,7 @@
 ---@field close fun(self: CopilotChat.Chat, bufnr: number?)
 ---@field focus fun(self: CopilotChat.Chat)
 ---@field follow fun(self: CopilotChat.Chat)
----@field finish fun(self: CopilotChat.Chat, msg: string?)
+---@field finish fun(self: CopilotChat.Chat, msg: string?, offset: number?)
 ---@field delete fun(self: CopilotChat.Chat)
 
 local Overlay = require('CopilotChat.overlay')
@@ -280,9 +280,13 @@ function Chat:follow()
   vim.api.nvim_win_set_cursor(self.winnr, { last_line + 1, last_column })
 end
 
-function Chat:finish(msg)
+function Chat:finish(msg, offset)
   if not self.spinner then
     return
+  end
+
+  if not offset then
+    offset = 0
   end
 
   self.spinner:finish()
@@ -295,7 +299,7 @@ function Chat:finish(msg)
     msg = self.help
   end
 
-  self:show_help(msg, -2)
+  self:show_help(msg, -offset)
   if self.auto_insert and self:active() then
     vim.cmd('startinsert')
   end

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -54,6 +54,7 @@ local select = require('CopilotChat.select')
 ---@field close CopilotChat.config.mapping?
 ---@field reset CopilotChat.config.mapping?
 ---@field submit_prompt CopilotChat.config.mapping?
+---@field toggle_sticky CopilotChat.config.mapping?
 ---@field accept_diff CopilotChat.config.mapping?
 ---@field yank_diff CopilotChat.config.mapping?
 ---@field show_diff CopilotChat.config.mapping?
@@ -125,10 +126,10 @@ return {
   -- default prompts
   prompts = {
     Explain = {
-      prompt = '/COPILOT_EXPLAIN Write an explanation for the selected code and diagnostics as paragraphs of text.',
+      prompt = '> /COPILOT_EXPLAIN\n\nWrite an explanation for the selected code and diagnostics as paragraphs of text.',
     },
     Review = {
-      prompt = '/COPILOT_REVIEW Review the selected code.',
+      prompt = '> /COPILOT_REVIEW\n\nReview the selected code.',
       callback = function(response, source)
         local diagnostics = {}
         for line in response:gmatch('[^\r\n]+') do
@@ -170,16 +171,16 @@ return {
       end,
     },
     Fix = {
-      prompt = '/COPILOT_GENERATE There is a problem in this code. Rewrite the code to show it with the bug fixed.',
+      prompt = '> /COPILOT_GENERATE\n\nThere is a problem in this code. Rewrite the code to show it with the bug fixed.',
     },
     Optimize = {
-      prompt = '/COPILOT_GENERATE Optimize the selected code to improve performance and readability.',
+      prompt = '> /COPILOT_GENERATE\n\nOptimize the selected code to improve performance and readability.',
     },
     Docs = {
-      prompt = '/COPILOT_GENERATE Please add documentation comments to the selected code.',
+      prompt = '> /COPILOT_GENERATE\n\nPlease add documentation comments to the selected code.',
     },
     Tests = {
-      prompt = '/COPILOT_GENERATE Please generate tests for my code.',
+      prompt = '> /COPILOT_GENERATE\n\nPlease generate tests for my code.',
     },
     Commit = {
       prompt = 'Write commit message for the change with commitizen convention. Make sure the title has maximum 50 characters and message is wrapped at 72 characters. Wrap the whole message in code block with language gitcommit.',
@@ -219,6 +220,10 @@ return {
     submit_prompt = {
       normal = '<CR>',
       insert = '<C-s>',
+    },
+    toggle_sticky = {
+      detail = 'Makes line under cursor sticky or deletes sticky line.',
+      normal = 'gr',
     },
     accept_diff = {
       normal = '<C-y>',

--- a/lua/CopilotChat/prompts.lua
+++ b/lua/CopilotChat/prompts.lua
@@ -85,8 +85,4 @@ Your task is to modify the provided code according to the user's request. Follow
 Remember that Your response SHOULD CONTAIN ONLY THE MODIFIED CODE to be used as DIRECT REPLACEMENT to the original file.
 ]]
 
-M.SHOW_CONTEXT = [[
-At the beginning of your response show code outline from all the provided files coming from Context and Active Selection.
-]]
-
 return M


### PR DESCRIPTION
- Everything in blockquote is copied to the next prompt and added at start
  automatically. This is useful for preserving context/agents etc.
- Remove SHOW_CONTEXT prompt as with sticky its no longer necessary imo and
  claude works fine without additional debugging.
- Use new sticky feature with default prompts so the system prompt choice is
  remembered automatically
- Add new `toggle_sticky` mapping for toggling sticky line under cursor
- Update README with sticky prompts, prompts and system prompts

Example:

```markdown
> #files

explain me this

---

> #files
```

![image](https://github.com/user-attachments/assets/de3f4ce3-ebbf-4b2a-9dd3-e42bcc640c8b)
