### PR TITLE
refactor: migrate chat history from UI to client layer

### DIFF
--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -39,6 +39,7 @@ return {
       }
     end,
   },
+
   buffers = {
     description = 'Includes all buffers in chat context. Supports input (default listed).',
     input = function(callback)
@@ -51,6 +52,7 @@ return {
       return context.buffers(input)
     end,
   },
+
   file = {
     description = 'Includes content of provided file in chat context. Supports input.',
     input = function(callback, source)
@@ -72,6 +74,7 @@ return {
       }
     end,
   },
+
   files = {
     description = 'Includes all non-hidden files in the current workspace in chat context. Supports input (default list).',
     input = function(callback)
@@ -93,6 +96,7 @@ return {
       return context.files(source.winnr, input == 'full')
     end,
   },
+
   git = {
     description = 'Requires `git`. Includes current git diff in chat context. Supports input (default unstaged, also accepts commit number).',
     input = function(callback)
@@ -107,6 +111,7 @@ return {
       }
     end,
   },
+
   url = {
     description = 'Includes content of provided URL in chat context. Supports input.',
     input = function(callback)
@@ -121,6 +126,7 @@ return {
       }
     end,
   },
+
   register = {
     description = 'Includes contents of register in chat context. Supports input (default +, e.g clipboard).',
     input = function(callback)
@@ -154,6 +160,7 @@ return {
       }
     end,
   },
+
   quickfix = {
     description = 'Includes quickfix list file contents in chat context.',
     resolve = function()

--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -137,7 +137,7 @@ return {
         end
       end
       vim.diagnostic.set(
-        vim.api.nvim_create_namespace('copilot_diagnostics'),
+        vim.api.nvim_create_namespace('copilot-chat-diagnostics'),
         source.bufnr,
         diagnostics
       )

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -628,7 +628,7 @@ function M.ask(prompt, config)
     return
   end
 
-  vim.diagnostic.reset(vim.api.nvim_create_namespace('copilot_diagnostics'))
+  vim.diagnostic.reset(vim.api.nvim_create_namespace('copilot-chat-diagnostics'))
   config = vim.tbl_deep_extend('force', state.chat.config, config or {})
   config = vim.tbl_deep_extend('force', M.config, config or {})
 
@@ -657,9 +657,6 @@ function M.ask(prompt, config)
     '\n'
   ))
 
-  -- Retrieve the history
-  local history = config.headless and {} or state.chat:parse_history()
-
   -- Retrieve the selection
   local selection = M.get_selection(config)
 
@@ -683,7 +680,7 @@ function M.ask(prompt, config)
 
     local ask_ok, response, references, token_count, token_max_count =
       pcall(client.ask, client, prompt, {
-        history = history,
+        headless = config.headless,
         selection = selection,
         embeddings = filtered_embeddings,
         system_prompt = system_prompt,
@@ -778,7 +775,7 @@ function M.save(name, history_path)
     return
   end
 
-  local history = vim.json.encode(state.chat:parse_history())
+  local history = vim.json.encode(client.history)
   history_path = vim.fn.expand(history_path)
   vim.fn.mkdir(history_path, 'p')
   history_path = history_path .. '/' .. name .. '.json'

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -13,6 +13,11 @@ function CopilotChatFoldExpr(lnum, separator)
   return '='
 end
 
+local HEADER_PATTERNS = {
+  '%[file:.+%]%((.+)%) line:(%d+)-(%d+)',
+  '%[file:(.+)%] line:(%d+)-(%d+)',
+}
+
 ---@param header? string
 ---@return string?, number?, number?
 local function match_header(header)
@@ -20,20 +25,14 @@ local function match_header(header)
     return
   end
 
-  local header_filename, header_start_line, header_end_line =
-    header:match('%[file:.+%]%((.+)%) line:(%d+)-(%d+)')
-  if not header_filename then
-    header_filename, header_start_line, header_end_line =
-      header:match('%[file:(.+)%] line:(%d+)-(%d+)')
+  for _, pattern in ipairs(HEADER_PATTERNS) do
+    local filename, start_line, end_line = header:match(pattern)
+    if filename then
+      return vim.fn.fnamemodify(filename, ':p:.'),
+        tonumber(start_line) or 1,
+        tonumber(end_line) or tonumber(start_line) or 1
+    end
   end
-
-  if header_filename then
-    header_filename = vim.fn.fnamemodify(header_filename, ':p:.')
-    header_start_line = tonumber(header_start_line) or 1
-    header_end_line = tonumber(header_end_line) or header_start_line
-  end
-
-  return header_filename, header_start_line, header_end_line
 end
 
 ---@class CopilotChat.ui.Chat.Section.Block.Header
@@ -337,29 +336,6 @@ function Chat:get_closest_block()
     end_line = closest_block.end_line,
     content = closest_block.content,
   }
-end
-
-function Chat:parse_history()
-  self:render()
-
-  local history = {}
-  for _, section in ipairs(self.sections) do
-    if not utils.empty(section.content) then
-      if section.answer then
-        table.insert(history, {
-          content = section.content,
-          role = 'assistant',
-        })
-      else
-        table.insert(history, {
-          content = section.content,
-          role = 'user',
-        })
-      end
-    end
-  end
-
-  return history
 end
 
 function Chat:load_history(history)


### PR DESCRIPTION
The chat history was previously managed in the UI layer through parsing of rendered chat sections. This change moves the history management directly into the client layer for better separation of concerns.

Key changes:
- Add history field to Client class to store conversation history
- Remove parse_history from Chat UI class
- Update history handling in ask function to use client's history
- Maintain history only when not in headless mode
- Clean up header pattern matching in chat UI
- Fix diagnostic namespace to use consistent naming

Using chat buffer for client history had issues with resolving the history properly without stuff like #buffers etc so just go back to this solution.