### PR TITLE
chore: add doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# (neo)vim helptags
+/doc/tags


### PR DESCRIPTION
`:helptags ALL` creates this file and `git status` then keeps telling me about it. Other nvim plugins have this in their .gitignores, so add it here as well to silence it.

(most of the `.gitignore` seems like useless boilerplate that doesn't belong here, btw)
