### PR TITLE
feat(context): add support for commit-specific git diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,16 +267,23 @@ If context supports input, you can set the input in the prompt by using `:` foll
 Default contexts are:
 
 - `buffer` - Includes specified buffer in chat context. Supports input (default current).
+  - `buffer:<number>` - Includes buffer with specified number in chat context.
 - `buffers` - Includes all buffers in chat context. Supports input (default listed).
+  - `buffers:listed` - Includes only listed buffers in chat context.
+  - `buffers:all` - Includes all buffers in chat context.
 - `file` - Includes content of provided file in chat context. Supports input.
+  - `file:<path>` - Includes content of specified file in chat context.
 - `files` - Includes all non-hidden files in the current workspace in chat context. Supports input (default list).
   - `files:list` - Only lists file names.
   - `files:full` - Includes file content for each file found. Can be slow on large workspaces, use with care.
-- `git` - Requires `git`. Includes current git diff in chat context. Supports input (default unstaged).
+- `git` - Requires `git`. Includes current git diff in chat context. Supports input (default unstaged, also accepts commit number).
   - `git:unstaged` - Includes unstaged changes in chat context.
   - `git:staged` - Includes staged changes in chat context.
+  - `git:<commit>` - Includes changes from specified commit in chat context.
 - `url` - Includes content of provided URL in chat context. Supports input.
+  - `url:<url>` - Includes content of specified URL in chat context.
 - `register` - Includes contents of register in chat context. Supports input (default +, e.g clipboard).
+  - `register:<register>` - Includes contents of specified register in chat context.
 - `quickfix` - Includes quickfix list file contents in chat context.
 
 You can define custom contexts like this:

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -229,7 +229,7 @@ return {
       end,
     },
     git = {
-      description = 'Requires `git`. Includes current git diff in chat context. Supports input (default unstaged).',
+      description = 'Requires `git`. Includes current git diff in chat context. Supports input (default unstaged, also accepts commit number).',
       input = function(callback)
         vim.ui.select({ 'unstaged', 'staged' }, {
           prompt = 'Select diff type> ',

--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -505,6 +505,10 @@ function M.gitdiff(type, winnr)
 
   if type == 'staged' then
     table.insert(cmd, '--staged')
+  elseif type == 'unstaged' then
+    table.insert(cmd, '--')
+  else
+    table.insert(cmd, type)
   end
 
   local out = utils.system(cmd)


### PR DESCRIPTION
Allow viewing diffs for specific commits by passing commit hash/reference to the git context. This extends the existing git context functionality which previously only supported staged and unstaged changes.

The change includes:
- Updated documentation in README.md to reflect new git context options
- Modified context handler to support commit references
- Updated config description to mention commit number support