### PR TITLE
fix: improve window CWD handling

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1320,6 +1320,19 @@ function M.setup(config)
   vim.api.nvim_create_user_command('CopilotChatLoad', function(args)
     M.load(args.args)
   end, { nargs = '*', force = true, complete = complete_load })
+
+  local augroup = vim.api.nvim_create_augroup('CopilotChat', {})
+
+  -- Store the current directory to window when directory changes
+  -- I dont think there is a better way to do this that functions
+  -- with "rooter" plugins, LSP and stuff as vim.fn.getcwd() when
+  -- i pass window number inside doesnt work
+  vim.api.nvim_create_autocmd('DirChanged', {
+    group = augroup,
+    callback = function()
+      vim.api.nvim_win_set_var(0, 'cchat_cwd', vim.fn.getcwd())
+    end,
+  })
 end
 
 return M

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -169,7 +169,6 @@ function M.quick_hash(str)
 end
 
 --- Get current working directory for target window
---- TODO: This is a hack to get the cwd of the previous window properly, its actually baffling I have to do this
 ---@param winnr number The buffer number
 ---@return string
 function M.win_cwd(winnr)
@@ -177,11 +176,7 @@ function M.win_cwd(winnr)
     return '.'
   end
 
-  local current_win = vim.api.nvim_get_current_win()
-  vim.api.nvim_set_current_win(winnr)
-  local dir = vim.fn.getcwd()
-  vim.api.nvim_set_current_win(current_win)
-
+  local dir = vim.api.nvim_win_get_var(winnr, 'cchat_cwd')
   if not dir or dir == '' then
     return '.'
   end


### PR DESCRIPTION
Previously, getting window cwd required switching active windows which could
cause unwanted side effects. Now, the cwd is stored in window variables and
updated via DirChanged autocmd, making the operation more reliable and
avoiding window switching.

Closes #582