### PR TITLE
fix: improve references display in chat UI

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -77,6 +77,7 @@ local function finish(start_of_chat)
       local last_prompt = state.last_prompt or ''
 
       if type(M.config.sticky) == 'table' then
+        ---@diagnostic disable-next-line: param-type-mismatch
         for _, sticky in ipairs(M.config.sticky) do
           last_prompt = last_prompt .. '\n> ' .. sticky
         end

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -252,17 +252,23 @@ function Chat:render()
       msg = msg .. self.token_count .. '/' .. self.token_max_count .. ' tokens used'
     end
 
+    self:show_help(msg, last_section.start_line - last_section.end_line - 1)
+
     if self.references and #self.references > 0 then
-      if msg ~= '' then
-        msg = msg .. '\n'
-      end
-      msg = msg .. '\nReferences:\n'
+      msg = 'References:\n'
       for _, ref in ipairs(self.references) do
         msg = msg .. '  ' .. ref.name .. '\n'
       end
-    end
 
-    self:show_help(msg, last_section.start_line - last_section.end_line - 1)
+      vim.api.nvim_buf_set_extmark(self.bufnr, self.header_ns, last_section.start_line - 2, 0, {
+        hl_mode = 'combine',
+        priority = 100,
+        virt_lines_above = true,
+        virt_lines = vim.tbl_map(function(t)
+          return { { t, 'CopilotChatHelp' } }
+        end, vim.split(msg, '\n')),
+      })
+    end
   else
     self:clear_help()
   end


### PR DESCRIPTION
The references section in the chat UI has been improved by moving it above the help section and displaying it with proper highlighting using virtual lines. This change also fixes a diagnostic warning in the sticky prompt handling code.

Changes:
- Move references section above help section
- Use virtual lines with highlighting for references display
- Add diagnostic disable comment for param-type-mismatch warning