### PR TITLE
perf: optimize curl connection settings

### DIFF
--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -322,15 +322,19 @@ local Copilot = class(function(self, proxy, allow_insecure)
       -- Wait 1 second between retries
       '--retry-delay',
       '1',
-      -- Maximum time for the request
+      -- Keep connections alive for better performance
+      '--keepalive-time',
+      '60',
+      -- Disable compression (since responses are already streamed efficiently)
+      '--no-compressed',
+      -- Important timeouts
       '--max-time',
       math.floor(TIMEOUT * 2 / 1000),
-      -- Timeout for initial connection
       '--connect-timeout',
       '10',
-      '--no-keepalive', -- Don't reuse connections
-      '--tcp-nodelay', -- Disable Nagle's algorithm for faster streaming
-      '--no-buffer', -- Disable output buffering for streaming
+      -- Streaming optimizations
+      '--tcp-nodelay',
+      '--no-buffer',
     },
   }
 end)


### PR DESCRIPTION
Improve performance of HTTP requests by:
- Enabling keepalive connections with 60s timeout
- Disabling compression since responses are already streamed
- Maintaining TCP nodelay and no-buffer settings for efficient streaming
- Adding explicit timeouts for better connection handling

The changes aim to reduce latency and improve overall request efficiency while maintaining reliable streaming behavior.