### PR TITLE
fix: improve error handling in embeddings and messages

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -772,6 +772,7 @@ function Client:embed(inputs, model)
   while #to_process > 0 do
     local chunk_size = initial_chunk_size -- Reset chunk size for each new batch
     local threshold = BIG_EMBED_THRESHOLD -- Reset threshold for each new batch
+    local last_error = nil
 
     -- Take next chunk
     local batch = {}
@@ -788,6 +789,7 @@ function Client:embed(inputs, model)
 
       if not ok then
         log.debug('Failed to get embeddings: ', data)
+        last_error = data
         attempts = attempts + 1
         -- If we have few items and the request failed, try reducing threshold first
         if #batch <= 5 then
@@ -820,7 +822,7 @@ function Client:embed(inputs, model)
     end
 
     if not success then
-      error('Failed to process embeddings after multiple attempts')
+      error(last_error)
     end
   end
 

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -131,9 +131,13 @@ local function show_error(err, append_newline)
   err = err or 'Unknown error'
 
   if type(err) == 'string' then
-    local message = err:match('^[^:]+:[^:]+:(.+)') or err
-    message = message:gsub('^%s*', '')
-    err = message
+    while true do
+      local new_err = err:gsub('^[^:]+:%d+: ', '')
+      if new_err == err then
+        break
+      end
+      err = new_err
+    end
   else
     err = utils.make_string(err)
   end


### PR DESCRIPTION
Enhance error reporting by preserving original error message when embedding requests fail instead of generic error. Clean up error message format by removing all file:line prefixes for better readability.