### PR TITLE
feat: add quickfix list support for chat answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ See [@deathbeam](https://github.com/deathbeam) for [configuration](https://githu
 - `gr` - Toggle sticky prompt for the line under cursor
 - `<C-y>` - Accept nearest diff (works best with `COPILOT_GENERATE` prompt)
 - `gj` - Jump to section of nearest diff. If in different buffer, jumps there; creates buffer if needed (works best with `COPILOT_GENERATE` prompt)
-- `gq` - Add all diffs from chat to quickfix list
+- `gqa` - Add all answers from chat to quickfix list
+- `gqd` - Add all diffs from chat to quickfix list
 - `gy` - Yank nearest diff to register (defaults to `"`)
 - `gd` - Show diff between source and nearest diff
 - `gi` - Show info about current chat (model, agent, system prompt)
@@ -547,8 +548,11 @@ Also see [here](/lua/CopilotChat/config.lua):
     jump_to_diff = {
       normal = 'gj',
     },
+    quickfix_answers = {
+      normal = 'gqa',
+    },
     quickfix_diffs = {
-      normal = 'gq',
+      normal = 'gqd',
     },
     yank_diff = {
       normal = 'gy',

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -383,8 +383,11 @@ return {
     jump_to_diff = {
       normal = 'gj',
     },
+    quickfix_answers = {
+      normal = 'gqa',
+    },
     quickfix_diffs = {
-      normal = 'gq',
+      normal = 'gqd',
     },
     yank_diff = {
       normal = 'gy',

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1116,6 +1116,39 @@ function M.setup(config)
         )
       end)
 
+      map_key('quickfix_answers', bufnr, function()
+        local items = {}
+        for i, section in ipairs(state.chat.sections) do
+          if section.answer then
+            local prev_section = state.chat.sections[i - 1]
+            local text = ''
+            if prev_section then
+              text = vim.trim(
+                table.concat(
+                  vim.api.nvim_buf_get_lines(
+                    bufnr,
+                    prev_section.start_line - 1,
+                    prev_section.end_line,
+                    false
+                  ),
+                  ' '
+                )
+              )
+            end
+
+            table.insert(items, {
+              bufnr = bufnr,
+              lnum = section.start_line,
+              end_lnum = section.end_line,
+              text = text,
+            })
+          end
+        end
+
+        vim.fn.setqflist(items)
+        vim.cmd('copen')
+      end)
+
       map_key('quickfix_diffs', bufnr, function()
         local selection = get_selection(state.chat.config)
         local items = {}


### PR DESCRIPTION
Split existing quickfix mapping (gq) into two separate mappings:
- gqa: adds all chat answers to quickfix list
- gqd: adds all code diffs to quickfix list (previous gq functionality)

This allows for easier navigation between different parts of the chat history, particularly when reviewing AI responses.