### PR TITLE
fix: allow single-line visual selections

### DIFF
--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -41,11 +41,6 @@ function M.visual(source)
   local start_line = unpack(vim.api.nvim_buf_get_mark(bufnr, '<'))
   local finish_line = unpack(vim.api.nvim_buf_get_mark(bufnr, '>'))
 
-  -- Exit if no actual selection
-  if start_line == finish_line then
-    return nil
-  end
-
   -- Swap positions if selection is backwards
   if start_line > finish_line then
     start_line, finish_line = finish_line, start_line


### PR DESCRIPTION
Previously, the visual selection function would return nil when start and end lines were the same, preventing single-line selections from working. This change removes this limitation, making the behavior more intuitive.

Closes #552