### PR TITLE
fix: update embeddings input parameter name

### DIFF
--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -287,7 +287,7 @@ M.copilot_embeddings = {
   prepare_input = function(inputs)
     return {
       dimensions = 512,
-      inputs = inputs,
+      input = inputs,
       model = 'text-embedding-3-small',
     }
   end,


### PR DESCRIPTION
Change the parameter name from 'inputs' to 'input' in the Copilot embeddings provider to match the OpenAI API requirements for text embeddings endpoint.