### PR TITLE
refactor(context): improve file search options handling

### DIFF
--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -83,7 +83,9 @@ return {
       }, callback)
     end,
     resolve = function(input, source)
-      return context.files(source.winnr, true, input and utils.glob_to_regex(input))
+      return context.files(source.winnr, true, {
+        search_pattern = input and utils.glob_to_regex(input),
+      })
     end,
   },
 
@@ -95,7 +97,9 @@ return {
       }, callback)
     end,
     resolve = function(input, source)
-      return context.files(source.winnr, false, input and utils.glob_to_regex(input))
+      return context.files(source.winnr, false, {
+        search_pattern = input and utils.glob_to_regex(input),
+      })
     end,
   },
 

--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -370,19 +370,21 @@ end
 --- Get list of all files in workspace
 ---@param winnr number?
 ---@param with_content boolean?
----@param filter string?
+---@param search_options table?
 ---@return table<CopilotChat.context.embed>
-function M.files(winnr, with_content, filter)
+function M.files(winnr, with_content, search_options)
   local cwd = utils.win_cwd(winnr)
 
   notify.publish(notify.STATUS, 'Scanning files')
 
-  local files = utils.scan_dir(cwd, {
-    add_dirs = false,
-    respect_gitignore = true,
-    max_files = MAX_FILES,
-    search_pattern = filter,
-  })
+  local files = utils.scan_dir(
+    cwd,
+    vim.tbl_extend('force', {
+      add_dirs = false,
+      respect_gitignore = true,
+      max_files = MAX_FILES,
+    }, search_options)
+  )
 
   notify.publish(notify.STATUS, 'Reading files')
 


### PR DESCRIPTION
Refactor the file context handling to use a more flexible search options approach. Instead of passing individual parameters, introduce a table-based configuration that can be extended with additional options.

This change makes the API more maintainable and extensible while keeping backward compatibility through the use of vim.tbl_extend.