### PR TITLE
feat: add snacks.nvim picker integration

### DIFF
--- a/lua/CopilotChat/integrations/snacks.lua
+++ b/lua/CopilotChat/integrations/snacks.lua
@@ -28,9 +28,9 @@ function M.pick(pick_actions, opts)
     preview = 'preview',
     title = pick_actions.prompt,
     confirm = function(picker)
-      local selected = picker:selected({ fallback = true })
-      if selected and #selected > 0 then
-        local action = pick_actions.actions[selected[1].id]
+      local selected = picker:current()
+      if selected then
+        local action = pick_actions.actions[selected.id]
         vim.defer_fn(function()
           chat.ask(action.prompt, action)
         end, 100)

--- a/lua/CopilotChat/integrations/snacks.lua
+++ b/lua/CopilotChat/integrations/snacks.lua
@@ -19,13 +19,14 @@ function M.pick(pick_actions, opts)
         id = name,
         text = name,
         file = name,
+        preview = {
+          text = pick_actions.actions[name].prompt,
+          ft = 'text',
+        },
       }
     end, vim.tbl_keys(pick_actions.actions)),
-    preview = 'text',
+    preview = 'preview',
     title = pick_actions.prompt,
-    layout = {
-      preview = false,
-    },
     confirm = function(picker)
       local selected = picker:selected({ fallback = true })
       if selected and #selected > 0 then

--- a/lua/CopilotChat/integrations/snacks.lua
+++ b/lua/CopilotChat/integrations/snacks.lua
@@ -26,6 +26,14 @@ function M.pick(pick_actions, opts)
       }
     end, vim.tbl_keys(pick_actions.actions)),
     preview = 'preview',
+    win = {
+      preview = {
+        wo = {
+          wrap = true,
+          linebreak = true,
+        },
+      },
+    },
     title = pick_actions.prompt,
     confirm = function(picker)
       local selected = picker:current()


### PR DESCRIPTION
This adds an integration for the new snacks.nvim picker to be used when picking prompt actions with prompt preview:
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/92b522e7-03b0-4975-a53f-609420643451" />
