### PR TITLE
fix: add null check for buffer symbols

### DIFF
--- a/lua/CopilotChat/ui/debug.lua
+++ b/lua/CopilotChat/ui/debug.lua
@@ -26,21 +26,23 @@ local function build_debug_info()
 
   local buf = context.buffer()
   if buf then
-    table.insert(lines, 'Current buffer symbols:')
-    for _, symbol in ipairs(buf.symbols) do
-      table.insert(
-        lines,
-        string.format(
-          '%s `%s` (%s %s %s %s) - `%s`',
-          symbol.type,
-          symbol.name,
-          symbol.start_row,
-          symbol.start_col,
-          symbol.end_row,
-          symbol.end_col,
-          symbol.signature
+    if buf.symbols then
+      table.insert(lines, 'Current buffer symbols:')
+      for _, symbol in ipairs(buf.symbols) do
+        table.insert(
+          lines,
+          string.format(
+            '%s `%s` (%s %s %s %s) - `%s`',
+            symbol.type,
+            symbol.name,
+            symbol.start_row,
+            symbol.start_col,
+            symbol.end_row,
+            symbol.end_col,
+            symbol.signature
+          )
         )
-      )
+      end
     end
     table.insert(lines, 'Current buffer outline:')
     table.insert(lines, '`' .. buf.filename .. '`')


### PR DESCRIPTION
Add a null check for buf.symbols before attempting to iterate through the symbols array in debug info builder. This prevents potential errors when symbols are not available for the current buffer.