### PR TITLE
feat: switch documentation to dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta name="description" content="Chat with GitHub Copilot in Neovim " />
     <link
       rel="stylesheet"
-      href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"
+      href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css"
     />
   </head>
 
@@ -26,6 +26,7 @@
 
     <!-- Required -->
     <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/js/docsify-themeable.min.js"></script>
 
     <!-- Recommended -->
     <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/zoom-image.min.js"></script>

--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -750,6 +750,7 @@ function Client:embed(inputs, model)
       })
 
       if err or not response or response.status ~= 200 then
+        log.debug('Failed to get embeddings: ', err)
         attempts = attempts + 1
         -- If we have few items and the request failed, try reducing threshold first
         if #batch <= 5 then


### PR DESCRIPTION
Changes the docsify theme from vue to simple-dark theme and adds error logging for failed embedding requests. This improves readability for users who prefer dark mode and helps with debugging embedding issues.

- Replace vue.css with theme-simple-dark.css
- Add docsify-themeable script
- Add debug logging for embedding errors