### PR TITLE
fix: change agent/model id provider suffix format

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -295,7 +295,7 @@ function Client:fetch_agents()
         for _, agent in ipairs(provider_agents) do
           agent.provider = provider_name
           if agents[agent.id] then
-            agent.id = provider_name .. ':' .. agent.id
+            agent.id = agent.id .. ':' .. provider_name
           end
           agents[agent.id] = agent
         end
@@ -529,6 +529,7 @@ function Client:ask(prompt, opts)
     parse_stream_line(line, job)
   end
 
+  opts.agent = opts.agent and opts.agent:gsub(':' .. provider_name .. '$', '')
   opts.model = opts.model:gsub(':' .. provider_name .. '$', '')
   local headers = self:authenticate(provider_name)
   local request = provider.prepare_input(


### PR DESCRIPTION
The change modifies how provider suffix is added to agent/model IDs to ensure consistent handling across the codebase. Now the provider name is appended to the ID instead of being prepended, and the suffix is properly stripped when making API calls.