### PR TITLE
feat: truncate large files and improve context output

### DIFF
--- a/lua/CopilotChat/prompts.lua
+++ b/lua/CopilotChat/prompts.lua
@@ -82,6 +82,8 @@ Your task is to modify the provided code according to the user's request. Follow
 
 9. Directly above every returned code snippet, add `[file:<file_name>](<file_path>) line:<start_line>-<end_line>`. Example: `[file:copilot.lua](nvim/.config/nvim/lua/config/copilot.lua) line:1-98`. This is markdown link syntax, so make sure to follow it.
 
+10. When examining code pay close attention to diagnostics. When fixing diagnostics, add the diagnostic message as a comment next to the line where the fix was applied.
+
 Remember that Your response SHOULD CONTAIN ONLY THE MODIFIED CODE to be used as DIRECT REPLACEMENT to the original file.
 ]]
 

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -64,7 +64,7 @@ function M.visual(source)
 
   return {
     content = lines_content,
-    filename = vim.api.nvim_buf_get_name(bufnr),
+    filename = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ':p:.'),
     filetype = vim.bo[bufnr].filetype,
     start_line = start_line,
     end_line = finish_line,
@@ -86,7 +86,7 @@ function M.buffer(source)
 
   local out = {
     content = table.concat(lines, '\n'),
-    filename = vim.api.nvim_buf_get_name(bufnr),
+    filename = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ':p:.'),
     filetype = vim.bo[bufnr].filetype,
     start_line = 1,
     end_line = #lines,
@@ -112,7 +112,7 @@ function M.line(source)
 
   local out = {
     content = line,
-    filename = vim.api.nvim_buf_get_name(bufnr),
+    filename = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ':p:.'),
     filetype = vim.bo[bufnr].filetype,
     start_line = cursor[1],
     end_line = cursor[1],


### PR DESCRIPTION
This change implements better handling of large files by adding truncation logic for both files and their outlines. The main improvements include:

- Add truncation for files over 2000 lines
- Add truncation for outlines over 600 lines
- Use relative paths for filenames for better context display
- Improve context formatting with proper file links
- Add default values for unknown filenames and filetypes

These changes help prevent token limits being exceeded while still preserving important context for the LLM.