### PR TITLE
refactor(context): improve accuracy of buffer processing

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -160,7 +160,7 @@ return {
       end,
       resolve = function(input, source)
         return {
-          context.outline(input and tonumber(input) or source.bufnr),
+          context.buffer(input and tonumber(input) or source.bufnr),
         }
       end,
     },
@@ -174,7 +174,7 @@ return {
       resolve = function(input)
         input = input or 'listed'
         return vim.tbl_map(
-          context.outline,
+          context.buffer,
           vim.tbl_filter(function(b)
             return vim.api.nvim_buf_is_loaded(b)
               and vim.fn.buflisted(b) == 1

--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -108,24 +108,6 @@ local function quick_hash(str)
   return #str .. str:sub(1, 32) .. str:sub(-32)
 end
 
-local function find_config_path()
-  local config = vim.fn.expand('$XDG_CONFIG_HOME')
-  if config and vim.fn.isdirectory(config) > 0 then
-    return config
-  end
-  if vim.fn.has('win32') > 0 then
-    config = vim.fn.expand('$LOCALAPPDATA')
-    if not config or vim.fn.isdirectory(config) == 0 then
-      config = vim.fn.expand('$HOME/AppData/Local')
-    end
-  else
-    config = vim.fn.expand('$HOME/.config')
-  end
-  if config and vim.fn.isdirectory(config) > 0 then
-    return config
-  end
-end
-
 local function get_cached_token()
   -- loading token from the environment only in GitHub Codespaces
   local token = os.getenv('GITHUB_TOKEN')
@@ -135,7 +117,7 @@ local function get_cached_token()
   end
 
   -- loading token from the file
-  local config_path = find_config_path()
+  local config_path = utils.config_path()
   if not config_path then
     return nil
   end

--- a/lua/CopilotChat/debuginfo.lua
+++ b/lua/CopilotChat/debuginfo.lua
@@ -10,15 +10,19 @@ function M.open()
     'Log file path:',
     '`' .. log.logfile .. '`',
     '',
-    'Temp directory:',
-    '`' .. vim.fn.fnamemodify(os.tmpname(), ':h') .. '`',
-    '',
     'Data directory:',
     '`' .. vim.fn.stdpath('data') .. '`',
     '',
+    'Config directory:',
+    '`' .. utils.config_path() .. '`',
+    '',
+    'Temp directory:',
+    '`' .. vim.fn.fnamemodify(os.tmpname(), ':h') .. '`',
+    '',
   }
 
-  local outline = context.outline(vim.api.nvim_get_current_buf())
+  local buf = context.buffer(vim.api.nvim_get_current_buf())
+  local outline = buf and context.outline(buf.content, buf.filename, buf.filetype)
   if outline then
     table.insert(lines, 'Current buffer outline:')
     table.insert(lines, '`' .. outline.filename .. '`')

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -49,6 +49,26 @@ function M.temp_file(text)
   return temp_file
 end
 
+--- Finds the path to the user's config directory
+---@return string?
+function M.config_path()
+  local config = vim.fn.expand('$XDG_CONFIG_HOME')
+  if config and vim.fn.isdirectory(config) > 0 then
+    return config
+  end
+  if vim.fn.has('win32') > 0 then
+    config = vim.fn.expand('$LOCALAPPDATA')
+    if not config or vim.fn.isdirectory(config) == 0 then
+      config = vim.fn.expand('$HOME/AppData/Local')
+    end
+  else
+    config = vim.fn.expand('$HOME/.config')
+  end
+  if config and vim.fn.isdirectory(config) > 0 then
+    return config
+  end
+end
+
 --- Check if a table is equal to another table
 ---@param a table The first table
 ---@param b table The second table


### PR DESCRIPTION
Rather than using harsh big file threshold for converting files/buffers
to outline format, outline is now used mostly for similarity scoring.
This preserves the original content while improving the accuracy of
content matching.

Additionally:
- Move find_config_path to utils module for reuse
- Add buffer function to get full buffer content
- Rewrite outline function to work with strings rather than buffers

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>