### PR TITLE
ci: update pandoc workflow to run on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
       contents: write
     name: pandoc to vimdoc
-    if: ${{ github.ref == 'refs/heads/canary' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Update GitHub Actions workflow configuration to run pandoc to vimdoc conversion on the main branch instead of the canary branch.

This change ensures documentation is properly generated and updated when changes are merged into the main branch.