### PR TITLE
fix: add debug logging for Copilot HTTP responses

### DIFF
--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -734,6 +734,10 @@ function Copilot:ask(prompt, opts)
     return
   end
 
+  log.debug('Response status: ' .. response.status)
+  log.debug('Response body: ' .. response.body)
+  log.debug('Response headers: ' .. vim.inspect(response.headers))
+
   if response.status ~= 200 then
     if response.status == 401 then
       local ok, content = pcall(vim.json.decode, response.body, {


### PR DESCRIPTION
Add detailed debug logging for Copilot HTTP response status, body and headers to help with troubleshooting API communication issues.