### PR TITLE
refactor: make client module stateless

### DIFF
--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -5,7 +5,7 @@ local utils = require('CopilotChat.utils')
 ---@class CopilotChat.config.context
 ---@field description string?
 ---@field input fun(callback: fun(input: string?), source: CopilotChat.source)?
----@field resolve fun(input: string?, source: CopilotChat.source):table<CopilotChat.context.embed>
+---@field resolve fun(input: string?, source: CopilotChat.source, prompt: string, model: string):table<CopilotChat.context.embed>
 
 ---@type table<string, CopilotChat.config.context>
 return {

--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -31,9 +31,10 @@ local EDITOR_VERSION = 'Neovim/'
   .. '.'
   .. vim.version().patch
 
---- Get the github oauth cached token
----@return string|nil
 local cached_github_token = nil
+
+--- Get the github copilot oauth cached token (gu_ token)
+---@return string
 local function get_github_token()
   if cached_github_token then
     return cached_github_token
@@ -84,10 +85,11 @@ M.copilot = {
 
   get_headers = function(token)
     return {
-      ['Authorization'] = 'Bearer ' .. token,
-      ['Editor-Version'] = EDITOR_VERSION,
-      ['Copilot-Integration-Id'] = 'vscode-chat',
-      ['Content-Type'] = 'application/json',
+      ['authorization'] = 'Bearer ' .. token,
+      ['editor-version'] = EDITOR_VERSION,
+      ['editor-plugin-version'] = 'CopilotChat.nvim/*',
+      ['copilot-integration-id'] = 'vscode-chat',
+      ['content-type'] = 'application/json',
     }
   end,
 


### PR DESCRIPTION
The client module has been refactored to be stateless by making it a singleton and moving provider initialization to a separate method. This simplifies the overall architecture and makes the code more maintainable.

Additional changes:
- Improved reference handling and generation
- Updated header naming convention for Copilot requests
- Fixed embedding context resolution to pass proper params
- Removed redundant client state from main module