### PR TITLE
refactor(chat): improve yank functionality and types

### DIFF
--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -6,6 +6,7 @@ local utils = require('CopilotChat.utils')
 ---@field input fun(callback: fun(input: string?), source: CopilotChat.source)?
 ---@field resolve fun(input: string?, source: CopilotChat.source):table<CopilotChat.context.embed>
 
+---@type table<string, CopilotChat.config.context>
 return {
   buffer = {
     description = 'Includes specified buffer in chat context. Supports input (default current).',

--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -99,7 +99,7 @@ end
 ---@field normal string?
 ---@field insert string?
 ---@field detail string?
----@field callback fun(overlay: CopilotChat.ui.Overlay, diff: CopilotChat.ui.Diff.Diff, chat: CopilotChat.ui.Chat, source: CopilotChat.source)
+---@field callback fun(overlay: CopilotChat.ui.Overlay, diff: CopilotChat.ui.Diff, chat: CopilotChat.ui.Chat, source: CopilotChat.source)
 
 ---@class CopilotChat.config.mapping.yank_diff : CopilotChat.config.mapping
 ---@field register string?
@@ -121,7 +121,6 @@ end
 ---@field show_info CopilotChat.config.mapping?
 ---@field show_context CopilotChat.config.mapping?
 ---@field show_help CopilotChat.config.mapping?
-
 return {
   complete = {
     insert = '<Tab>',
@@ -317,12 +316,12 @@ return {
     normal = 'gy',
     register = '"', -- Default register to use for yanking
     callback = function(overlay, diff, chat)
-      local content = get_diff(chat)
-      if not content then
+      local block = chat:get_closest_block()
+      if not block then
         return
       end
 
-      vim.fn.setreg(copilot.config.mappings.yank_diff.register, content.change)
+      vim.fn.setreg(copilot.config.mappings.yank_diff.register, block.content)
     end,
   },
 

--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -79,6 +79,7 @@ Your task is to modify the provided code according to the user's request. Follow
 Remember: Your response should ONLY contain file headers with line numbers and code blocks for direct replacement.
 ]]
 
+---@type table<string, CopilotChat.config.prompt>
 return {
   COPILOT_INSTRUCTIONS = {
     system_prompt = COPILOT_INSTRUCTIONS,


### PR DESCRIPTION
Update yank functionality to use closest chat block instead of diff content. Add proper type annotations for contexts and prompts tables. Clean up unnecessary comment and improve type definition for callback function.

This change makes the yank feature more intuitive by copying the actual chat block content rather than diff changes.