### PR TITLE
fix: improve provider handling and model uniqueness

### DIFF
--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -18,7 +18,7 @@ local utils = require('CopilotChat.utils')
 ---@field disabled nil|boolean
 ---@field embeddings nil|string
 ---@field get_headers fun(token:string):table<string, string>
----@field get_token fun():string,number?
+---@field get_token nil|fun():string,number?
 ---@field get_agents nil|fun(headers:table):table<CopilotChat.Provider.agent>
 ---@field get_models nil|fun(headers:table):table<CopilotChat.Provider.model>
 ---@field prepare_input fun(inputs:table, opts:CopilotChat.Client.ask, model:table):table


### PR DESCRIPTION
Makes the provider handling more robust by:
- Making get_token optional for providers
- Adding error handling for model and agent fetching
- Ensuring unique model/agent IDs by appending provider name on conflicts
- Sorting providers for consistent order
- Removing provider suffix from model name before request

These changes improve reliability when multiple providers are configured and prevent conflicts between models/agents with the same IDs from different providers.