### PR TITLE
fix: improve prompt embedding and ranking

### DIFF
--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -420,12 +420,6 @@ function M.filter_embeddings(copilot, prompt, embeddings)
   local original_map = utils.ordered_map()
   local embedded_map = utils.ordered_map()
 
-  embedded_map:set('prompt', {
-    content = prompt,
-    filename = 'prompt',
-    filetype = 'raw',
-  })
-
   -- Map embeddings by filename
   for _, embed in ipairs(embeddings) do
     original_map:set(embed.filename, embed)
@@ -439,12 +433,20 @@ function M.filter_embeddings(copilot, prompt, embeddings)
     log.debug(string.format('%s: %s - %s', i, item.score, item.filename))
   end
 
+  -- Add prompt so it can be embedded
+  table.insert(ranked_data, {
+    content = prompt,
+    filename = 'prompt',
+    filetype = 'raw',
+  })
+
   -- Get embeddings from all items
   local embedded_data = copilot:embed(ranked_data)
 
   -- Rate embeddings by relatedness to the query
-  local ranked_embeddings =
-    data_ranked_by_relatedness(table.remove(embedded_data, 1), embedded_data, TOP_RELATED)
+  local embedded_query = table.remove(embedded_data, #embedded_data)
+  log.debug('Embedded query:', embedded_query.content)
+  local ranked_embeddings = data_ranked_by_relatedness(embedded_query, embedded_data, TOP_RELATED)
   log.debug('Ranked embeddings:', #ranked_embeddings)
   for i, item in ipairs(ranked_embeddings) do
     log.debug(string.format('%s: %s - %s', i, item.score, item.filename))

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -664,12 +664,12 @@ function M.ask(prompt, config)
   local resolved_prompt, system_prompt = resolve_prompts(prompt, config.system_prompt)
 
   -- Remove sticky prefix
-  prompt = table.concat(
+  prompt = vim.trim(table.concat(
     vim.tbl_map(function(l)
       return l:gsub('>%s+', '')
     end, vim.split(resolved_prompt, '\n')),
     '\n'
-  )
+  ))
 
   -- Resolve embeddings
   local embeddings, embedded_prompt = resolve_embeddings(prompt, config)


### PR DESCRIPTION
The changes improve how prompts are embedded and ranked in the context system:
- Move prompt embedding to after initial data ranking to maintain correct ordering
- Fix log output to show correct embedded query content
- Trim whitespace from resolved prompts to improve matching

This ensures more accurate context retrieval and better prompt handling in the chat system.