### PR TITLE
feat: add buffer validation for chat window

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -97,6 +97,17 @@ function Chat:create()
   return bufnr
 end
 
+function Chat:validate()
+  Overlay.validate(self)
+  if
+    self.winnr
+    and vim.api.nvim_win_is_valid(self.winnr)
+    and vim.api.nvim_win_get_buf(self.winnr) ~= self.bufnr
+  then
+    vim.api.nvim_win_set_buf(self.winnr, self.bufnr)
+  end
+end
+
 function Chat:visible()
   return self.winnr
     and vim.api.nvim_win_is_valid(self.winnr)


### PR DESCRIPTION
Add validate() method to Chat class that ensures the window buffer stays in sync. This prevents potential issues where the window could show incorrect buffer content by validating and resetting the buffer if needed.