### PR TITLE
Use relative paths for file references in contexts

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -141,7 +141,7 @@ return {
         vim.ui.select(
           vim.tbl_map(
             function(buf)
-              return { id = buf, name = vim.api.nvim_buf_get_name(buf) }
+              return { id = buf, name = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(buf), ':p:.') }
             end,
             vim.tbl_filter(function(buf)
               return vim.api.nvim_buf_is_loaded(buf) and vim.fn.buflisted(buf) == 1

--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -116,7 +116,7 @@ function M.file(filename)
 
   return {
     content = table.concat(content, '\n'),
-    filename = filename,
+    filename = vim.fn.fnamemodify(filename, ':p:.'),
     filetype = vim.filetype.match({ filename = filename }),
   }
 end
@@ -127,6 +127,7 @@ end
 ---@return CopilotChat.copilot.embed?
 function M.outline(bufnr)
   local name = vim.api.nvim_buf_get_name(bufnr)
+  name = vim.fn.fnamemodify(name, ':p:.')
   local ft = vim.bo[bufnr].filetype
 
   -- If buffer is not too big, just return the content


### PR DESCRIPTION
Makes data smaller and faster