### PR TITLE
fix: use proper headers for GitHub models API call

### DIFF
--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -236,11 +236,9 @@ M.github_models = {
     return get_github_token(), nil
   end,
 
-  get_models = function()
+  get_models = function(headers)
     local response = utils.curl_post('https://api.catalog.azureml.ms/asset-gallery/v1.0/models', {
-      headers = {
-        ['content-type'] = 'application/json',
-      },
+      headers = headers,
       body = [[
         {
           "filters": [


### PR DESCRIPTION
Previously, headers were hardcoded in the get_models function which made the code less flexible. This change passes headers as a parameter, allowing for proper header configuration when making API calls to the GitHub models endpoint.