### PR TITLE
fix: improve chat window handling and auto-insert behavior

### DIFF
--- a/lua/CopilotChat/chat.lua
+++ b/lua/CopilotChat/chat.lua
@@ -435,7 +435,7 @@ function Chat:open(config)
   end
 
   self.layout = layout
-  self.auto_insert = config.auto_insert
+  self.auto_insert = config.auto_insert_mode
   self.auto_follow_cursor = config.auto_follow_cursor
   self.highlight_headers = config.highlight_headers
   self.question_header = config.question_header
@@ -494,11 +494,13 @@ function Chat:close(bufnr)
 end
 
 function Chat:focus()
-  if self:visible() then
-    vim.api.nvim_set_current_win(self.winnr)
-    if self.auto_insert and self:active() then
-      vim.cmd('startinsert')
-    end
+  if not self:visible() then
+    return
+  end
+
+  vim.api.nvim_set_current_win(self.winnr)
+  if self.auto_insert and self:active() and vim.bo[self.bufnr].modifiable then
+    vim.cmd('startinsert')
   end
 end
 

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -99,9 +99,8 @@ function M.return_to_normal_mode()
   local mode = vim.fn.mode():lower()
   if mode:find('v') then
     vim.cmd([[execute "normal! \<Esc>"]])
-  elseif mode:find('i') then
-    vim.cmd('stopinsert')
   end
+  vim.cmd('stopinsert')
 end
 
 --- Mark a function as deprecated


### PR DESCRIPTION
- Fix loading of auto-insert-mode config
- Fix auto-insert mode to only trigger when buffer is modifiable
- Remove unnecessary undojoin command in chat append
- Simplify stop/reset logic and remove scheduling wrapper
- Fix return to normal mode function to always call stopinsert