### PR TITLE
fix: guard completeopt setting behind nvim-0.11.0 check

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Optional:
 
 > For Arch Linux user, you can install [`luajit-tiktoken-bin`](https://aur.archlinux.org/packages/luajit-tiktoken-bin) or [`lua51-tiktoken-bin`](https://aur.archlinux.org/packages/lua51-tiktoken-bin) from aur!
 
+> [!WARNING]
+> If you are on neovim < 0.11.0, you also might want to add `noinsert` and `popup` to your `completeopt` to make the chat completion behave well.
+
 ## Installation
 
 ### Lazy.nvim

--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -91,7 +91,9 @@ function Chat:create()
     table.insert(completeopt, 'popup')
   end
   if updated then
-    vim.bo[bufnr].completeopt = table.concat(completeopt, ',')
+    if vim.fn.has('nvim-0.11.0') == 1 then
+      vim.bo[bufnr].completeopt = table.concat(completeopt, ',')
+    end
   end
 
   vim.api.nvim_create_autocmd({ 'TextChanged', 'InsertLeave' }, {


### PR DESCRIPTION
The completeopt buffer option was being set unconditionally, which could cause errors in older Neovim versions. This change adds a version check to ensure the setting is only modified on Neovim 0.11.0 and newer versions.