### PR TITLE
feat: migrate from Jekyll to Docsify

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -29,13 +29,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v4
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./
-          destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: "."
 
   # Deployment job
   deploy:

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,0 @@
-markdown: kramdown
-kramdown:
-  toc_levels: 1..3
-  auto_ids: true
-  parse_block_html: true
-  input: GFM
-theme: jekyll-theme-midnight

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1.0, shrink-to-fit=no, viewport-fit=cover">
+  <title>Copilot Chat for Neovim</title>
+  <meta name="description" content="Chat with GitHub Copilot in Neovim ">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+</head>
+
+<body>
+  <div id="app"></div>
+
+  <script>
+    window.$docsify = {
+      maxLevel: 3,
+      subMaxLevel: 3,
+    };
+  </script>
+
+  <!-- Required -->
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
+
+  <!-- Recommended -->
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/zoom-image.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,29 +1,34 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, minimum-scale=1.0, shrink-to-fit=no, viewport-fit=cover"
+    />
+    <title>Copilot Chat for Neovim</title>
+    <meta name="description" content="Chat with GitHub Copilot in Neovim " />
+    <link
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"
+    />
+  </head>
 
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1.0, shrink-to-fit=no, viewport-fit=cover">
-  <title>Copilot Chat for Neovim</title>
-  <meta name="description" content="Chat with GitHub Copilot in Neovim ">
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
-</head>
+  <body>
+    <div id="app"></div>
 
-<body>
-  <div id="app"></div>
+    <script>
+      window.$docsify = {
+        maxLevel: 3,
+        subMaxLevel: 3,
+      };
+    </script>
 
-  <script>
-    window.$docsify = {
-      maxLevel: 3,
-      subMaxLevel: 3,
-    };
-  </script>
+    <!-- Required -->
+    <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
 
-  <!-- Required -->
-  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
-
-  <!-- Recommended -->
-  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/zoom-image.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.js"></script>
-</body>
+    <!-- Recommended -->
+    <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/zoom-image.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
Replace Jekyll-based documentation with Docsify for simpler and more flexible documentation setup. This change:
- Removes Jekyll configuration and build step from GH Pages workflow
- Adds basic Docsify setup with search and image zoom plugins
- Creates .nojekyll file to disable GitHub Pages Jekyll processing

The migration provides a more maintainable documentation system that works better with single-page documentation sites.