### PR TITLE
refactor!: simplify header authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Providers are modules that implement integration with different AI providers.
 
 - `copilot` - Default GitHub Copilot provider used for chat and embeddings
 - `github_models` - Provider for GitHub Marketplace models
+- `copilot_embeddings` - Provider for Copilot embeddings, not standalone
 
 ### Provider Interface
 
@@ -366,26 +367,26 @@ Custom providers can implement these methods:
   -- Optional: Disable provider
   disabled?: boolean,
 
-  -- Optional: Provider to use for embeddings
-  embeddings?: string,
+  -- Optional: Embeddings provider name or function
+  embed?: string|function,
 
-  -- Optional: Get authentication token
-  get_token(): string, number?,
+  -- Required: Get request headers with optional expiration time
+  get_headers(): table<string,string>, number?,
 
-  -- Required: Get request headers
-  get_headers(token: string): table,
+  -- Optional: Get API endpoint URL
+  get_url?(opts: CopilotChat.Provider.options): string,
 
-  -- Required: Get API endpoint URL
-  get_url(opts: table): string,
+  -- Optional: Prepare request input
+  prepare_input?(inputs: table<CopilotChat.Provider.input>, opts: CopilotChat.Provider.options): table,
 
-  -- Required: Prepare request body
-  prepare_input(inputs: table, opts: table, model: table): table,
+  -- Optional: Prepare response output
+  prepare_output?(output: table, opts: CopilotChat.Provider.options): CopilotChat.Provider.output,
 
   -- Optional: Get available models
-  get_models?(headers: table): table,
+  get_models?(headers: table): table<CopilotChat.Provider.model>,
 
-  -- Optional: Get available agents
-  get_agents?(headers: table): table,
+  -- Optional: Get available agents 
+  get_agents?(headers: table): table<CopilotChat.Provider.agent>,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Custom providers can implement these methods:
   -- Optional: Get available models
   get_models?(headers: table): table<CopilotChat.Provider.model>,
 
-  -- Optional: Get available agents 
+  -- Optional: Get available agents
   get_agents?(headers: table): table<CopilotChat.Provider.agent>,
 }
 ```

--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -268,12 +268,7 @@ function Client:authenticate(provider_name)
   local expires_at = self.provider_cache[provider_name].expires_at
 
   if not headers or (expires_at and expires_at <= math.floor(os.time())) then
-    local token
-    if provider.get_token then
-      token, expires_at = provider.get_token()
-    end
-
-    headers = provider.get_headers(token)
+    headers, expires_at = provider.get_headers()
     self.provider_cache[provider_name].headers = headers
     self.provider_cache[provider_name].expires_at = expires_at
   end


### PR DESCRIPTION
Simplifies provider interface by combining get_token and get_headers into a single get_headers method that returns both headers and expiration time. This reduces complexity and removes the need to pass tokens between functions.

Updates documentation to reflect the new provider interface and adds better type hints for provider methods. Also extracts copilot embeddings provider into a separate module.