### PR TITLE
fix: update token handling and message ordering

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -535,13 +535,13 @@ function Client:ask(prompt, opts)
     end
 
     local out = provider.prepare_output(content, options)
+    last_message = out
+
     if out.references then
       for _, reference in ipairs(out.references) do
         table.insert(references, reference)
       end
     end
-
-    last_message = out
 
     if out.content then
       full_response = full_response .. out.content

--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -244,10 +244,18 @@ M.copilot = {
     local content = message.message and message.message.content
       or message.delta and message.delta.content
 
+    local usage = message.usage and message.usage.total_tokens
+      or output.usage and output.usage.total_tokens
+
+    local finish_reason = message.finish_reason
+      or message.done_reason
+      or output.finish_reason
+      or output.done_reason
+
     return {
       content = content,
-      finish_reason = message.finish_reason or message.done_reason,
-      total_tokens = message.usage and message.usage.total_tokens,
+      finish_reason = finish_reason,
+      total_tokens = usage,
       references = references,
     }
   end,


### PR DESCRIPTION
Move last_message assignment before references check to ensure proper state tracking. Improve token usage and finish reason handling by adding fallback paths for different response formats from the Copilot API.