### PR TITLE
fix: type annotation of config.providers

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -46,7 +46,7 @@ local select = require('CopilotChat.select')
 ---@field answer_header string?
 ---@field error_header string?
 ---@field separator string?
----@field providers table<string, CopilotChat.Provider?>
+---@field providers table<string, CopilotChat.Provider>?
 ---@field contexts table<string, CopilotChat.config.context>?
 ---@field prompts table<string, CopilotChat.config.prompt|string>?
 ---@field mappings CopilotChat.config.mappings?


### PR DESCRIPTION
I might be wrong but I believe the type annotation for this one was a mistake based on the types from other fields.

Noticed this because I was getting the spurious warning shown below:

![image](https://github.com/user-attachments/assets/9d59c62f-d332-455c-8c64-e88b6b3b7358)
