### PR TITLE
feat: Add theme options to select Telescope themes

### DIFF
--- a/lua/CopilotChat/integrations/telescope.lua
+++ b/lua/CopilotChat/integrations/telescope.lua
@@ -13,21 +13,16 @@ local M = {}
 --- Pick an action from a list of actions
 ---@param pick_actions CopilotChat.integrations.actions?: A table with the actions to pick from
 ---@param opts table?: Telescope options
----@param theme string?: Telescope theme
-function M.pick(pick_actions, opts, theme)
+function M.pick(pick_actions, opts)
   if not pick_actions or not pick_actions.actions or vim.tbl_isempty(pick_actions.actions) then
     return
   end
 
   utils.return_to_normal_mode()
-  theme = theme or 'dropdown'
-  local theme_functions = {
-    dropdown = themes.get_dropdown,
-    ivy = themes.get_ivy,
-    cursor = themes.get_cursor,
-  }
 
-  opts = (theme_functions[theme] or themes.get_dropdown)(opts or {})
+  -- if opt.theme is not set, use the default theme
+  opts = opts or {}
+  opts = opts.theme or themes.get_dropdown(opts)
 
   pickers
     .new(opts, {

--- a/lua/CopilotChat/integrations/telescope.lua
+++ b/lua/CopilotChat/integrations/telescope.lua
@@ -13,13 +13,22 @@ local M = {}
 --- Pick an action from a list of actions
 ---@param pick_actions CopilotChat.integrations.actions?: A table with the actions to pick from
 ---@param opts table?: Telescope options
-function M.pick(pick_actions, opts)
+---@param theme string?: Telescope theme
+function M.pick(pick_actions, opts, theme)
   if not pick_actions or not pick_actions.actions or vim.tbl_isempty(pick_actions.actions) then
     return
   end
 
   utils.return_to_normal_mode()
-  opts = themes.get_dropdown(opts or {})
+  theme = theme or 'dropdown'
+  local theme_functions = {
+    dropdown = themes.get_dropdown,
+    ivy = themes.get_ivy,
+    cursor = themes.get_cursor,
+  }
+
+  opts = (theme_functions[theme] or themes.get_dropdown)(opts or {})
+
   pickers
     .new(opts, {
       prompt_title = pick_actions.prompt,

--- a/lua/CopilotChat/integrations/telescope.lua
+++ b/lua/CopilotChat/integrations/telescope.lua
@@ -20,9 +20,9 @@ function M.pick(pick_actions, opts)
 
   utils.return_to_normal_mode()
 
-  -- if opt.theme is not set, use the default theme
-  opts = opts or {}
-  opts = opts.theme or themes.get_dropdown(opts)
+  if not (opts and opts.theme) then
+    opts = themes.get_dropdown(opts or {})
+  end
 
   pickers
     .new(opts, {


### PR DESCRIPTION
Added theme options to the M.pick function to allow selection of dropdown, ivy, and cursor themes.

<img width="1918" alt="image" src="https://github.com/user-attachments/assets/ed35b511-6323-49e8-868e-c2e0b87d8617" />
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/125deee0-0bc2-41e0-9a01-b6b2eb0dc3f3" />
