### PR TITLE
fix: rerender chat after opening as well

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -246,6 +246,8 @@ function Chat:open(config)
   else
     vim.wo[self.winnr].foldcolumn = '0'
   end
+
+  self:render()
 end
 
 function Chat:close(bufnr)


### PR DESCRIPTION
Prevents issue when rerendering is not triggered due to buffer being hidden but still being updated