### PR TITLE
WIP: feat: summarise question/answer/error in 'foldtext'

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -14,6 +14,30 @@ function CopilotChatFoldExpr(lnum, separator)
   return '='
 end
 
+function CopilotChatMakeFoldText(winnr, config)
+  vim.w[winnr].CopilotChatFoldText = function (lnum)
+    local nlines = vim.v.foldend - vim.v.foldstart
+    local initial = "+-- " .. nlines .. " "
+
+    local line = vim.fn.getline(lnum)
+    if startswith(line, config.question_header) then
+      return initial .. config.question_header
+    elseif startswith(line, config.answer_header) then
+      return initial .. config.answer_header
+    elseif startswith(line, config.error_header) then
+      return initial .. config.error_header
+    else
+      return initial
+    end
+  end
+
+  return "luaeval(\"vim.w.CopilotChatFoldText(vim.v.lnum)\")"
+end
+
+local function startswith(text, initial)
+  return line:sub(1, to_match:len()) == to_match
+end
+
 ---@param header? string
 ---@return string?, number?, number?
 local function match_header(header)
@@ -467,6 +491,7 @@ function Chat:open(config)
     vim.wo[self.winnr].foldcolumn = '1'
     vim.wo[self.winnr].foldmethod = 'expr'
     vim.wo[self.winnr].foldexpr = "v:lua.CopilotChatFoldExpr(v:lnum, '" .. self.separator .. "')"
+    vim.wo[self.winnr].foldtext = CopilotChatMakeFoldText(winnr, config)
   else
     vim.wo[self.winnr].foldcolumn = '0'
   end

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -15,9 +15,9 @@ function CopilotChatFoldExpr(lnum, separator)
 end
 
 function CopilotChatMakeFoldText(winnr, config)
-  vim.w[winnr].CopilotChatFoldText = function (lnum)
+  vim.w[winnr].CopilotChatFoldText = function(lnum)
     local nlines = vim.v.foldend - vim.v.foldstart
-    local initial = "+-- " .. nlines .. " "
+    local initial = '+-- ' .. nlines .. ' '
 
     local line = vim.fn.getline(lnum)
     if startswith(line, config.question_header) then
@@ -31,7 +31,7 @@ function CopilotChatMakeFoldText(winnr, config)
     end
   end
 
-  return "luaeval(\"vim.w.CopilotChatFoldText(vim.v.lnum)\")"
+  return 'luaeval("vim.w.CopilotChatFoldText(vim.v.lnum)")'
 end
 
 local function startswith(text, initial)


### PR DESCRIPTION
This summarises the type of fold in `foldtext` - currently shown is:
```
++--  5 l───────────

++-- 16 line────────

++--  3 l───────────

++-- 10 line────────

++--  3 l───────────
```

With this PR aiming to improve this to:
```
++--  5 ## User ───────────

++-- 16 ## Copilot ────────

++--  3 ## User ───────────

++-- 10 ## Copilot ────────

++--  3 ## User ───────────
```