### PR TITLE
Show errors inline in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,9 +645,11 @@ require('render-markdown').setup({
   file_types = { 'markdown', 'copilot-chat' },
 })
 
--- You might also want to disable default header highlighting for copilot chat when doing this
+-- You might also want to disable default header highlighting for copilot chat when doing this and set error header style and separator
 require('CopilotChat').setup({
   highlight_headers = false,
+  separator = '---',
+  error_header = '> [!ERROR] Error',
   -- rest of your config
 })
 ```


### PR DESCRIPTION
Instead of creating new error section, show error inline in response to not waste chat space

![image](https://github.com/user-attachments/assets/24d39d5b-dbef-47a9-a02c-7b6a2c9790a1)