### PR TITLE
fix: headless mode causing nil source

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -600,6 +600,10 @@ function M.open(config)
 
   config = vim.tbl_deep_extend('force', M.config, config or {})
   if config.headless then
+    state.source = {
+      bufnr = vim.api.nvim_get_current_buf(),
+      winnr = vim.api.nvim_get_current_win(),
+    }
     return
   end
 


### PR DESCRIPTION
fixes https://github.com/CopilotC-Nvim/CopilotChat.nvim/issues/703

This change ensures we set the source in headless mode so it can still be used by callback/prompts.

For example, opening nvim and immediately running 
```lua
local chat = require("CopilotChat")
chat.ask("/Review", {
    headless = true,
})
```
will now work!

whereas before, it gave the following error
```
Error executing vim.schedule lua callback: ...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:18: The coroutine failed with this message: ...re/nvim/lazy/CopilotChat.nvim/lua/CopilotChat/config.lua:330: attempt to index local 'source' (a nil value)
stack traceback:
	[C]: in function 'error'
	...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:18: in function 'callback_or_next'
	...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:45: in function <...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:44>
```