### PR TITLE
feat: add quickfix list context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Default contexts are:
   - `git:staged` - Includes staged changes in chat context.
 - `url` - Includes content of provided URL in chat context. Supports input.
 - `register` - Includes contents of register in chat context. Supports input (default +, e.g clipboard).
+- `quickfix` - Includes quickfix list file contents in chat context.
 
 You can define custom contexts like this:
 
@@ -485,6 +486,9 @@ Also see [here](/lua/CopilotChat/config.lua):
       -- see config.lua for implementation
     },
     register = {
+      -- see config.lua for implementation
+    },
+    quickfix = {
       -- see config.lua for implementation
     },
   },

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -283,6 +283,12 @@ return {
         }
       end,
     },
+    quickfix = {
+      description = 'Includes quickfix list file contents in chat context.',
+      resolve = function()
+        return context.quickfix()
+      end,
+    },
   },
 
   -- default prompts


### PR DESCRIPTION
This commit adds support for the quickfix list context in CopilotChat. The quickfix context allows including the contents of files listed in the quickfix list as part of the chat context.

The implementation includes:
- New quickfix context type in config.lua
- Function to extract and process quickfix list files
- Updated documentation in README.md with the new context type