### PR TITLE
fix: make token counting optional in chat client

### DIFF
--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -4,15 +4,15 @@ local utils = require('CopilotChat.utils')
 ---@class CopilotChat.Provider.model
 ---@field id string
 ---@field name string
----@field version string
----@field tokenizer string
----@field max_prompt_tokens number
----@field max_output_tokens number
+---@field version string?
+---@field tokenizer string?
+---@field max_prompt_tokens number?
+---@field max_output_tokens number?
 
 ---@class CopilotChat.Provider.agent
 ---@field id string
 ---@field name string
----@field description string
+---@field description string?
 
 ---@class CopilotChat.Provider
 ---@field disabled nil|boolean


### PR DESCRIPTION
Currently token counting and limiting messages is enforced for all chat providers, but this should be optional as not all chat providers support token limiting. This change makes token counting optional and only enabled when max_tokens and tokenizer are provided in model config.

The types in providers.lua have also been updated to reflect the optional nature of these fields.

Closes #812 