### PR TITLE
feat!: add glob pattern support for file context

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ You can also set default sticky prompts in the configuration:
 {
   sticky = {
     '@models Using Mistral-small',
-    '#files:full',
+    '#files',
   }
 }
 ```
@@ -285,23 +285,25 @@ The default "noop" agent is `none`. For more information:
 
 Contexts provide additional information to the chat. Add context using `#context_name[:input]` syntax:
 
-| Context    | Input Support | Description                         |
-| ---------- | ------------- | ----------------------------------- |
-| `buffer`   | ✓ (number)    | Current or specified buffer content |
-| `buffers`  | ✓ (type)      | All buffers content (listed/all)    |
-| `file`     | ✓ (path)      | Content of specified file           |
-| `files`    | ✓ (mode)      | Workspace files (list/full content) |
-| `git`      | ✓ (ref)       | Git diff (unstaged/staged/commit)   |
-| `url`      | ✓ (url)       | Content from URL                    |
-| `register` | ✓ (name)      | Content of vim register             |
-| `quickfix` | -             | Quickfix list file contents         |
+| Context     | Input Support | Description                         |
+| ----------- | ------------- | ----------------------------------- |
+| `buffer`    | ✓ (number)    | Current or specified buffer content |
+| `buffers`   | ✓ (type)      | All buffers content (listed/all)    |
+| `file`      | ✓ (path)      | Content of specified file           |
+| `files`     | ✓ (glob)      | Workspace files                     |
+| `filenames` | ✓ (glob)      | Workspace file names                |
+| `git`       | ✓ (ref)       | Git diff (unstaged/staged/commit)   |
+| `url`       | ✓ (url)       | Content from URL                    |
+| `register`  | ✓ (name)      | Content of vim register             |
+| `quickfix`  | -             | Quickfix list file contents         |
 
 Examples:
 
 ```markdown
 > #buffer
 > #buffer:2
-> #files:list
+> #files:.lua
+> #filenames
 > #git:staged
 > #url:https://example.com
 ```

--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -76,24 +76,26 @@ return {
   },
 
   files = {
-    description = 'Includes all non-hidden files in the current workspace in chat context. Supports input (default list).',
+    description = 'Includes all non-hidden files in the current workspace in chat context. Supports input (glob pattern).',
     input = function(callback)
-      local choices = utils.kv_list({
-        list = 'Only lists file names',
-        full = 'Includes file content for each file found, up to a limit.',
-      })
-
-      vim.ui.select(choices, {
-        prompt = 'Select files content> ',
-        format_item = function(choice)
-          return choice.key .. ' - ' .. choice.value
-        end,
-      }, function(choice)
-        callback(choice and choice.key)
-      end)
+      vim.ui.input({
+        prompt = 'Enter glob> ',
+      }, callback)
     end,
     resolve = function(input, source)
-      return context.files(source.winnr, input == 'full')
+      return context.files(source.winnr, true, input and utils.glob_to_regex(input))
+    end,
+  },
+
+  filenames = {
+    description = 'Includes names of all non-hidden files in the current workspace in chat context. Supports input (glob pattern).',
+    input = function(callback)
+      vim.ui.input({
+        prompt = 'Enter glob> ',
+      }, callback)
+    end,
+    resolve = function(input, source)
+      return context.files(source.winnr, false, input and utils.glob_to_regex(input))
     end,
   },
 

--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -369,9 +369,10 @@ end
 
 --- Get list of all files in workspace
 ---@param winnr number?
----@param with_content boolean
+---@param with_content boolean?
+---@param filter string?
 ---@return table<CopilotChat.context.embed>
-function M.files(winnr, with_content)
+function M.files(winnr, with_content, filter)
   local cwd = utils.win_cwd(winnr)
 
   notify.publish(notify.STATUS, 'Scanning files')
@@ -380,6 +381,7 @@ function M.files(winnr, with_content)
     add_dirs = false,
     respect_gitignore = true,
     max_files = MAX_FILES,
+    search_pattern = filter,
   })
 
   notify.publish(notify.STATUS, 'Reading files')
@@ -401,11 +403,11 @@ function M.files(winnr, with_content)
       content = table.concat(chunk, '\n'),
       filename = chunk_name,
       filetype = 'text',
-      score = 0.2,
+      score = 0.1,
     })
   end
 
-  -- Read all files if we want content as well
+  -- Read file contents
   if with_content then
     async.util.scheduler()
 

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -543,4 +543,25 @@ function M.empty(v)
   return false
 end
 
+--- Convert glob pattern to regex pattern
+---@param glob string The glob pattern
+---@return string?
+function M.glob_to_regex(glob)
+  if not glob or glob == '' then
+    return nil
+  end
+
+  -- Escape regex special chars except * and ?
+  local pattern = glob:gsub('[%^%$%(%)%%%.%[%]%+%-]', '%%%1')
+
+  -- Convert glob to regex pattern
+  pattern = pattern
+    :gsub('%*%*/%*', '.*') -- **/* -> .*
+    :gsub('%*%*', '.*') -- ** -> .*
+    :gsub('%*', '[^/]*') -- * -> [^/]*
+    :gsub('%?', '.') -- ? -> .
+
+  return pattern .. '$'
+end
+
 return M


### PR DESCRIPTION
Replace the basic list/full mode for files context with glob pattern matching support. This allows for more granular file filtering in the workspace using standard glob patterns like *.lua or **/*.js.

Split the original files context into two separate contexts:
- files: Returns file contents matching the glob pattern
- filenames: Returns only filenames matching the glob pattern

BREAKING CHANGE: The files context no longer accepts list/full as input options. Instead, it now expects a glob pattern. The old functionality has been split into two separate contexts: files and filenames.