### PR TITLE
feat: Report early stop reason to the UI

### DIFF
--- a/lua/CopilotChat/copilot.lua
+++ b/lua/CopilotChat/copilot.lua
@@ -646,7 +646,13 @@ function Copilot:ask(prompt, opts)
     end
 
     if choice.finish_reason and job then
-      finish_stream(nil, job)
+      local reason = choice.finish_reason
+      if reason == 'stop' then
+        reason = nil
+      else
+        reason = 'Early stop: ' .. reason
+      end
+      finish_stream(reason, job)
     end
   end
 


### PR DESCRIPTION
The Copilot API returns a `finish_reason` field that indicates why the response stopped. This commit adds this information to the UI, so the user knows why the response stopped.

If the reason is `stop`, it means that the response was finished normally, so we don't need to show any message.

Closes https://github.com/CopilotC-Nvim/CopilotChat.nvim/issues/711