### PR TITLE
style: add missing trailing comma in headers table

### DIFF
--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -96,7 +96,7 @@ M.copilot = {
       headers = {
         ['Authorization'] = 'Token ' .. get_github_token(),
         ['Accept'] = 'application/json',
-      }
+      },
     })
 
     if err then


### PR DESCRIPTION
Fix code style consistency by adding a trailing comma in the headers table definition in providers.lua