### PR TITLE
feat(context): add full file content support for files

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Default contexts are:
 - `buffer` - Includes specified buffer in chat context (default current). Supports input.
 - `buffers` - Includes all buffers in chat context (default listed). Supports input.
 - `file` - Includes content of provided file in chat context. Supports input.
-- `files` - Includes all non-hidden filenames in the current workspace in chat context.
+- `files` - Includes all non-hidden files in the current workspace in chat context. By default includes only filenames, includes also content with `full` input. Including all content can be slow on big workspaces so use with care. Supports input.
 - `git` - Includes current git diff in chat context (default unstaged). Supports input.
 - `register` - Includes content of specified register in chat context (default `+`, e.g system clipboard). Supports input.
 
@@ -719,7 +719,7 @@ require('CopilotChat').setup({
 
 ## Roadmap (Wishlist)
 
-- Use indexed vector database with current workspace for better context selection
+- Caching for contexts
 - General QOL improvements
 
 ## Development

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -228,9 +228,14 @@ return {
       end,
     },
     files = {
-      description = 'Includes all non-hidden filenames in the current workspace in chat context.',
-      resolve = function(_, source)
-        return context.files(source.winnr)
+      description = 'Includes all non-hidden files in the current workspace in chat context. By default includes only filenames, includes also content with `full` input. Including all content can be slow on big workspaces so use with care. Supports input.',
+      input = function(callback)
+        vim.ui.select({ 'list', 'full' }, {
+          prompt = 'Select files content> ',
+        }, callback)
+      end,
+      resolve = function(input, source)
+        return context.files(source.winnr, input == 'full')
       end,
     },
     git = {

--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -329,9 +329,7 @@ local Copilot = class(function(self, proxy, allow_insecure)
       '60',
       -- Disable compression (since responses are already streamed efficiently)
       '--no-compressed',
-      -- Important timeouts
-      '--max-time',
-      math.floor(TIMEOUT * 2 / 1000),
+      -- Connect timeout of 10 seconds
       '--connect-timeout',
       '10',
       -- Streaming optimizations

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -180,6 +180,24 @@ function M.filename_same(file1, file2)
   return vim.fn.fnamemodify(file1, ':p') == vim.fn.fnamemodify(file2, ':p')
 end
 
+--- Get the filetype of a file
+---@param filename string The file name
+---@return string|nil
+function M.filetype(filename)
+  local ft = vim.filetype.match({ filename = filename })
+  if ft == '' then
+    return nil
+  end
+  return ft
+end
+
+--- Get the file path
+---@param filename string The file name
+---@return string
+function M.filepath(filename)
+  return vim.fn.fnamemodify(filename, ':p:.')
+end
+
 --- Generate a UUID
 ---@return string
 function M.uuid()


### PR DESCRIPTION
The files context provider now supports two modes:
- 'list' (default) - includes only filenames in the workspace
- 'full' - includes both filenames and their content

This change provides more flexibility when needing full context from workspace files. The implementation also adds proper filetype detection and filtering for files to ensure only text files are included.

Closes #360