### PR TITLE
fix: add missing selection messages to generated output

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -482,6 +482,9 @@ function Client:ask(prompt, opts)
     end
   else
     -- Add all embedding messages as we cant limit them
+    for _, message in ipairs(selection_messages) do
+      table.insert(generated_messages, message)
+    end
     for _, message in ipairs(embeddings_messages) do
       table.insert(generated_messages, message)
     end


### PR DESCRIPTION
Previously the selection messages were not being added to the final generated messages array when embedding messages were not limited. This fix ensures selection messages are properly included in the output.