### PR TITLE
fix: typescript file type matching

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -200,6 +200,20 @@ end
 ---@return string|nil
 function M.filetype(filename)
   local ft = vim.filetype.match({ filename = filename })
+
+  -- weird TypeScript bug for vim.filetype.match
+  -- see: https://github.com/neovim/neovim/issues/27265
+  if not ft then
+    local base_name = vim.fs.basename(filename)
+    local split_name = vim.split(base_name, '%.')
+    if #split_name > 1 then
+      local ext = split_name[#split_name]
+      if ext == 'ts' then
+        ft = 'typescript'
+      end
+    end
+  end
+
   if ft == '' then
     return nil
   end


### PR DESCRIPTION
Was having a hard time to understand why typescript files `.ts` are not being taken to the context through `#file:`.
Seems to be because of this issue with `vim.filetype.match`: https://github.com/neovim/neovim/issues/27265

Copied `GitMurf`'s fix from that GH issue, which temporarily solves it till it's properly fixed on the neovim side.