### PR TITLE
feat: add show context command for Copilot Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ See @deathbeam for [configuration](https://github.com/deathbeam/dotfiles/blob/ma
 - `gd` - Show diff between source and nearest diff
 - `gp` - Show system prompt for current chat
 - `gs` - Show current user selection
+- `gc` - Show current user context
 - `gh` - Show help message
 
 The mappings can be customized by setting the `mappings` table in your configuration. Each mapping can have:
@@ -557,6 +558,12 @@ Also see [here](/lua/CopilotChat/config.lua):
     },
     show_user_selection = {
       normal = 'gs'
+    },
+    show_user_context = {
+      normal = 'gc',
+    },
+    show_help = {
+      normal = 'gh',
     },
   },
 }

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -66,6 +66,7 @@ local utils = require('CopilotChat.utils')
 ---@field show_diff CopilotChat.config.mapping?
 ---@field show_system_prompt CopilotChat.config.mapping?
 ---@field show_user_selection CopilotChat.config.mapping?
+---@field show_user_context CopilotChat.config.mapping?
 ---@field show_help CopilotChat.config.mapping?
 
 --- CopilotChat default configuration
@@ -389,6 +390,9 @@ return {
     },
     show_user_selection = {
       normal = 'gs',
+    },
+    show_user_context = {
+      normal = 'gc',
     },
     show_help = {
       normal = 'gh',

--- a/lua/CopilotChat/overlay.lua
+++ b/lua/CopilotChat/overlay.lua
@@ -42,6 +42,10 @@ function Overlay:validate()
 end
 
 function Overlay:show(text, filetype, winnr, syntax)
+  if not text or vim.trim(text) == '' then
+    return
+  end
+
   self:validate()
   text = text .. '\n'
 


### PR DESCRIPTION
Add new command to show context of the current chat message that maps to `gc` by default. Unify existing overlay windows into single overlay implementation and improve resolution of prompts and embeddings by extracting them into separate functions. The overlay now also shows truncated preview of longer files.

This change improves debugging experience when working with contextual prompts by allowing users to inspect what files and contexts are being used for the current prompt.