### PR TITLE
refactor: optimize vim scheduler usage in chat module

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -264,6 +264,16 @@ end, 3)
 --- FIXME: Make async
 M.scan_dir = scandir.scan_dir
 
+-- M.scan_dir = async.wrap(function(path, opts, callback)
+--   scandir.scan_dir_async(path, vim.tbl_deep_extend('force', opts, {
+--     on_exit = callback,
+--     on_error = function(err)
+--       err = err and err.stderr or vim.inspect(err)
+--       callback(nil, err)
+--     end,
+--   }))
+-- end, 3)
+
 --- Check if a file exists
 --- FIXME: Make async
 ---@param path string The file path

--- a/test/plugin_spec.lua
+++ b/test/plugin_spec.lua
@@ -8,6 +8,7 @@ package.loaded['plenary.async'] = {
 }
 package.loaded['plenary.curl'] = {}
 package.loaded['plenary.log'] = {}
+package.loaded['plenary.scandir'] = {}
 
 describe('CopilotChat plugin', function()
   it('should be able to load', function()


### PR DESCRIPTION
Remove redundant vim.schedule calls and replace them with more efficient async scheduler utilities. This includes:
- Using async.util.scheduler() instead of vim.schedule wrapper functions
- Consolidating scheduler calls to reduce overhead
- Utilizing vim.schedule_wrap for progress callbacks

The changes make the code more maintainable and potentially improve performance by reducing unnecessary scheduler invocations.