### PR TITLE
refactor(context): simplify outline building and add typing

### DIFF
--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -2,6 +2,7 @@
 ---@field content string
 ---@field filename string
 ---@field filetype string
+---@field embedding table<number>
 
 ---@class CopilotChat.copilot.ask.opts
 ---@field selection CopilotChat.config.selection?


### PR DESCRIPTION
The commit improves the outline building functionality by:
- Adding field_declaration and record_declaration to outline types
- Removing redundant comment handling logic to simplify the code
- Adding proper type annotations for functions
- Extracting reusable functions for getting node names and signatures
- Adding embedding type definition to copilot class