### PR TITLE
refactor: move source type to init.lua

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -3,14 +3,10 @@ local context = require('CopilotChat.context')
 local select = require('CopilotChat.select')
 local utils = require('CopilotChat.utils')
 
---- @class CopilotChat.config.source
---- @field bufnr number
---- @field winnr number
-
 ---@class CopilotChat.config.context
 ---@field description string?
----@field input fun(callback: fun(input: string?), source: CopilotChat.config.source)?
----@field resolve fun(input: string?, source: CopilotChat.config.source):table<CopilotChat.context.embed>
+---@field input fun(callback: fun(input: string?), source: CopilotChat.source)?
+---@field resolve fun(input: string?, source: CopilotChat.source):table<CopilotChat.context.embed>
 
 ---@class CopilotChat.config.prompt : CopilotChat.config.shared
 ---@field prompt string?
@@ -59,8 +55,8 @@ local utils = require('CopilotChat.utils')
 ---@field context string|table<string>|nil
 ---@field temperature number?
 ---@field headless boolean?
----@field callback fun(response: string, source: CopilotChat.config.source)?
----@field selection nil|fun(source: CopilotChat.config.source):CopilotChat.select.selection?
+---@field callback fun(response: string, source: CopilotChat.source)?
+---@field selection nil|fun(source: CopilotChat.source):CopilotChat.select.selection?
 ---@field window CopilotChat.config.window?
 ---@field show_help boolean?
 ---@field show_folds boolean?

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -15,9 +15,13 @@ local M = {}
 local PLUGIN_NAME = 'CopilotChat'
 local WORD = '([^%s]+)'
 
+--- @class CopilotChat.source
+--- @field bufnr number
+--- @field winnr number
+
 --- @class CopilotChat.state
 --- @field copilot CopilotChat.Copilot?
---- @field source CopilotChat.config.source?
+--- @field source CopilotChat.source?
 --- @field last_prompt string?
 --- @field last_response string?
 --- @field chat CopilotChat.ui.Chat?

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -48,7 +48,7 @@ local function get_diagnostics_in_range(bufnr, start_line, end_line)
 end
 
 --- Select and process current visual selection
---- @param source CopilotChat.config.source
+--- @param source CopilotChat.source
 --- @return CopilotChat.select.selection|nil
 function M.visual(source)
   local bufnr = source.bufnr
@@ -82,7 +82,7 @@ function M.visual(source)
 end
 
 --- Select and process whole buffer
---- @param source CopilotChat.config.source
+--- @param source CopilotChat.source
 --- @return CopilotChat.select.selection|nil
 function M.buffer(source)
   local bufnr = source.bufnr
@@ -105,7 +105,7 @@ function M.buffer(source)
 end
 
 --- Select and process current line
---- @param source CopilotChat.config.source
+--- @param source CopilotChat.source
 --- @return CopilotChat.select.selection|nil
 function M.line(source)
   local bufnr = source.bufnr
@@ -130,7 +130,7 @@ function M.line(source)
 end
 
 --- Select and process contents of unnamed register ("). This register contains last deleted, changed or yanked content.
---- @param source CopilotChat.config.source
+--- @param source CopilotChat.source
 --- @return CopilotChat.select.selection|nil
 function M.unnamed(source)
   local bufnr = source.bufnr


### PR DESCRIPTION
Move the CopilotChat.source type definition from config.lua to init.lua and update all references to use the new type location. This improves type organization by placing the core source type definition in the main module file.