### PR TITLE
feat: add jump to diff feature with `gj` mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,9 @@ Also see [here](/lua/CopilotChat/config.lua):
       normal = '<C-y>',
       insert = '<C-y>'
     },
+    jump_to_diff = {
+      normal = 'gj',
+    },
     yank_diff = {
       normal = 'gy',
       register = '"',

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -60,6 +60,7 @@ local utils = require('CopilotChat.utils')
 ---@field submit_prompt CopilotChat.config.mapping?
 ---@field toggle_sticky CopilotChat.config.mapping?
 ---@field accept_diff CopilotChat.config.mapping?
+---@field jump_to_diff CopilotChat.config.mapping?
 ---@field yank_diff CopilotChat.config.mapping?
 ---@field show_diff CopilotChat.config.mapping?
 ---@field show_system_prompt CopilotChat.config.mapping?
@@ -328,6 +329,9 @@ return {
     accept_diff = {
       normal = '<C-y>',
       insert = '<C-y>',
+    },
+    jump_to_diff = {
+      normal = 'gj',
     },
     yank_diff = {
       normal = 'gy',

--- a/lua/CopilotChat/diff.lua
+++ b/lua/CopilotChat/diff.lua
@@ -3,8 +3,8 @@
 ---@field reference string
 ---@field filename string
 ---@field filetype string
----@field start_line number?
----@field end_line number?
+---@field start_line number
+---@field end_line number
 ---@field bufnr number?
 
 ---@class CopilotChat.Diff

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -196,4 +196,15 @@ function M.buf_valid(bufnr)
   return bufnr and vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_is_loaded(bufnr) or false
 end
 
+--- Check if file paths are the same
+---@param file1 string? The first file path
+---@param file2 string? The second file path
+---@return boolean
+function M.filename_same(file1, file2)
+  if not file1 or not file2 then
+    return false
+  end
+  return vim.fn.fnamemodify(file1, ':p') == vim.fn.fnamemodify(file2, ':p')
+end
+
 return M


### PR DESCRIPTION
Adds new mapping that allows jumping to the target file and line number from the diff view. If the target file is already open in a buffer, it will switch to that buffer. Otherwise, it creates a new buffer with proper filetype.

This improves navigation between diff view and source files, making it easier to review and apply suggested changes.