### PR TITLE
feat: add quickfix list for code blocks in chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,9 @@ Also see [here](/lua/CopilotChat/config.lua):
     jump_to_diff = {
       normal = 'gj',
     },
+    quickfix_diffs = {
+      normal = 'gq',
+    },
     yank_diff = {
       normal = 'gy',
       register = '"',

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -61,6 +61,7 @@ local utils = require('CopilotChat.utils')
 ---@field toggle_sticky CopilotChat.config.mapping?
 ---@field accept_diff CopilotChat.config.mapping?
 ---@field jump_to_diff CopilotChat.config.mapping?
+---@field quickfix_diffs CopilotChat.config.mapping?
 ---@field yank_diff CopilotChat.config.mapping?
 ---@field show_diff CopilotChat.config.mapping?
 ---@field show_system_prompt CopilotChat.config.mapping?
@@ -332,6 +333,9 @@ return {
     },
     jump_to_diff = {
       normal = 'gj',
+    },
+    quickfix_diffs = {
+      normal = 'gq',
     },
     yank_diff = {
       normal = 'gy',


### PR DESCRIPTION
Add new mapping 'gq' that populates quickfix list with code blocks from AI responses. Each entry includes source file and line numbers if available, making it easier to navigate through suggested code changes.

Also fixes selection update to ignore special window types.

![image](https://github.com/user-attachments/assets/b05a303f-7958-459c-aaeb-dee97e35bbb4)