### PR TITLE
fix: add scheduler in register function

### DIFF
--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -524,6 +524,8 @@ end
 ---@param register string
 ---@return CopilotChat.context.embed?
 function M.register(register)
+  async.util.scheduler()
+
   local lines = vim.fn.getreg(register)
   if not lines or lines == '' then
     return nil


### PR DESCRIPTION
Ensures proper async scheduling when accessing vim registers by adding async.util.scheduler() call before register operations.