### PR TITLE
fix: improve chat prompt clearing and cwd detection

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -4,6 +4,7 @@
 ---@field sections table<string, table>
 ---@field get_closest_section fun(self: CopilotChat.Chat): table|nil
 ---@field get_closest_block fun(self: CopilotChat.Chat): table|nil
+---@field clear_prompt fun(self: CopilotChat.Chat)
 ---@field valid fun(self: CopilotChat.Chat)
 ---@field visible fun(self: CopilotChat.Chat)
 ---@field active fun(self: CopilotChat.Chat)
@@ -276,6 +277,23 @@ function Chat:get_closest_block()
     end_line = closest_block.end_line,
     content = table.concat(block_content, '\n'),
   }
+end
+
+function Chat:clear_prompt()
+  if not self:visible() then
+    return
+  end
+
+  self:render()
+
+  local section = self.sections[#self.sections]
+  if not section or section.answer then
+    return
+  end
+
+  vim.bo[self.bufnr].modifiable = true
+  vim.api.nvim_buf_set_lines(self.bufnr, section.start_line - 1, section.end_line, false, {})
+  vim.bo[self.bufnr].modifiable = false
 end
 
 function Chat:active()

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -667,19 +667,8 @@ function M.ask(prompt, config)
       finish(config, nil, true)
     end
 
-    local section = state.chat:get_closest_section()
-    if not section or section.answer then
-      return
-    end
-
     state.last_prompt = prompt
-    vim.api.nvim_buf_set_lines(
-      state.chat.bufnr,
-      section.start_line - 1,
-      section.end_line,
-      false,
-      {}
-    )
+    state.chat:clear_prompt()
     state.chat:append('\n\n' .. prompt)
     state.chat:append('\n\n' .. config.answer_header .. config.separator .. '\n\n')
   end
@@ -1327,12 +1316,10 @@ function M.setup(config)
   -- I dont think there is a better way to do this that functions
   -- with "rooter" plugins, LSP and stuff as vim.fn.getcwd() when
   -- i pass window number inside doesnt work
-  vim.api.nvim_create_autocmd('DirChanged', {
+  vim.api.nvim_create_autocmd({ 'VimEnter', 'WinEnter' }, {
     group = augroup,
     callback = function()
-      if vim.v.event and vim.v.event.cwd then
-        vim.api.nvim_win_set_var(0, 'cchat_cwd', vim.v.event.cwd)
-      end
+      vim.api.nvim_win_set_var(0, 'cchat_cwd', vim.fn.getcwd())
     end,
   })
 end

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -176,8 +176,8 @@ function M.win_cwd(winnr)
     return '.'
   end
 
-  local dir = vim.api.nvim_win_get_var(winnr, 'cchat_cwd')
-  if not dir or dir == '' then
+  local ok, dir = pcall(vim.api.nvim_win_get_var, winnr, 'cchat_cwd')
+  if not ok or not dir or dir == '' then
     return '.'
   end
 


### PR DESCRIPTION
Clear chat prompt logic has been moved to dedicated method in Chat class to improve code reusability and maintainability. Window local cwd detection has been simplified and now uses VimEnter/WinEnter events instead of DirChanged for more reliable current working directory tracking.