### PR TITLE
visual selection

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -58,11 +58,11 @@ local function get_selection(config)
   state.source.mode = state.source_mode or 'n'
 
   if
-      config
-      and config.selection
-      and utils.buf_valid(bufnr)
-      and winnr
-      and vim.api.nvim_win_is_valid(winnr)
+    config
+    and config.selection
+    and utils.buf_valid(bufnr)
+    and winnr
+    and vim.api.nvim_win_is_valid(winnr)
   then
     return config.selection(state.source)
   end
@@ -85,21 +85,27 @@ local function highlight_selection(clear, config)
 
   local selection = get_selection(config)
   if
-      not selection
-      or not utils.buf_valid(selection.bufnr)
-      or not selection.start_line
-      or not selection.end_line
+    not selection
+    or not utils.buf_valid(selection.bufnr)
+    or not selection.start_line
+    or not selection.end_line
   then
     return
   end
 
   if selection.start_col and selection.end_col then
-    vim.api.nvim_buf_set_extmark(selection.bufnr, selection_ns, selection.start_line - 1, selection.start_col, {
-      hl_group = 'CopilotChatSelection',
-      end_row = selection.end_line - 1,
-      end_col = selection.end_col,
-      strict = false,
-    })
+    vim.api.nvim_buf_set_extmark(
+      selection.bufnr,
+      selection_ns,
+      selection.start_line - 1,
+      selection.start_col,
+      {
+        hl_group = 'CopilotChatSelection',
+        end_row = selection.end_line - 1,
+        end_col = selection.end_col,
+        strict = false,
+      }
+    )
   else
     vim.api.nvim_buf_set_extmark(selection.bufnr, selection_ns, selection.start_line - 1, 0, {
       hl_group = 'CopilotChatSelection',
@@ -164,7 +170,7 @@ local function get_diff(config)
     -- If we found a valid buffer, get the reference content
     if bufnr and utils.buf_valid(bufnr) then
       reference =
-          table.concat(vim.api.nvim_buf_get_lines(bufnr, start_line - 1, end_line, false), '\n')
+        table.concat(vim.api.nvim_buf_get_lines(bufnr, start_line - 1, end_line, false), '\n')
       filetype = vim.bo[bufnr].filetype
     end
   end
@@ -753,7 +759,7 @@ function M.ask(prompt, config)
 
     local has_output = false
     local query_ok, filtered_embeddings =
-        pcall(context.filter_embeddings, state.copilot, prompt, embeddings)
+      pcall(context.filter_embeddings, state.copilot, prompt, embeddings)
 
     if not query_ok then
       async.util.scheduler()
@@ -765,21 +771,21 @@ function M.ask(prompt, config)
     end
 
     local ask_ok, response, token_count, token_max_count =
-        pcall(state.copilot.ask, state.copilot, prompt, {
-          selection = selection,
-          embeddings = filtered_embeddings,
-          system_prompt = system_prompt,
-          model = selected_model,
-          agent = selected_agent,
-          temperature = config.temperature,
-          no_history = config.headless,
-          on_progress = vim.schedule_wrap(function(token)
-            if not config.headless then
-              state.chat:append(token)
-            end
-            has_output = true
-          end),
-        })
+      pcall(state.copilot.ask, state.copilot, prompt, {
+        selection = selection,
+        embeddings = filtered_embeddings,
+        system_prompt = system_prompt,
+        model = selected_model,
+        agent = selected_agent,
+        temperature = config.temperature,
+        no_history = config.headless,
+        on_progress = vim.schedule_wrap(function(token)
+          if not config.headless then
+            state.chat:append(token)
+          end
+          has_output = true
+        end),
+      })
 
     async.util.scheduler()
 
@@ -1107,9 +1113,9 @@ function M.setup(config)
 
       map_key('jump_to_diff', bufnr, function()
         if
-            not state.source
-            or not state.source.winnr
-            or not vim.api.nvim_win_is_valid(state.source.winnr)
+          not state.source
+          or not state.source.winnr
+          or not vim.api.nvim_win_is_valid(state.source.winnr)
         then
           return
         end

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -58,11 +58,11 @@ local function get_selection(config)
   state.source.mode = state.source_mode or 'n'
 
   if
-    config
-    and config.selection
-    and utils.buf_valid(bufnr)
-    and winnr
-    and vim.api.nvim_win_is_valid(winnr)
+      config
+      and config.selection
+      and utils.buf_valid(bufnr)
+      and winnr
+      and vim.api.nvim_win_is_valid(winnr)
   then
     return config.selection(state.source)
   end
@@ -85,19 +85,28 @@ local function highlight_selection(clear, config)
 
   local selection = get_selection(config)
   if
-    not selection
-    or not utils.buf_valid(selection.bufnr)
-    or not selection.start_line
-    or not selection.end_line
+      not selection
+      or not utils.buf_valid(selection.bufnr)
+      or not selection.start_line
+      or not selection.end_line
   then
     return
   end
 
-  vim.api.nvim_buf_set_extmark(selection.bufnr, selection_ns, selection.start_line - 1, 0, {
-    hl_group = 'CopilotChatSelection',
-    end_row = selection.end_line,
-    strict = false,
-  })
+  if selection.start_col and selection.end_col then
+    vim.api.nvim_buf_set_extmark(selection.bufnr, selection_ns, selection.start_line - 1, selection.start_col, {
+      hl_group = 'CopilotChatSelection',
+      end_row = selection.end_line - 1,
+      end_col = selection.end_col,
+      strict = false,
+    })
+  else
+    vim.api.nvim_buf_set_extmark(selection.bufnr, selection_ns, selection.start_line - 1, 0, {
+      hl_group = 'CopilotChatSelection',
+      end_row = selection.end_line,
+      strict = false,
+    })
+  end
 end
 
 --- Updates the selection based on previous window
@@ -155,7 +164,7 @@ local function get_diff(config)
     -- If we found a valid buffer, get the reference content
     if bufnr and utils.buf_valid(bufnr) then
       reference =
-        table.concat(vim.api.nvim_buf_get_lines(bufnr, start_line - 1, end_line, false), '\n')
+          table.concat(vim.api.nvim_buf_get_lines(bufnr, start_line - 1, end_line, false), '\n')
       filetype = vim.bo[bufnr].filetype
     end
   end
@@ -744,7 +753,7 @@ function M.ask(prompt, config)
 
     local has_output = false
     local query_ok, filtered_embeddings =
-      pcall(context.filter_embeddings, state.copilot, prompt, embeddings)
+        pcall(context.filter_embeddings, state.copilot, prompt, embeddings)
 
     if not query_ok then
       async.util.scheduler()
@@ -756,21 +765,21 @@ function M.ask(prompt, config)
     end
 
     local ask_ok, response, token_count, token_max_count =
-      pcall(state.copilot.ask, state.copilot, prompt, {
-        selection = selection,
-        embeddings = filtered_embeddings,
-        system_prompt = system_prompt,
-        model = selected_model,
-        agent = selected_agent,
-        temperature = config.temperature,
-        no_history = config.headless,
-        on_progress = vim.schedule_wrap(function(token)
-          if not config.headless then
-            state.chat:append(token)
-          end
-          has_output = true
-        end),
-      })
+        pcall(state.copilot.ask, state.copilot, prompt, {
+          selection = selection,
+          embeddings = filtered_embeddings,
+          system_prompt = system_prompt,
+          model = selected_model,
+          agent = selected_agent,
+          temperature = config.temperature,
+          no_history = config.headless,
+          on_progress = vim.schedule_wrap(function(token)
+            if not config.headless then
+              state.chat:append(token)
+            end
+            has_output = true
+          end),
+        })
 
     async.util.scheduler()
 
@@ -1098,9 +1107,9 @@ function M.setup(config)
 
       map_key('jump_to_diff', bufnr, function()
         if
-          not state.source
-          or not state.source.winnr
-          or not vim.api.nvim_win_is_valid(state.source.winnr)
+            not state.source
+            or not state.source.winnr
+            or not vim.api.nvim_win_is_valid(state.source.winnr)
         then
           return
         end

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -58,11 +58,11 @@ local function get_selection(config)
   state.source.mode = state.source_mode or 'n'
 
   if
-      config
-      and config.selection
-      and utils.buf_valid(bufnr)
-      and winnr
-      and vim.api.nvim_win_is_valid(winnr)
+    config
+    and config.selection
+    and utils.buf_valid(bufnr)
+    and winnr
+    and vim.api.nvim_win_is_valid(winnr)
   then
     return config.selection(state.source)
   end
@@ -85,10 +85,10 @@ local function highlight_selection(clear, config)
 
   local selection = get_selection(config)
   if
-      not selection
-      or not utils.buf_valid(selection.bufnr)
-      or not selection.start_line
-      or not selection.end_line
+    not selection
+    or not utils.buf_valid(selection.bufnr)
+    or not selection.start_line
+    or not selection.end_line
   then
     return
   end
@@ -155,7 +155,7 @@ local function get_diff(config)
     -- If we found a valid buffer, get the reference content
     if bufnr and utils.buf_valid(bufnr) then
       reference =
-          table.concat(vim.api.nvim_buf_get_lines(bufnr, start_line - 1, end_line, false), '\n')
+        table.concat(vim.api.nvim_buf_get_lines(bufnr, start_line - 1, end_line, false), '\n')
       filetype = vim.bo[bufnr].filetype
     end
   end
@@ -744,7 +744,7 @@ function M.ask(prompt, config)
 
     local has_output = false
     local query_ok, filtered_embeddings =
-        pcall(context.filter_embeddings, state.copilot, prompt, embeddings)
+      pcall(context.filter_embeddings, state.copilot, prompt, embeddings)
 
     if not query_ok then
       async.util.scheduler()
@@ -756,21 +756,21 @@ function M.ask(prompt, config)
     end
 
     local ask_ok, response, token_count, token_max_count =
-        pcall(state.copilot.ask, state.copilot, prompt, {
-          selection = selection,
-          embeddings = filtered_embeddings,
-          system_prompt = system_prompt,
-          model = selected_model,
-          agent = selected_agent,
-          temperature = config.temperature,
-          no_history = config.headless,
-          on_progress = vim.schedule_wrap(function(token)
-            if not config.headless then
-              state.chat:append(token)
-            end
-            has_output = true
-          end),
-        })
+      pcall(state.copilot.ask, state.copilot, prompt, {
+        selection = selection,
+        embeddings = filtered_embeddings,
+        system_prompt = system_prompt,
+        model = selected_model,
+        agent = selected_agent,
+        temperature = config.temperature,
+        no_history = config.headless,
+        on_progress = vim.schedule_wrap(function(token)
+          if not config.headless then
+            state.chat:append(token)
+          end
+          has_output = true
+        end),
+      })
 
     async.util.scheduler()
 
@@ -1098,9 +1098,9 @@ function M.setup(config)
 
       map_key('jump_to_diff', bufnr, function()
         if
-            not state.source
-            or not state.source.winnr
-            or not vim.api.nvim_win_is_valid(state.source.winnr)
+          not state.source
+          or not state.source.winnr
+          or not vim.api.nvim_win_is_valid(state.source.winnr)
         then
           return
         end

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -51,7 +51,7 @@ end
 --- @param source CopilotChat.source
 --- @return CopilotChat.select.selection|nil
 function M.visual(source)
-  local bufnr = source.bufnr or 0
+  local bufnr = source.bufnr
   local mode = source.mode
   local start_line, start_col = unpack(vim.api.nvim_buf_get_mark(bufnr, '<'))
   local finish_line, finish_col = unpack(vim.api.nvim_buf_get_mark(bufnr, '>'))

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -8,6 +8,8 @@
 ---@field content string
 ---@field start_line number
 ---@field end_line number
+---@field start_col number
+---@field end_col number
 ---@field filename string
 ---@field filetype string
 ---@field bufnr number
@@ -95,6 +97,8 @@ function M.visual(source)
     filetype = vim.bo[bufnr].filetype,
     start_line = start_line,
     end_line = finish_line,
+    start_col = start_col,
+    end_col = finish_col,
     bufnr = bufnr,
     diagnostics = get_diagnostics_in_range(bufnr, start_line, finish_line),
   }

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -64,13 +64,21 @@ function M.visual(source)
 
   -- Visual Line mode, adjusting the end column
   local ok, lines
-  if mode == "V" then
+  if mode == 'V' then
     ok, lines = pcall(vim.api.nvim_buf_get_lines, bufnr, start_line - 1, finish_line, false)
     if not ok then
       return nil
     end
   else
-    ok, lines = pcall(vim.api.nvim_buf_get_text, bufnr, start_line - 1, start_col, finish_line - 1, finish_col + 1, {})
+    ok, lines = pcall(
+      vim.api.nvim_buf_get_text,
+      bufnr,
+      start_line - 1,
+      start_col,
+      finish_line - 1,
+      finish_col + 1,
+      {}
+    )
     if not ok then
       return nil
     end


### PR DESCRIPTION
I'm not sure if this #734 is a bug or intentional.

My scenario is:
I have a use case to search for current highlighted text in a chat. If i use `select.visual`, the selection would highlight the entire line as the context, instead of the highlighted text.

So instead of `vim.api.nvim_buf_get_lines`, i use `nvim_buf_get_text` to get the exact text i want as the context to the chat, and added a state to track the vim mode. To be honest, I didn't test this intensively, let me know if I am doing something wrong :smile:.