### PR TITLE
feat: sort completion items by kind and word

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -522,6 +522,9 @@ function M.complete_items(callback)
     end
 
     table.sort(items, function(a, b)
+      if a.kind == b.kind then
+        return a.word < b.word
+      end
       return a.kind < b.kind
     end)
 


### PR DESCRIPTION
Sort completion items consistently by first comparing their kinds, and when kinds are equal, sort them alphabetically by word. This provides a more predictable and user-friendly order in completion menus.