### PR TITLE
refactor(selection): normalize line ranges and content handling

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -7,22 +7,19 @@ local select = require('CopilotChat.select')
 --- @field winnr number
 
 ---@class CopilotChat.config.selection.diagnostic
----@field message string
+---@field content string
+---@field start_line number
+---@field end_line number
 ---@field severity string
----@field start_row number
----@field start_col number
----@field end_row number
----@field end_col number
 
 ---@class CopilotChat.config.selection
----@field lines string
----@field diagnostics table<CopilotChat.config.selection.diagnostic>?
+---@field content string
+---@field start_line number?
+---@field end_line number?
 ---@field filename string?
 ---@field filetype string?
----@field start_row number?
----@field start_col number?
----@field end_row number?
----@field end_col number?
+---@field bufnr number?
+---@field diagnostics table<CopilotChat.config.selection.diagnostic>?
 
 ---@class CopilotChat.config.context
 ---@field description string?

--- a/lua/CopilotChat/overlay.lua
+++ b/lua/CopilotChat/overlay.lua
@@ -2,7 +2,7 @@
 ---@field bufnr number
 ---@field valid fun(self: CopilotChat.Overlay)
 ---@field validate fun(self: CopilotChat.Overlay)
----@field show fun(self: CopilotChat.Overlay, text: string, filetype: string, winnr: number)
+---@field show fun(self: CopilotChat.Overlay, text: string, filetype: string?, winnr: number)
 ---@field restore fun(self: CopilotChat.Overlay, winnr: number, bufnr: number)
 ---@field delete fun(self: CopilotChat.Overlay)
 ---@field show_help fun(self: CopilotChat.Overlay, msg: string, offset: number)
@@ -47,6 +47,7 @@ function Overlay:show(text, filetype, winnr, syntax)
   self:show_help(self.help, -1)
   vim.api.nvim_win_set_cursor(winnr, { vim.api.nvim_buf_line_count(self.bufnr), 0 })
 
+  filetype = filetype or 'text'
   syntax = syntax or filetype
 
   -- Dual mode with treesitter (for diffs for example)


### PR DESCRIPTION
Refactors selection related code to use consistent approach for handling
line ranges, content and diagnostics. Updates diff/overlay code to use
proper filetype defaults, handle buffer references correctly and use proper
visual selection after diff application.

Main changes:
- Rename row to line in all API references for consistency
- Move content field from lines to content for better clarity
- Add proper handling of filetype defaults and buffer references
- Make selection state properly track across buffer changes
- Update visual selection properly after applying diffs