### PR TITLE
fix: check if in insert mode before showing completions

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -303,6 +303,10 @@ local function trigger_complete()
   end
 
   M.complete_items(function(items)
+    if vim.fn.mode() ~= 'i' then
+      return
+    end
+
     vim.fn.complete(
       cmp_start + 1,
       vim.tbl_filter(function(item)


### PR DESCRIPTION
Ensures completion menu is only shown when user is in insert mode to prevent unexpected behavior when triggering completion in other modes.