### PR TITLE
context: Fix bugs.

### DIFF
--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -559,7 +559,7 @@ function M.quickfix()
         name = utils.filepath(file),
         ft = utils.filetype(file),
       }
-    end, vim.tbl_values(unique_files))
+    end, vim.tbl_keys(unique_files))
   )
 
   local out = {}


### PR DESCRIPTION
We use files not booleans.

This pull request includes a small change to the `lua/CopilotChat/context.lua` file. The change modifies the `quickfix` function to use `vim.tbl_keys` instead of `vim.tbl_values` when processing `unique_files`.

* [`lua/CopilotChat/context.lua`](diffhunk://#diff-2d1d203284a8d057142c9904421ec216f7b8dafc696915f24f3552608dfb5e75L562-R562): Changed the `quickfix` function to use `vim.tbl_keys` instead of `vim.tbl_values` when iterating over `unique_files`.