### PR TITLE
refactor(context): extract buffer list logic to new function

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -180,14 +180,7 @@ return {
       end,
       resolve = function(input)
         input = input or 'listed'
-        return vim.tbl_map(
-          context.buffer,
-          vim.tbl_filter(function(b)
-            return utils.buf_valid(b)
-              and vim.fn.buflisted(b) == 1
-              and (input == 'listed' or #vim.fn.win_findbuf(b) > 0)
-          end, vim.api.nvim_list_bufs())
-        )
+        return context.buffers(input)
       end,
     },
     file = {

--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -412,6 +412,22 @@ function M.buffer(bufnr)
   )
 end
 
+--- Get content of all buffers
+---@param buf_type string
+---@return table<CopilotChat.context.embed>
+function M.buffers(buf_type)
+  async.util.scheduler()
+
+  return vim.tbl_map(
+    M.buffer,
+    vim.tbl_filter(function(b)
+      return utils.buf_valid(b)
+        and vim.fn.buflisted(b) == 1
+        and (buf_type == 'listed' or #vim.fn.win_findbuf(b) > 0)
+    end, vim.api.nvim_list_bufs())
+  )
+end
+
 --- Get the content of an URL
 ---@param url string
 ---@return CopilotChat.context.embed?


### PR DESCRIPTION
Move buffer list filtering logic from config.lua to a new dedicated function `buffers()` in context.lua for better code organization and reusability.