### PR TITLE
style: improve debug output readability

### DIFF
--- a/lua/CopilotChat/ui/debug.lua
+++ b/lua/CopilotChat/ui/debug.lua
@@ -43,7 +43,9 @@ local function build_debug_info()
           )
         )
       end
+      table.insert(lines, '')
     end
+
     table.insert(lines, 'Current buffer outline:')
     table.insert(lines, '`' .. buf.filename .. '`')
     table.insert(lines, '```' .. buf.filetype)


### PR DESCRIPTION
Add empty lines between sections in debug info to make the output more readable and easier to scan visually.