### PR TITLE
refactor(config): split config into static and shared parts properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,10 +420,8 @@ Also see [here](/lua/CopilotChat/config.lua):
 
 ```lua
 {
-  debug = false, -- Enable debug logging (same as 'log_level = 'debug')
-  log_level = 'info', -- Log level to use, 'trace', 'debug', 'info', 'warn', 'error', 'fatal'
-  proxy = nil, -- [protocol://]host[:port] Use this proxy
-  allow_insecure = false, -- Allow insecure server connections
+
+  -- Shared config starts here (can be passed to functions at runtime)
 
   system_prompt = prompts.COPILOT_INSTRUCTIONS, -- System prompt to use (can be specified manually in prompt via /).
   model = 'gpt-4o', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
@@ -431,23 +429,7 @@ Also see [here](/lua/CopilotChat/config.lua):
   context = nil, -- Default context or array of contexts to use (can be specified manually in prompt via #).
   temperature = 0.1, -- GPT result temperature
 
-  question_header = '## User ', -- Header to use for user questions
-  answer_header = '## Copilot ', -- Header to use for AI answers
-  error_header = '## Error ', -- Header to use for errors
-  separator = '───', -- Separator to use in chat
-
-  chat_autocomplete = true, -- Enable chat autocompletion (when disabled, requires manual `mappings.complete` trigger)
-  show_folds = true, -- Shows folds for sections in chat
-  show_help = true, -- Shows help message as virtual lines when waiting for user input
-  auto_follow_cursor = true, -- Auto-follow cursor in chat
-  auto_insert_mode = false, -- Automatically enter insert mode when opening window and on new prompt
-  insert_at_end = false, -- Move cursor to end of buffer when inserting text
-  clear_chat_on_new_prompt = false, -- Clears chat on every new prompt
-  highlight_selection = true, -- Highlight selection
-  highlight_headers = true, -- Highlight headers in chat, disable if using markdown renderers (like render-markdown.nvim)
-
-  history_path = vim.fn.stdpath('data') .. '/copilotchat_history', -- Default path to stored history
-  no_chat = false, -- Do not write to chat buffer and use history(useful for using callback for custom processing)
+  headless = false, -- Do not write to chat buffer and use history(useful for using callback for custom processing)
   callback = nil, -- Callback to use when ask response is received
 
   -- default selection
@@ -469,6 +451,30 @@ Also see [here](/lua/CopilotChat/config.lua):
     footer = nil, -- footer of chat window
     zindex = 1, -- determines if window is on top or below other floating windows
   },
+
+  -- Static config starts here (can be configured only via setup function)
+
+  debug = false, -- Enable debug logging (same as 'log_level = 'debug')
+  log_level = 'info', -- Log level to use, 'trace', 'debug', 'info', 'warn', 'error', 'fatal'
+  proxy = nil, -- [protocol://]host[:port] Use this proxy
+  allow_insecure = false, -- Allow insecure server connections
+  history_path = vim.fn.stdpath('data') .. '/copilotchat_history', -- Default path to stored history
+
+  question_header = '## User ', -- Header to use for user questions
+  answer_header = '## Copilot ', -- Header to use for AI answers
+  error_header = '## Error ', -- Header to use for errors
+  separator = '───', -- Separator to use in chat
+
+  show_folds = true, -- Shows folds for sections in chat
+  show_help = true, -- Shows help message as virtual lines when waiting for user input
+  highlight_selection = true, -- Highlight selection
+  highlight_headers = true, -- Highlight headers in chat, disable if using markdown renderers (like render-markdown.nvim)
+
+  chat_autocomplete = true, -- Enable chat autocompletion (when disabled, requires manual `mappings.complete` trigger)
+  auto_follow_cursor = true, -- Auto-follow cursor in chat
+  auto_insert_mode = false, -- Automatically enter insert mode when opening window and on new prompt
+  insert_at_end = false, -- Move cursor to end of buffer when inserting text
+  clear_chat_on_new_prompt = false, -- Clears chat on every new prompt
 
   -- default contexts
   contexts = {

--- a/lua/CopilotChat/actions.lua
+++ b/lua/CopilotChat/actions.lua
@@ -13,7 +13,7 @@ function M.help_actions()
 end
 
 --- User prompt actions
----@param config CopilotChat.config?: The chat configuration
+---@param config CopilotChat.config.shared?: The chat configuration
 ---@return CopilotChat.integrations.actions?: The prompt actions
 function M.prompt_actions(config)
   local actions = {}

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -74,18 +74,7 @@ local utils = require('CopilotChat.utils')
 ---@field agent string?
 ---@field context string|table<string>|nil
 ---@field temperature number?
----@field question_header string?
----@field answer_header string?
----@field error_header string?
----@field separator string?
----@field show_folds boolean?
----@field show_help boolean?
----@field auto_follow_cursor boolean?
----@field auto_insert_mode boolean?
----@field clear_chat_on_new_prompt boolean?
----@field highlight_selection boolean?
----@field highlight_headers boolean?
----@field no_chat boolean?
+---@field headless boolean?
 ---@field callback fun(response: string, source: CopilotChat.config.source)?
 ---@field selection nil|fun(source: CopilotChat.config.source):CopilotChat.config.selection?
 ---@field window CopilotChat.config.window?
@@ -96,16 +85,26 @@ local utils = require('CopilotChat.utils')
 ---@field log_level string?
 ---@field proxy string?
 ---@field allow_insecure boolean?
----@field chat_autocomplete boolean?
 ---@field history_path string?
+---@field question_header string?
+---@field answer_header string?
+---@field error_header string?
+---@field separator string?
+---@field show_folds boolean?
+---@field show_help boolean?
+---@field highlight_selection boolean?
+---@field highlight_headers boolean?
+---@field chat_autocomplete boolean?
+---@field auto_follow_cursor boolean?
+---@field auto_insert_mode boolean?
+---@field insert_at_end boolean?
+---@field clear_chat_on_new_prompt boolean?
 ---@field contexts table<string, CopilotChat.config.context>?
 ---@field prompts table<string, CopilotChat.config.prompt|string>?
 ---@field mappings CopilotChat.config.mappings?
 return {
-  debug = false, -- Enable debug logging (same as 'log_level = 'debug')
-  log_level = 'info', -- Log level to use, 'trace', 'debug', 'info', 'warn', 'error', 'fatal'
-  proxy = nil, -- [protocol://]host[:port] Use this proxy
-  allow_insecure = false, -- Allow insecure server connections
+
+  -- Shared config starts here (can be passed to functions at runtime)
 
   system_prompt = prompts.COPILOT_INSTRUCTIONS, -- System prompt to use (can be specified manually in prompt via /).
   model = 'gpt-4o', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
@@ -113,23 +112,7 @@ return {
   context = nil, -- Default context or array of contexts to use (can be specified manually in prompt via #).
   temperature = 0.1, -- GPT result temperature
 
-  question_header = '## User ', -- Header to use for user questions
-  answer_header = '## Copilot ', -- Header to use for AI answers
-  error_header = '## Error ', -- Header to use for errors
-  separator = '───', -- Separator to use in chat
-
-  chat_autocomplete = true, -- Enable chat autocompletion (when disabled, requires manual `mappings.complete` trigger)
-  show_folds = true, -- Shows folds for sections in chat
-  show_help = true, -- Shows help message as virtual lines when waiting for user input
-  auto_follow_cursor = true, -- Auto-follow cursor in chat
-  auto_insert_mode = false, -- Automatically enter insert mode when opening window and on new prompt
-  insert_at_end = false, -- Move cursor to end of buffer when inserting text
-  clear_chat_on_new_prompt = false, -- Clears chat on every new prompt
-  highlight_selection = true, -- Highlight selection
-  highlight_headers = true, -- Highlight headers in chat, disable if using markdown renderers (like render-markdown.nvim)
-
-  history_path = vim.fn.stdpath('data') .. '/copilotchat_history', -- Default path to stored history
-  no_chat = false, -- Do not write to chat buffer and use history(useful for using callback for custom processing)
+  headless = false, -- Do not write to chat buffer and use history(useful for using callback for custom processing)
   callback = nil, -- Callback to use when ask response is received
 
   -- default selection
@@ -151,6 +134,30 @@ return {
     footer = nil, -- footer of chat window
     zindex = 1, -- determines if window is on top or below other floating windows
   },
+
+  -- Static config starts here (can be configured only via setup function)
+
+  debug = false, -- Enable debug logging (same as 'log_level = 'debug')
+  log_level = 'info', -- Log level to use, 'trace', 'debug', 'info', 'warn', 'error', 'fatal'
+  proxy = nil, -- [protocol://]host[:port] Use this proxy
+  allow_insecure = false, -- Allow insecure server connections
+  history_path = vim.fn.stdpath('data') .. '/copilotchat_history', -- Default path to stored history
+
+  question_header = '## User ', -- Header to use for user questions
+  answer_header = '## Copilot ', -- Header to use for AI answers
+  error_header = '## Error ', -- Header to use for errors
+  separator = '───', -- Separator to use in chat
+
+  show_folds = true, -- Shows folds for sections in chat
+  show_help = true, -- Shows help message as virtual lines when waiting for user input
+  highlight_selection = true, -- Highlight selection
+  highlight_headers = true, -- Highlight headers in chat, disable if using markdown renderers (like render-markdown.nvim)
+
+  chat_autocomplete = true, -- Enable chat autocompletion (when disabled, requires manual `mappings.complete` trigger)
+  auto_follow_cursor = true, -- Auto-follow cursor in chat
+  auto_insert_mode = false, -- Automatically enter insert mode when opening window and on new prompt
+  insert_at_end = false, -- Move cursor to end of buffer when inserting text
+  clear_chat_on_new_prompt = false, -- Clears chat on every new prompt
 
   -- default contexts
   contexts = {


### PR DESCRIPTION
Split the plugin configuration into two parts:
- Static config that can only be set via setup()
- Shared config that can be passed as runtime parameters to functions

This improves the configuration management by clearly separating configuration parameters that should be set only once during setup from those that can be modified during runtime. Also renamed no_chat option to headless for better clarity.