### PR TITLE
fix: use cwd when getting git diffs and files

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -6,6 +6,7 @@ local utils = require('CopilotChat.utils')
 --- @class CopilotChat.config.source
 --- @field bufnr number
 --- @field winnr number
+--- @field cwd string
 
 ---@class CopilotChat.config.selection.diagnostic
 ---@field content string
@@ -24,7 +25,7 @@ local utils = require('CopilotChat.utils')
 
 ---@class CopilotChat.config.context
 ---@field description string?
----@field input fun(callback: fun(input: string?))?
+---@field input fun(callback: fun(input: string?), source: CopilotChat.config.source)?
 ---@field resolve fun(input: string?, source: CopilotChat.config.source):table<CopilotChat.copilot.embed>
 
 ---@class CopilotChat.config.prompt
@@ -188,10 +189,10 @@ return {
     },
     file = {
       description = 'Includes content of provided file in chat context. Supports input.',
-      input = function(callback)
+      input = function(callback, source)
         local files = vim.tbl_filter(function(file)
           return vim.fn.isdirectory(file) == 0
-        end, vim.fn.glob('**/*', false, true))
+        end, vim.fn.glob(source.cwd .. '/**/*', false, true))
 
         vim.ui.select(files, {
           prompt = 'Select a file> ',
@@ -211,8 +212,8 @@ return {
           default = '**/*',
         }, callback)
       end,
-      resolve = function(input)
-        return context.files(input)
+      resolve = function(input, source)
+        return context.files(input, source.cwd)
       end,
     },
     git = {
@@ -224,7 +225,7 @@ return {
       end,
       resolve = function(input, source)
         return {
-          context.gitdiff(input, source.bufnr),
+          context.gitdiff(input, source.cwd),
         }
       end,
     },

--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -191,11 +191,13 @@ end
 
 --- Get list of all files in workspace
 ---@param pattern string?
+---@param cwd string
 ---@return table<CopilotChat.copilot.embed>
-function M.files(pattern)
+function M.files(pattern, cwd)
+  local search = cwd .. '/' .. (pattern or '**/*')
   local files = vim.tbl_filter(function(file)
     return vim.fn.isdirectory(file) == 0
-  end, vim.fn.glob(pattern or '**/*', false, true))
+  end, vim.fn.glob(search, false, true))
 
   if #files == 0 then
     return {}
@@ -263,23 +265,11 @@ end
 
 --- Get current git diff
 ---@param type string?
----@param bufnr number
+---@param cwd string
 ---@return CopilotChat.copilot.embed?
-function M.gitdiff(type, bufnr)
-  if not utils.buf_valid(bufnr) then
-    return nil
-  end
-
+function M.gitdiff(type, cwd)
   type = type or 'unstaged'
-  local bufname = vim.api.nvim_buf_get_name(bufnr)
-  local file_path = bufname:gsub('^%w+://', '')
-  local dir = vim.fn.fnamemodify(file_path, ':h')
-  if not dir or dir == '' then
-    return nil
-  end
-  dir = dir:gsub('.git$', '')
-
-  local cmd = 'git -C ' .. dir .. ' diff --no-color --no-ext-diff'
+  local cmd = 'git -C ' .. cwd .. ' diff --no-color --no-ext-diff'
 
   if type == 'staged' then
     cmd = cmd .. ' --staged'

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -92,9 +92,16 @@ end
 local function update_selection()
   local prev_winnr = vim.fn.win_getid(vim.fn.winnr('#'))
   if prev_winnr ~= state.chat.winnr and vim.fn.win_gettype(prev_winnr) == '' then
+    -- TODO: This is a hack to get the cwd of the previous window properly, its actually baffling I have to do this
+    local current_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_set_current_win(prev_winnr)
+    local cwd = vim.fn.getcwd()
+    vim.api.nvim_set_current_win(current_win)
+
     state.source = {
       bufnr = vim.api.nvim_win_get_buf(prev_winnr),
       winnr = prev_winnr,
+      cwd = cwd,
     }
   end
 
@@ -431,7 +438,7 @@ local function trigger_complete()
         local value_str = tostring(value)
         vim.api.nvim_buf_set_text(bufnr, row - 1, col, row - 1, col, { value_str })
         vim.api.nvim_win_set_cursor(0, { row, col + #value_str })
-      end)
+      end, state.source)
     end
 
     return


### PR DESCRIPTION
The current implementation incorrectly used buffer-based paths for git diffs
and file listing. This change properly uses the current working directory
(cwd) for both operations, ensuring correct paths are used when accessing
files and git diffs across the workspace.

The cwd field is now added to the source configuration and properly passed
through to relevant functions. This fixes issues with file listing and git
diff operations when working with files outside the current buffer's
directory.

Closes #577