### PR TITLE
refactor(copilot): improve embedding reliability

### DIFF
--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -58,7 +58,7 @@ local OFF_SIDE_RULE_LANGUAGES = {
 
 local TOP_SYMBOLS = 64
 local TOP_RELATED = 20
-local MULTI_FILE_THRESHOLD = 3
+local MULTI_FILE_THRESHOLD = 5
 
 --- Compute the cosine similarity between two vectors
 ---@param a table<number>


### PR DESCRIPTION
Implement adaptive batch sizing and content thresholding for embeddings to handle API failures more gracefully. This change:

- Removes manual token counting in favor of API-driven feedback
- Adds progressive batch size reduction when requests fail
- Implements content threshold reduction for large files
- Adds proper curl failure handling with --fail-with-body
- Increases multi-file threshold from 3 to 5 files
- Adjusts embedding thresholds for better performance