### PR TITLE
fix(context): ensure minimum number of search results

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -427,6 +427,8 @@ function Client:ask(prompt, opts)
     end
   end
 
+  log.debug('Generated messages: ', #generated_messages)
+
   local last_message = nil
   local errored = false
   local finished = false


### PR DESCRIPTION
Adds MIN_RESULTS constant to guarantee at least 3 results are returned when searching for related code context, even if they don't meet the similarity threshold. This improves the quality of contextual responses by preventing cases where too few results would be returned.

Also adds score normalization for symbol-based search and debug logging for generated messages.