### PR TITLE
feat: add automatic chat autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Also see [here](/lua/CopilotChat/config.lua):
   error_header = '## Error ', -- Header to use for errors
   separator = '───', -- Separator to use in chat
 
+  chat_autocomplete = true, -- Enable chat autocompletion (when disabled, requires manual `mappings.complete` trigger)
   show_folds = true, -- Shows folds for sections in chat
   show_help = true, -- Shows help message as virtual lines when waiting for user input
   auto_follow_cursor = true, -- Auto-follow cursor in chat
@@ -572,30 +573,6 @@ Requires [fzf-lua](https://github.com/ibhagwan/fzf-lua) plugin to be installed.
 ```
 
 ![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/5115805/743455bb-9517-48a8-a7a1-81215dc3b747)
-
-</details>
-
-<details>
-<summary>nvim-cmp integration</summary>
-
-Requires [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) plugin to be installed (and properly configured).
-
-```lua
--- Registers copilot-chat source and enables it for copilot-chat filetype (so copilot chat window)
-require("CopilotChat.integrations.cmp").setup()
-
--- You might also want to disable default <tab> complete mapping for copilot chat when doing this
-require('CopilotChat').setup({
-  mappings = {
-    complete = {
-      insert = '',
-    },
-  },
-  -- rest of your config
-})
-```
-
-![image](https://github.com/CopilotC-Nvim/CopilotChat.nvim/assets/5115805/063fc99f-a4b2-4187-a065-0fdd287ebee2)
 
 </details>
 

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -83,6 +83,7 @@ local select = require('CopilotChat.select')
 ---@field answer_header string?
 ---@field error_header string?
 ---@field separator string?
+---@field chat_autocomplete boolean?
 ---@field show_folds boolean?
 ---@field show_help boolean?
 ---@field auto_follow_cursor boolean?
@@ -114,6 +115,7 @@ return {
   error_header = '## Error ', -- Header to use for errors
   separator = '───', -- Separator to use in chat
 
+  chat_autocomplete = true, -- Enable chat autocompletion (when disabled, requires manual `mappings.complete` trigger)
   show_folds = true, -- Shows folds for sections in chat
   show_help = true, -- Shows help message as virtual lines when waiting for user input
   auto_follow_cursor = true, -- Auto-follow cursor in chat

--- a/lua/CopilotChat/integrations/cmp.lua
+++ b/lua/CopilotChat/integrations/cmp.lua
@@ -1,52 +1,9 @@
-local cmp = require('cmp')
-local chat = require('CopilotChat')
-
-local Source = {}
-
-function Source:get_trigger_characters()
-  return chat.complete_info().triggers
-end
-
-function Source:get_keyword_pattern()
-  return chat.complete_info().pattern
-end
-
-function Source:complete(params, callback)
-  chat.complete_items(function(items)
-    items = vim.tbl_map(function(item)
-      return {
-        label = item.word,
-        kind = cmp.lsp.CompletionItemKind.Keyword,
-      }
-    end, items)
-
-    local prefix = string.lower(params.context.cursor_before_line:sub(params.offset))
-
-    callback({
-      items = vim.tbl_filter(function(item)
-        return vim.startswith(item.label:lower(), prefix:lower())
-      end, items),
-    })
-  end)
-end
-
----@param completion_item lsp.CompletionItem
----@param callback fun(completion_item: lsp.CompletionItem|nil)
-function Source:execute(completion_item, callback)
-  callback(completion_item)
-  vim.api.nvim_set_option_value('buflisted', false, { buf = 0 })
-end
+local utils = require('CopilotChat.utils')
 
 local M = {}
 
---- Setup the nvim-cmp source for copilot-chat window
 function M.setup()
-  cmp.register_source('copilot-chat', Source)
-  cmp.setup.filetype('copilot-chat', {
-    sources = {
-      { name = 'copilot-chat' },
-    },
-  })
+  utils.deprecate('CopilotChat.integrations.cmp.setup', 'config.chat_autocomplete=true')
 end
 
 return M

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -1,4 +1,3 @@
-local log = require('plenary.log')
 local M = {}
 
 --- Create class
@@ -74,6 +73,23 @@ function M.table_equals(a, b)
   return true
 end
 
+--- Blend a color with the neovim background
+function M.blend_color_with_neovim_bg(color_name, blend)
+  local color_int = vim.api.nvim_get_hl(0, { name = color_name }).fg
+  local bg_int = vim.api.nvim_get_hl(0, { name = 'Normal' }).bg
+
+  if not color_int or not bg_int then
+    return
+  end
+
+  local color = { (color_int / 65536) % 256, (color_int / 256) % 256, color_int % 256 }
+  local bg = { (bg_int / 65536) % 256, (bg_int / 256) % 256, bg_int % 256 }
+  local r = math.floor((color[1] * blend + bg[1] * (100 - blend)) / 100)
+  local g = math.floor((color[2] * blend + bg[2] * (100 - blend)) / 100)
+  local b = math.floor((color[3] * blend + bg[3] * (100 - blend)) / 100)
+  return string.format('#%02x%02x%02x', r, g, b)
+end
+
 --- Return to normal mode
 function M.return_to_normal_mode()
   local mode = vim.fn.mode():lower()
@@ -84,8 +100,17 @@ function M.return_to_normal_mode()
   end
 end
 
+--- Mark a function as deprecated
 function M.deprecate(old, new)
-  vim.deprecate(old, new, '3.0.0', 'CopilotChat.nvim', false)
+  vim.deprecate(old, new, '3.0.X', 'CopilotChat.nvim', false)
+end
+
+--- Debounce a function
+function M.debounce(fn, delay)
+  if M.timer then
+    M.timer:stop()
+  end
+  M.timer = vim.defer_fn(fn, delay)
 end
 
 return M


### PR DESCRIPTION
Adds new config option `chat_autocomplete` (enabled by default) that will trigger completion automatically when typing trigger characters (@, /, #, $, :). This replaces the nvim-cmp integration which is now deprecated in favor of this new solution.

The automatic completion is debounced to avoid too many triggers and uses the same completion logic as before, just moved to separate function.