### PR TITLE
fix: update system_prompt config reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Below are all available configuration options with their default values:
 
   -- Shared config starts here (can be passed to functions at runtime and configured via setup function)
 
-  system_prompt = prompts.COPILOT_INSTRUCTIONS, -- System prompt to use (can be specified manually in prompt via /).
+  system_prompt = prompts.COPILOT_INSTRUCTIONS.system_prompt, -- System prompt to use (can be specified manually in prompt via /).
 
   model = 'gpt-4o', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
   agent = 'copilot', -- Default agent to use, see ':CopilotChatAgents' for available agents (can be specified manually in prompt via @).


### PR DESCRIPTION
The system_prompt configuration option was incorrectly referencing the COPILOT_INSTRUCTIONS table directly. This change updates it to correctly reference the system_prompt field within that table.