### PR TITLE
fix: only log debug messages when data exists

### DIFF
--- a/lua/CopilotChat/notify.lua
+++ b/lua/CopilotChat/notify.lua
@@ -11,7 +11,10 @@ M.listeners = {}
 ---@param data any
 function M.publish(event_name, data)
   if M.listeners[event_name] then
-    log.debug(event_name .. ':', data)
+    if data and data ~= '' then
+      log.debug(event_name .. ':', data)
+    end
+
     for _, callback in ipairs(M.listeners[event_name]) do
       callback(data)
     end


### PR DESCRIPTION
Previously debug messages were always logged even with empty data. This change adds a condition to only log debug messages when data exists and is not empty, reducing noise in the debug output.