### PR TITLE
refactor: move embed truncation logic to proper places

### DIFF
--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -52,7 +52,6 @@ local OFF_SIDE_RULE_LANGUAGES = {
   'fsharp',
 }
 
-local OUTLINE_THRESHOLD = 600
 local MULTI_FILE_THRESHOLD = 3
 
 local function spatial_distance_cosine(a, b)
@@ -339,19 +338,8 @@ function M.filter_embeddings(copilot, prompt, embeddings)
   -- Map embeddings by filename
   for _, embed in ipairs(embeddings) do
     original_map:set(embed.filename, embed)
-
     if embed.filetype ~= 'raw' then
-      local outline = M.outline(embed.content, embed.filename, embed.filetype)
-      local outline_lines = vim.split(outline.content, '\n')
-
-      -- If outline is too big, truncate it
-      if #outline_lines > 0 and #outline_lines > OUTLINE_THRESHOLD then
-        outline_lines = vim.list_slice(outline_lines, 1, OUTLINE_THRESHOLD)
-        table.insert(outline_lines, '... (truncated)')
-      end
-
-      outline.content = table.concat(outline_lines, '\n')
-      embedded_map:set(embed.filename, outline)
+      embedded_map:set(embed.filename, M.outline(embed.content, embed.filename, embed.filetype))
     else
       embedded_map:set(embed.filename, embed)
     end

--- a/lua/CopilotChat/ui/overlay.lua
+++ b/lua/CopilotChat/ui/overlay.lua
@@ -1,7 +1,7 @@
 local utils = require('CopilotChat.utils')
 local class = utils.class
 
----@class CopilotChat.ui.Overlay : CopilotChat.utils.Class
+---@class CopilotChat.ui.Overlay : Class
 ---@field name string
 ---@field help string
 ---@field help_ns number

--- a/lua/CopilotChat/ui/spinner.lua
+++ b/lua/CopilotChat/ui/spinner.lua
@@ -14,7 +14,7 @@ local spinner_frames = {
   '⠏',
 }
 
----@class CopilotChat.ui.Spinner : CopilotChat.utils.Class
+---@class CopilotChat.ui.Spinner : Class
 ---@field ns number
 ---@field bufnr number
 ---@field timer table

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -1,14 +1,14 @@
 local M = {}
 M.timers = {}
 
----@class CopilotChat.utils.Class
+---@class Class
 ---@field new fun(...):table
 ---@field init fun(self, ...)
 
 --- Create class
 ---@param fn function The class constructor
 ---@param parent table? The parent class
----@return CopilotChat.utils.Class
+---@return Class
 function M.class(fn, parent)
   local out = {}
   out.__index = out
@@ -36,6 +36,43 @@ function M.class(fn, parent)
   end
 
   return out
+end
+
+---@class OrderedMap
+---@field set fun(self:OrderedMap, key:any, value:any)
+---@field get fun(self:OrderedMap, key:any):any
+---@field keys fun(self:OrderedMap):table
+---@field values fun(self:OrderedMap):table
+
+--- Create an ordered map
+---@return OrderedMap
+function M.ordered_map()
+  return {
+    _keys = {},
+    _data = {},
+    set = function(self, key, value)
+      if not self._data[key] then
+        table.insert(self._keys, key)
+      end
+      self._data[key] = value
+    end,
+
+    get = function(self, key)
+      return self._data[key]
+    end,
+
+    keys = function(self)
+      return self._keys
+    end,
+
+    values = function(self)
+      local result = {}
+      for _, key in ipairs(self._keys) do
+        table.insert(result, self._data[key])
+      end
+      return result
+    end,
+  }
 end
 
 --- Check if the current version of neovim is stable
@@ -185,43 +222,6 @@ function M.win_cwd(winnr)
   end
 
   return dir
-end
-
----@class OrderedMap
----@field set fun(self:OrderedMap, key:any, value:any)
----@field get fun(self:OrderedMap, key:any):any
----@field keys fun(self:OrderedMap):table
----@field values fun(self:OrderedMap):table
-
---- Create an ordered map
----@return OrderedMap
-function M.ordered_map()
-  return {
-    _keys = {},
-    _data = {},
-    set = function(self, key, value)
-      if not self._data[key] then
-        table.insert(self._keys, key)
-      end
-      self._data[key] = value
-    end,
-
-    get = function(self, key)
-      return self._data[key]
-    end,
-
-    keys = function(self)
-      return self._keys
-    end,
-
-    values = function(self)
-      local result = {}
-      for _, key in ipairs(self._keys) do
-        table.insert(result, self._data[key])
-      end
-      return result
-    end,
-  }
 end
 
 return M


### PR DESCRIPTION
This commit reorganizes the code to handle truncation of large files and embeddings in a more consistent way. The changes include:

- Moving ordered_map implementation to top of utils.lua
- Centralizing truncation logic for embeddings with BIG_EMBED_THRESHOLD
- Simplifying outline truncation by moving it to embedding generation
- Updating class type definitions to be more consistent
- Removing duplicate code related to truncation handlers

The main goal is to make the codebase more maintainable by having truncation logic in appropriate locations rather than scattered across different files.