### PR TITLE
fix: properly escape highlight pattern chars

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -43,7 +43,8 @@ local function update_highlights()
 
   M.complete_items(function(items)
     for _, item in ipairs(items) do
-      vim.cmd.syntax('match CopilotChatKeyword "' .. vim.pesc(item.word) .. '"')
+      local pattern = vim.fn.escape(item.word, '.-$^*[]')
+      vim.cmd.syntax('match CopilotChatKeyword "' .. pattern .. '"')
     end
 
     state.highlights_loaded = true


### PR DESCRIPTION
The commit fixes an issue with syntax highlighting patterns where special regex characters were not properly escaped, leading to incorrect highlighting of keywords containing characters like dots, brackets or asterisks.