### PR TITLE
refactor: improve semantic embeddings performance

### DIFF
--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -315,6 +315,7 @@ end
 
 local function generate_embedding_request(inputs, model)
   return {
+    dimensions = 512,
     input = vim.tbl_map(function(input)
       local out = ''
       if input.prompt then
@@ -323,8 +324,8 @@ local function generate_embedding_request(inputs, model)
       if input.content then
         out = out
           .. string.format(
-            '# FILE:%s CONTEXT\n```%s\n%s\n```',
-            input.filename:upper(),
+            'File: `%s`\n```%s\n%s\n```',
+            input.filename,
             input.filetype,
             input.content
           )
@@ -881,7 +882,7 @@ end
 ---@param opts CopilotChat.copilot.embed.opts: Options for the request
 function Copilot:embed(inputs, opts)
   opts = opts or {}
-  local model = opts.model or 'copilot-text-embedding-ada-002'
+  local model = opts.model or 'text-embedding-3-small'
   local chunk_size = opts.chunk_size or 15
 
   if not inputs or #inputs == 0 then

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -559,7 +559,12 @@ function M.ask(prompt, config)
     ))
     or 'untitled'
 
-  local embeddings = {}
+  local embeddings = {
+    {
+      prompt = prompt,
+    },
+  }
+
   local function parse_context(prompt_context)
     local split = vim.split(prompt_context, ':')
     local context_name = table.remove(split, 1)
@@ -604,14 +609,8 @@ function M.ask(prompt, config)
       end
     end
 
-    local query_ok, filtered_embeddings = pcall(context.filter_embeddings, state.copilot, {
-      embeddings = embeddings,
-      prompt = prompt,
-      selection = selection.lines,
-      filename = filename,
-      filetype = filetype,
-      bufnr = state.source.bufnr,
-    })
+    local query_ok, filtered_embeddings =
+      pcall(context.filter_embeddings, state.copilot, embeddings)
 
     if not query_ok then
       vim.schedule(function()


### PR DESCRIPTION
Previously the semantic embeddings were using older model and not using the query in most optimal way. Now it is using text-embedding-3-small model for reduced cost and better performance, embeddings are stored in 512 dimensions and the embedding process was refactored to be more straightforward and use less API calls by including the query in the initial embedding call.

Also slightly improves the formatting of the embedding prompt to be more readable.