### PR TITLE
refactor: unify info display into show_info and show_context

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,8 @@ See @deathbeam for [configuration](https://github.com/deathbeam/dotfiles/blob/ma
 - `gq` - Add all diffs from chat to quickfix list
 - `gy` - Yank nearest diff to register (defaults to `"`)
 - `gd` - Show diff between source and nearest diff
-- `gp` - Show system prompt for current chat
-- `gs` - Show current user selection
-- `gc` - Show current user context
+- `gi` - Show info about current chat (model, agent, system prompt)
+- `gc` - Show current chat context
 - `gh` - Show help message
 
 The mappings can be customized by setting the `mappings` table in your configuration. Each mapping can have:
@@ -562,13 +561,10 @@ Also see [here](/lua/CopilotChat/config.lua):
     show_diff = {
       normal = 'gd',
     },
-    show_system_prompt = {
-      normal = 'gp',
+    show_info = {
+      normal = 'gi',
     },
-    show_user_selection = {
-      normal = 'gs',
-    },
-    show_user_context = {
+    show_context = {
       normal = 'gc',
     },
     show_help = {

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -48,9 +48,8 @@ local utils = require('CopilotChat.utils')
 ---@field quickfix_diffs CopilotChat.config.mapping?
 ---@field yank_diff CopilotChat.config.mapping.register?
 ---@field show_diff CopilotChat.config.mapping?
----@field show_system_prompt CopilotChat.config.mapping?
----@field show_user_selection CopilotChat.config.mapping?
----@field show_user_context CopilotChat.config.mapping?
+---@field show_info CopilotChat.config.mapping?
+---@field show_context CopilotChat.config.mapping?
 ---@field show_help CopilotChat.config.mapping?
 
 ---@class CopilotChat.config.shared
@@ -378,13 +377,10 @@ return {
     show_diff = {
       normal = 'gd',
     },
-    show_system_prompt = {
-      normal = 'gp',
+    show_info = {
+      normal = 'gi',
     },
-    show_user_selection = {
-      normal = 'gs',
-    },
-    show_user_context = {
+    show_context = {
       normal = 'gc',
     },
     show_help = {


### PR DESCRIPTION
Consolidates multiple info display commands (show_system_prompt,
show_user_selection, show_user_context) into two more comprehensive
commands:
- show_info (gi): displays model, agent and system prompt
- show_context (gc): shows selection and embeddings

This change improves UX by providing more organized and complete
information when inspecting chat context and configuration.

BREAKING CHANGE: Removed show_system_prompt (gp), show_user_selection (gs)
and show_user_context mappings in favor of new unified commands.