### PR TITLE
perf: improve file and context matching performance

### DIFF
--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -58,6 +58,7 @@ return {
       local files = utils.scan_dir(cwd, {
         add_dirs = false,
         respect_gitignore = true,
+        max_files = 1000,
       })
 
       async.util.scheduler()
@@ -76,7 +77,7 @@ return {
     input = function(callback)
       local choices = utils.kv_list({
         list = 'Only lists file names',
-        full = 'Includes file content for each file found. Can be slow on large workspaces, use with care.',
+        full = 'Includes file content for each file found, up to a limit.',
       })
 
       vim.ui.select(choices, {

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -363,7 +363,12 @@ M.scan_dir = async.wrap(function(path, opts, callback)
   scandir.scan_dir_async(
     path,
     vim.tbl_deep_extend('force', opts, {
-      on_exit = callback,
+      on_exit = function(files)
+        if opts.max_files then
+          files = vim.list_slice(files, 1, opts.max_files)
+        end
+        callback(files)
+      end,
     })
   )
 end, 3)


### PR DESCRIPTION
Introduces similarity thresholds and file limits to improve matching performance:
- Add MIN_SYMBOL_SIMILARITY (0.4) and MIN_SEMANTIC_SIMILARITY (0.3) thresholds
- Implement max_files limit (1000) for directory scanning
- Refactor ranking algorithms to filter by similarity instead of taking top N
- Improve symbol matching to use normalized similarity scores

These changes help prevent performance issues with large codebases while maintaining matching quality by using similarity-based filtering.