### PR TITLE
feat: add keyword highlights and improve buffer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,22 +578,33 @@ Below are all available configuration options with their default values:
 
 ## Customizing Buffers
 
-You can set local options for plugin buffers (`copilot-chat`, `copilot-diff`, `copilot-overlay`):
+Types of copilot buffers:
+
+- `copilot-chat` - Main chat buffer
+- `copilot-diff` - Diff overlay buffer
+- `copilot-overlay` - Every other overlay buffer (e.g. help, info)
+
+You can set local options for plugin buffers like this:
 
 ```lua
 vim.api.nvim_create_autocmd('BufEnter', {
     pattern = 'copilot-*',
     callback = function()
         -- Set buffer-local options
-        vim.opt_local.relativenumber = true
-
-        -- Add buffer-local mappings
-        vim.keymap.set('n', '<C-p>', function()
-          print(require("CopilotChat").response())
-        end, { buffer = true })
     end
 })
 ```
+
+## Customizing Highlights
+
+Types of copilot highlights:
+
+- `CopilotChatSpinner` - Spinner in chat buffer
+- `CopilotChatHelp` - Help messages in chat buffer (help, references)
+- `CopilotChatSelection` - Selection highlight in source buffer
+- `CopilotChatKeyword` - Keyword highlight in chat buffer (e.g. prompts, contexts)
+- `CopilotChatHeader` - Header highlight in chat buffer
+- `CopilotChatSeparator` - Separator highlight in chat buffer
 
 # API Reference
 

--- a/lua/CopilotChat/health.lua
+++ b/lua/CopilotChat/health.lua
@@ -46,18 +46,7 @@ function M.check()
   start('CopilotChat.nvim [core]')
 
   local vim_version = vim.trim(vim.api.nvim_command_output('version'))
-  local dev_number = tonumber(vim_version:match('dev%-(%d+)'))
-
-  if dev_number then
-    local to_check = vim.fn.has('nvim-0.11.0') and 0 or 2500
-    if dev_number >= to_check then
-      ok('nvim: ' .. vim_version)
-    else
-      error(
-        'nvim: outdated, please upgrade to a up to date nightly version. See "https://github.com/neovim/neovim".'
-      )
-    end
-  elseif vim.fn.has('nvim-0.10.0') == 1 then
+  if vim.fn.has('nvim-0.10.0') == 1 then
     ok('nvim: ' .. vim_version)
   else
     error('nvim: unsupported, please upgrade to 0.10.0 or later. See "https://neovim.io/".')

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -1,7 +1,6 @@
 local Overlay = require('CopilotChat.ui.overlay')
 local Spinner = require('CopilotChat.ui.spinner')
 local utils = require('CopilotChat.utils')
-local is_stable = utils.is_stable
 local class = utils.class
 
 function CopilotChatFoldExpr(lnum, separator)
@@ -493,10 +492,9 @@ function Chat:open(config)
       title = window.title,
       row = window.row or math.floor((vim.o.lines - height) / 2),
       col = window.col or math.floor((vim.o.columns - width) / 2),
+      footer = window.footer,
     }
-    if not is_stable() then
-      win_opts.footer = window.footer
-    end
+
     self.winnr = vim.api.nvim_open_win(self.bufnr, false, win_opts)
   elseif layout == 'vertical' then
     local orig = vim.api.nvim_get_current_win()

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -97,12 +97,6 @@ function M.ordered_map()
   }
 end
 
---- Check if the current version of neovim is stable
----@return boolean
-function M.is_stable()
-  return vim.fn.has('nvim-0.10.0') == 0
-end
-
 --- Writes text to a temporary file and returns path
 ---@param text string The text to write
 ---@return string?


### PR DESCRIPTION
This commit adds syntax highlighting for keywords in the chat buffer and improves documentation around buffer types and highlights. It also:

- Removes the development version check in health.lua in favor of stable version check only
- Removes is_stable() utility function as it's no longer needed
- Updates CopilotChatSpinner highlight to use DiagnosticHint
- Improves README documentation for buffer types and highlight groups

The highlight keywords are populated from completion items and are updated when entering the chat buffer.