### PR TITLE
fix: improve chat buffer rendering and state handling

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -740,6 +740,7 @@ function M.ask(prompt, config)
         on_progress = function(token)
           vim.schedule(function()
             if not config.no_chat then
+              vim.cmd('undojoin')
               state.chat:append(token)
             end
 

--- a/lua/CopilotChat/overlay.lua
+++ b/lua/CopilotChat/overlay.lua
@@ -18,6 +18,7 @@ local Overlay = class(function(self, name, help, on_buf_create)
   self.buf_create = function()
     local bufnr = vim.api.nvim_create_buf(false, true)
     vim.bo[bufnr].filetype = name
+    vim.bo[bufnr].modifiable = false
     vim.api.nvim_buf_set_name(bufnr, name)
     return bufnr
   end


### PR DESCRIPTION
- Make chat buffer non-modifiable by default and only allow modifications during content updates and after response is finished
- Join response progress undos together so user can undo whole ask/response at once
- Rerender headers in chat window on text change automatically, which means that when users accidentally edits the separators in buffer the highlights do not break until next question is asked