### PR TITLE
fix: improve debug info window handling

### DIFF
--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -358,10 +358,11 @@ function M.file(filename)
 end
 
 --- Get the content of a buffer
----@param bufnr number
+---@param bufnr? number
 ---@return CopilotChat.copilot.embed?
 function M.buffer(bufnr)
   async.util.scheduler()
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
 
   if not utils.buf_valid(bufnr) then
     return nil


### PR DESCRIPTION
Previously, the debug info window could be opened multiple times and didn't properly handle async operations. This commit:

- Makes buffer parameter optional in context.buffer()
- Adds proper window cleanup on close
- Wraps debug info building in async operation to prevent UI blocking
- Stores window number reference to manage single instance