### PR TITLE
chore: add extra newline when showing system prompt and selection

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1121,7 +1121,7 @@ function M.setup(config)
           return
         end
 
-        state.system_prompt:show(prompt .. '\n', 'markdown', state.chat.winnr)
+        state.system_prompt:show(prompt .. '\n\n', 'markdown', state.chat.winnr)
       end)
 
       map_key(M.config.mappings.show_user_selection, bufnr, function()
@@ -1130,7 +1130,7 @@ function M.setup(config)
         end
 
         state.user_selection:show(
-          state.selection.content .. '\n',
+          state.selection.content .. '\n\n',
           state.selection.filetype,
           state.chat.winnr
         )


### PR DESCRIPTION
Without this its hard to see the help text at the end