### PR TITLE
docs: update README with setup function for lazy installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ return {
       -- See Configuration section for options
     },
     -- See Commands section for default commands if you want to lazy load on them
+    config = function()
+      require("CopilotChat").setup {
+        -- See Configuration section for options
+      }
+    end
   },
 }
 ```


### PR DESCRIPTION
I think d82c5a30571e9759335cc50a27c0de0573e888f7 removed the `setup()` function from the lazy.nvim installation snippet. `setup()` seems to be mandatory for this plugin as all the user commands are created within it.