### PR TITLE
fix: improve logging output format and consistency

### DIFF
--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -427,7 +427,7 @@ function Copilot:fetch_models()
   end
 
   log.info('Models fetched')
-  log.trace(vim.inspect(models))
+  log.trace(models)
   self.models = out
   return out
 end
@@ -463,7 +463,7 @@ function Copilot:fetch_agents()
   out['copilot'] = { name = 'Copilot', default = true, description = 'Default noop agent' }
 
   log.info('Agents fetched')
-  log.trace(vim.inspect(agents))
+  log.trace(agents)
   self.agents = out
   return out
 end
@@ -486,7 +486,7 @@ function Copilot:enable_policy(model)
   self.policies[model] = true
 
   if err or response.status ~= 200 then
-    log.warn('Failed to enable policy for ' .. model .. ': ' .. vim.inspect(err or response.body))
+    log.warn('Failed to enable policy for ', model, ': ', (err or response.body))
     return
   end
 
@@ -510,13 +510,13 @@ function Copilot:ask(prompt, opts)
   local job_id = utils.uuid()
   self.current_job = job_id
 
-  log.trace('System prompt: ' .. system_prompt)
-  log.trace('Selection: ' .. (selection.content or ''))
-  log.debug('Prompt: ' .. prompt)
-  log.debug('Embeddings: ' .. #embeddings)
-  log.debug('Model: ' .. model)
-  log.debug('Agent: ' .. agent)
-  log.debug('Temperature: ' .. temperature)
+  log.trace('System prompt: ', system_prompt)
+  log.trace('Selection: ', selection.content)
+  log.debug('Prompt: ', prompt)
+  log.debug('Embeddings: ', #embeddings)
+  log.debug('Model: ', model)
+  log.debug('Agent: ', agent)
+  log.debug('Temperature: ', temperature)
 
   local history = no_history and {} or self.history
   local models = self:fetch_models()
@@ -534,8 +534,8 @@ function Copilot:ask(prompt, opts)
   local max_tokens = capabilities.limits.max_prompt_tokens -- FIXME: Is max_prompt_tokens the right limit?
   local max_output_tokens = capabilities.limits.max_output_tokens
   local tokenizer = capabilities.tokenizer
-  log.debug('Max tokens: ' .. max_tokens)
-  log.debug('Tokenizer: ' .. tokenizer)
+  log.debug('Max tokens: ', max_tokens)
+  log.debug('Tokenizer: ', tokenizer)
   tiktoken.load(tokenizer)
 
   local generated_messages = {}
@@ -666,7 +666,7 @@ function Copilot:ask(prompt, opts)
 
     local err = parse_line(line)
     if err and job then
-      finish_stream('Failed to parse response: ' .. vim.inspect(err) .. '\n' .. line, job)
+      finish_stream('Failed to parse response: ' .. utils.make_string(err) .. '\n' .. line, job)
     end
   end
 
@@ -681,7 +681,7 @@ function Copilot:ask(prompt, opts)
     end
 
     if err then
-      finish_stream('Failed to get response: ' .. (err and vim.inspect(err) or line), job)
+      finish_stream('Failed to get response: ' .. utils.make_string(err and err or line), job)
       return
     end
 
@@ -735,9 +735,9 @@ function Copilot:ask(prompt, opts)
     return
   end
 
-  log.debug('Response status: ' .. response.status)
-  log.debug('Response body: ' .. response.body)
-  log.debug('Response headers: ' .. vim.inspect(response.headers))
+  log.debug('Response status: ', response.status)
+  log.debug('Response body: ', response.body)
+  log.debug('Response headers: ', response.headers)
 
   if response.status ~= 200 then
     if response.status == 401 then
@@ -791,8 +791,8 @@ function Copilot:ask(prompt, opts)
     end
   end
 
-  log.trace('Full response: ' .. full_response)
-  log.debug('Last message: ' .. vim.inspect(last_message))
+  log.trace('Full response: ', full_response)
+  log.debug('Last message: ', last_message)
 
   table.insert(history, {
     content = prompt,

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -317,7 +317,7 @@ local function show_error(err, append_newline)
     message = message:gsub('^%s*', '')
     err = message
   else
-    err = vim.inspect(err)
+    err = utils.make_string(err)
   end
 
   if append_newline then
@@ -713,7 +713,7 @@ function M.ask(prompt, config)
 
     if not query_ok then
       async.util.scheduler()
-      log.error(vim.inspect(filtered_embeddings))
+      log.error(filtered_embeddings)
       if not config.headless then
         show_error(filtered_embeddings, has_output)
       end
@@ -740,7 +740,7 @@ function M.ask(prompt, config)
     async.util.scheduler()
 
     if not ask_ok then
-      log.error(vim.inspect(response))
+      log.error(response)
       if not config.headless then
         show_error(response, has_output)
       end

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -230,6 +230,25 @@ function M.quick_hash(str)
   return #str .. str:sub(1, 32) .. str:sub(-32)
 end
 
+--- Make a string from arguments
+---@vararg any The arguments
+---@return string
+function M.make_string(...)
+  local t = {}
+  for i = 1, select('#', ...) do
+    local x = select(i, ...)
+
+    if type(x) == 'table' then
+      x = vim.inspect(x)
+    else
+      x = tostring(x)
+    end
+
+    t[#t + 1] = x
+  end
+  return table.concat(t, ' ')
+end
+
 --- Get current working directory for target window
 ---@param winnr number? The buffer number
 ---@return string
@@ -255,7 +274,7 @@ M.curl_get = async.wrap(function(url, opts, callback)
     vim.tbl_deep_extend('force', opts, {
       callback = callback,
       on_error = function(err)
-        err = err and err.stderr or vim.inspect(err)
+        err = M.make_string(err and err.stderr or err)
         callback(nil, err)
       end,
     })
@@ -271,7 +290,7 @@ M.curl_post = async.wrap(function(url, opts, callback)
     vim.tbl_deep_extend('force', opts, {
       callback = callback,
       on_error = function(err)
-        err = err and err.stderr or vim.inspect(err)
+        err = M.make_string(err and err.stderr or err)
         callback(nil, err)
       end,
     })
@@ -286,10 +305,6 @@ M.scan_dir = async.wrap(function(path, opts, callback)
     path,
     vim.tbl_deep_extend('force', opts, {
       on_exit = callback,
-      on_error = function(err)
-        err = err and err.stderr or vim.inspect(err)
-        callback(nil, err)
-      end,
     })
   )
 end, 3)


### PR DESCRIPTION
Replace vim.inspect usage with new make_string utility function to provide more consistent and cleaner logging output across the codebase. This makes logs more readable and uniform when handling both simple values and complex data structures.

The changes include:
- Add make_string utility function for standardized string conversion
- Replace vim.inspect calls with direct logging or make_string
- Improve error message formatting for better readability