### PR TITLE
fix: stop window vars from throwing tantrums

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1319,7 +1319,7 @@ function M.setup(config)
   vim.api.nvim_create_autocmd({ 'VimEnter', 'WinEnter' }, {
     group = augroup,
     callback = function()
-      vim.api.nvim_win_set_var(0, 'cchat_cwd', vim.fn.getcwd())
+      vim.w.cchat_cwd = vim.fn.getcwd()
     end,
   })
 end

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -176,8 +176,8 @@ function M.win_cwd(winnr)
     return '.'
   end
 
-  local ok, dir = pcall(vim.api.nvim_win_get_var, winnr, 'cchat_cwd')
-  if not ok or not dir or dir == '' then
+  local dir = vim.w[winnr].cchat_cwd
+  if not dir or dir == '' then
     return '.'
   end
 


### PR DESCRIPTION
Turns out nvim_win_get_var was a drama queen, throwing exceptions
whenever it couldn't find its precious variable - like a toddler having
a meltdown when they can't find their favorite toy.

Switched to vim.w, the more chill cousin who just returns nil and goes
about their day when something's missing. Now our code won't have an
existential crisis just because a directory hasn't changed.

No more exception-al behavior, just peaceful, quiet coding.

---

(Having some fun with system prompts, trying to make it act like a comedian.
I'm very new to prompt engineering, as you can tell by this not being all that
funny.)

Anyway, disclaimer: this is partially untested. It fixes the exception which
happens if the dir hasn't changed, but I haven't tested actually changing the
dir because I don't know what the scenario to test is. Sorry!
