### PR TITLE
refactor: remove redundant treesitter parser init

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -52,10 +52,6 @@ local Chat = class(function(self, help, on_buf_create)
     vim.bo[bufnr].filetype = self.name
     vim.bo[bufnr].syntax = 'markdown'
     vim.bo[bufnr].textwidth = 0
-    local ok, parser = pcall(vim.treesitter.get_parser, bufnr, 'markdown')
-    if ok and parser then
-      vim.treesitter.start(bufnr, 'markdown')
-    end
 
     if not self.spinner then
       self.spinner = Spinner(bufnr)


### PR DESCRIPTION
The treesitter parser initialization for markdown was redundant since the buffer's syntax is already set to markdown via vim.bo[bufnr].syntax.