### PR TITLE
docs: update list of customizable buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ Also see [here](/lua/CopilotChat/config.lua):
 
 ## Customizing buffers
 
-You can set local options for the buffers that are created by this plugin: `copilot-diff`, `copilot-system-prompt`, `copilot-user-selection`, `copilot-chat`.
+You can set local options for the buffers that are created by this plugin, `copilot-chat`, `copilot-diff`, `copilot-overlay`:
 
 ```lua
 vim.api.nvim_create_autocmd('BufEnter', {


### PR DESCRIPTION
Update the documentation to reflect the correct list of buffers that can be customized by users: copilot-chat, copilot-diff, and copilot-overlay. Remove mention of copilot-system-prompt and copilot-user-selection which are no longer used.