### PR TITLE
fix: remove unused model param from context resolving

### DIFF
--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -5,7 +5,7 @@ local utils = require('CopilotChat.utils')
 ---@class CopilotChat.config.context
 ---@field description string?
 ---@field input fun(callback: fun(input: string?), source: CopilotChat.source)?
----@field resolve fun(input: string?, source: CopilotChat.source, prompt: string, model: string):table<CopilotChat.context.embed>
+---@field resolve fun(input: string?, source: CopilotChat.source, prompt: string):table<CopilotChat.context.embed>
 
 ---@type table<string, CopilotChat.config.context>
 return {

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -219,10 +219,9 @@ end
 
 --- Resolve the embeddings from the prompt.
 ---@param prompt string
----@param model string
 ---@param config CopilotChat.config.shared
 ---@return table<CopilotChat.context.embed>, string
-function M.resolve_embeddings(prompt, model, config)
+function M.resolve_embeddings(prompt, config)
   local contexts = {}
   local function parse_context(prompt_context)
     local split = vim.split(prompt_context, ':')
@@ -262,7 +261,7 @@ function M.resolve_embeddings(prompt, model, config)
   for _, context_data in ipairs(contexts) do
     local context_value = M.config.contexts[context_data.name]
     for _, embedding in
-      ipairs(context_value.resolve(context_data.input, state.source or {}, prompt, model))
+      ipairs(context_value.resolve(context_data.input, state.source or {}, prompt))
     do
       if embedding then
         embeddings:set(embedding.filename, embedding)


### PR DESCRIPTION
The model parameter was unused in context resolution functions and has been removed to simplify the API. This change affects both the type definition and implementation of context resolving functions.