### PR TITLE
fix: improve sticky prompt handling and section detection

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -287,11 +287,15 @@ local function finish(start_of_chat)
 
   state.chat:append(M.config.question_header .. M.config.separator .. '\n\n')
 
+  -- Reinsert sticky prompts from last prompt
   if state.last_prompt then
     local has_sticky = false
-    for sticky_line in state.last_prompt:gmatch('(>%s+[^\n]+)') do
-      state.chat:append(sticky_line .. '\n')
-      has_sticky = true
+    local lines = vim.split(state.last_prompt, '\n')
+    for _, line in ipairs(lines) do
+      if vim.startswith(line, '> ') then
+        state.chat:append(line .. '\n')
+        has_sticky = true
+      end
     end
     if has_sticky then
       state.chat:append('\n')
@@ -666,7 +670,7 @@ function M.ask(prompt, config)
   -- Remove sticky prefix
   prompt = vim.trim(table.concat(
     vim.tbl_map(function(l)
-      return l:gsub('>%s+', '')
+      return l:gsub('^>%s+', '')
     end, vim.split(resolved_prompt, '\n')),
     '\n'
   ))

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -242,6 +242,7 @@ function Chat:get_closest_section()
     return nil
   end
 
+  self:render()
   local cursor_pos = vim.api.nvim_win_get_cursor(self.winnr)
   local cursor_line = cursor_pos[1]
   local closest_section = nil
@@ -279,6 +280,7 @@ function Chat:get_closest_block()
     return nil
   end
 
+  self:render()
   local cursor_pos = vim.api.nvim_win_get_cursor(self.winnr)
   local cursor_line = cursor_pos[1]
   local closest_block = nil
@@ -318,7 +320,6 @@ function Chat:clear_prompt()
   end
 
   self:render()
-
   local section = self.sections[#self.sections]
   if not section or section.answer then
     return


### PR DESCRIPTION
This commit improves handling of sticky prompts by:
1. Using proper line splitting and startswith check instead of gmatch
2. Fixing the sticky prefix removal to only match start of line
3. Ensuring proper rendering before section/block detection

The changes make sticky prompts more reliable and fix edge cases in the UI rendering.

Closes #614