### PR TITLE
fix: improve selection validation checks

### DIFF
--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -161,7 +161,7 @@ local function generate_selection_messages(selection)
 
   local out = string.format('# FILE:%s CONTEXT\n', filename:upper())
   out = out .. "User's active selection:\n"
-  if selection.start_line and selection.end_line > 0 then
+  if selection.start_line and selection.end_line then
     out = out
       .. string.format(
         'Excerpt from %s, lines %s to %s:\n',

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -75,7 +75,12 @@ local function highlight_selection(clear)
   end
 
   local selection = get_selection(state.config)
-  if not selection or not utils.buf_valid(selection.bufnr) then
+  if
+    not selection
+    or not utils.buf_valid(selection.bufnr)
+    or not selection.start_line
+    or not selection.end_line
+  then
     return
   end
 


### PR DESCRIPTION
Enhance selection validation by properly checking for existence of start_line and end_line values. This prevents potential nil access errors when handling invalid selections.

Previously the code only checked if end_line was greater than 0, which could lead to errors if start_line or end_line were nil.