### PR TITLE
fix: move line endings to overlay.show function

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -979,7 +979,6 @@ function M.setup(config)
             end
           end
         end
-        chat_help = chat_help .. M.config.separator .. '\n'
         state.help:show(chat_help, 'markdown', state.chat.winnr)
       end)
 
@@ -1184,7 +1183,7 @@ function M.setup(config)
           return
         end
 
-        state.system_prompt:show(prompt .. '\n\n', 'markdown', state.chat.winnr)
+        state.system_prompt:show(vim.trim(prompt) .. '\n', 'markdown', state.chat.winnr)
       end)
 
       map_key(M.config.mappings.show_user_selection, bufnr, function()
@@ -1193,7 +1192,7 @@ function M.setup(config)
           return
         end
 
-        state.user_selection:show(selection.content .. '\n\n', selection.filetype, state.chat.winnr)
+        state.user_selection:show(selection.content .. '\n', selection.filetype, state.chat.winnr)
       end)
 
       vim.api.nvim_create_autocmd({ 'BufEnter', 'BufLeave' }, {

--- a/lua/CopilotChat/overlay.lua
+++ b/lua/CopilotChat/overlay.lua
@@ -38,6 +38,8 @@ end
 
 function Overlay:show(text, filetype, winnr, syntax)
   self:validate()
+  text = text .. '\n'
+
   vim.api.nvim_win_set_buf(winnr, self.bufnr)
   vim.bo[self.bufnr].modifiable = true
   vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, vim.split(text, '\n'))


### PR DESCRIPTION
Previously, line endings were inconsistently added in different show calls. This change centralizes the line ending management in the overlay.show function, making it more maintainable and consistent across all usages.

The changes include:
- Remove duplicate line endings from individual show calls
- Add line ending handling in overlay.show function
- Clean up trailing whitespace in system prompt display