### PR TITLE
feat: improve help display and token count visibility

### DIFF
--- a/lua/CopilotChat/overlay.lua
+++ b/lua/CopilotChat/overlay.lua
@@ -8,6 +8,7 @@
 ---@field restore fun(self: CopilotChat.Overlay, winnr: number, bufnr: number)
 ---@field delete fun(self: CopilotChat.Overlay)
 ---@field show_help fun(self: CopilotChat.Overlay, msg: string, offset: number)
+---@field clear_help fun(self: CopilotChat.Overlay)
 
 local utils = require('CopilotChat.utils')
 local class = utils.class
@@ -99,6 +100,10 @@ function Overlay:show_help(msg, offset)
       return { { t, 'CopilotChatHelp' } }
     end, vim.split(msg, '\n')),
   })
+end
+
+function Overlay:clear_help()
+  vim.api.nvim_buf_del_extmark(self.bufnr, self.help_ns, 1)
 end
 
 return Overlay

--- a/lua/CopilotChat/spinner.lua
+++ b/lua/CopilotChat/spinner.lua
@@ -21,7 +21,7 @@ local spinner_frames = {
 }
 
 local Spinner = class(function(self, bufnr)
-  self.ns = vim.api.nvim_create_namespace('copilot-chat-help')
+  self.ns = vim.api.nvim_create_namespace('copilot-chat-spinner')
   self.bufnr = bufnr
   self.timer = nil
   self.index = 1


### PR DESCRIPTION
The help display and token count mechanism has been improved by:
- Moving token count display to be part of the help message
- Adding clear help functionality to overlay
- Cleaning up finish function parameters and logic
- Using dedicated namespace for spinner
- Simplifying help display logic in chat rendering

This change makes the UI cleaner and more consistent by integrating the token count into the help display system instead of showing it separately.