### PR TITLE
fix: remove unnecessary escape in pattern matching

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -120,7 +120,7 @@ local function get_diff()
         header:match('%[file:.+%]%((.+)%) line:(%d+)-(%d+)')
       if not header_filename then
         header_filename, header_start_line, header_end_line =
-          header:match('%[file:(.+)%]% line:(%d+)-(%d+)')
+          header:match('%[file:(.+)%] line:(%d+)-(%d+)')
       end
 
       if header_filename and header_start_line and header_end_line then


### PR DESCRIPTION
The '%' character in the pattern matching string doesn't need to be escaped as it's not a special pattern matching character in Lua.