### PR TITLE
feat: include chat history in embedding query

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -667,7 +667,7 @@ function M.ask(prompt, config)
 
     local has_output = false
     local query_ok, filtered_embeddings =
-      pcall(context.filter_embeddings, prompt, selected_model, embeddings)
+      pcall(context.filter_embeddings, prompt, selected_model, config.headless, embeddings)
 
     if not query_ok then
       async.util.scheduler()


### PR DESCRIPTION
When filtering embeddings, include previous user messages from chat history in the query string for better context matching. This helps improve the relevance of filtered embeddings by considering the full conversation context rather than just the current prompt.

The history inclusion can be disabled via the headless config option.