### PR TITLE
Fix: Replace iter with ipairs for Safe Iteration

### DIFF
--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -156,23 +156,26 @@ M.copilot = {
       error(err)
     end
 
-    local models = vim
-      .iter(response.body.data)
-      :filter(function(model)
-        return model['capabilities']['type'] == 'chat'
-      end)
-      :map(function(model)
-        return {
-          id = model.id,
-          name = model.name,
-          version = model.version,
-          tokenizer = model.capabilities.tokenizer,
-          max_input_tokens = model.capabilities.limits.max_prompt_tokens,
-          max_output_tokens = model.capabilities.limits.max_output_tokens,
-          policy = not model['policy'] or model['policy']['state'] == 'enabled',
-        }
-      end)
-      :totable()
+    local models = {}
+
+    -- Ensure response.body and response.body.data are valid tables
+    if type(response.body) == "table" and type(response.body.data) == "table" then
+      for _, model in ipairs(response.body.data) do
+        if model.capabilities and model.capabilities.type == "chat" then
+          table.insert(models, {
+            id = model.id,
+            name = model.name,
+            version = model.version,
+            tokenizer = model.capabilities.tokenizer,
+            max_input_tokens = model.capabilities.limits.max_prompt_tokens,
+            max_output_tokens = model.capabilities.limits.max_output_tokens,
+            policy = not model.policy or model.policy.state == "enabled",
+          })
+        end
+      end
+    else
+      print("Error: response.body.data is not a valid table")
+    end
 
     for _, model in ipairs(models) do
       if not model.policy then
@@ -301,22 +304,27 @@ M.github_models = {
       error(err)
     end
 
-    return vim
-      .iter(response.body.summaries)
-      :filter(function(model)
-        return vim.tbl_contains(model.inferenceTasks, 'chat-completion')
-      end)
-      :map(function(model)
-        return {
-          id = model.name,
-          name = model.displayName,
-          version = model.name .. '-' .. model.version,
-          tokenizer = 'o200k_base',
-          max_input_tokens = model.modelLimits.textLimits.inputContextWindow,
-          max_output_tokens = model.modelLimits.textLimits.maxOutputTokens,
-        }
-      end)
-      :totable()
+    local models = {}
+
+    -- Ensure response.body and response.body.summaries are valid tables
+    if type(response.body) == "table" and type(response.body.summaries) == "table" then
+      for _, model in ipairs(response.body.summaries) do
+        if type(model.inferenceTasks) == "table" and vim.tbl_contains(model.inferenceTasks, "chat-completion") then
+          table.insert(models, {
+            id = model.name,
+            name = model.displayName,
+            version = model.name .. "-" .. model.version,
+            tokenizer = "o200k_base",
+            max_input_tokens = model.modelLimits.textLimits.inputContextWindow,
+            max_output_tokens = model.modelLimits.textLimits.maxOutputTokens,
+          })
+        end
+      end
+    else
+      print("Error: response.body.summaries is not a valid table")
+    end
+
+    return models
   end,
 
   prepare_input = M.copilot.prepare_input,

--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -159,9 +159,9 @@ M.copilot = {
     local models = {}
 
     -- Ensure response.body and response.body.data are valid tables
-    if type(response.body) == "table" and type(response.body.data) == "table" then
+    if type(response.body) == 'table' and type(response.body.data) == 'table' then
       for _, model in ipairs(response.body.data) do
-        if model.capabilities and model.capabilities.type == "chat" then
+        if model.capabilities and model.capabilities.type == 'chat' then
           table.insert(models, {
             id = model.id,
             name = model.name,
@@ -169,12 +169,12 @@ M.copilot = {
             tokenizer = model.capabilities.tokenizer,
             max_input_tokens = model.capabilities.limits.max_prompt_tokens,
             max_output_tokens = model.capabilities.limits.max_output_tokens,
-            policy = not model.policy or model.policy.state == "enabled",
+            policy = not model.policy or model.policy.state == 'enabled',
           })
         end
       end
     else
-      print("Error: response.body.data is not a valid table")
+      print('Error: response.body.data is not a valid table')
     end
 
     for _, model in ipairs(models) do
@@ -307,21 +307,24 @@ M.github_models = {
     local models = {}
 
     -- Ensure response.body and response.body.summaries are valid tables
-    if type(response.body) == "table" and type(response.body.summaries) == "table" then
+    if type(response.body) == 'table' and type(response.body.summaries) == 'table' then
       for _, model in ipairs(response.body.summaries) do
-        if type(model.inferenceTasks) == "table" and vim.tbl_contains(model.inferenceTasks, "chat-completion") then
+        if
+          type(model.inferenceTasks) == 'table'
+          and vim.tbl_contains(model.inferenceTasks, 'chat-completion')
+        then
           table.insert(models, {
             id = model.name,
             name = model.displayName,
-            version = model.name .. "-" .. model.version,
-            tokenizer = "o200k_base",
+            version = model.name .. '-' .. model.version,
+            tokenizer = 'o200k_base',
             max_input_tokens = model.modelLimits.textLimits.inputContextWindow,
             max_output_tokens = model.modelLimits.textLimits.maxOutputTokens,
           })
         end
       end
     else
-      print("Error: response.body.summaries is not a valid table")
+      print('Error: response.body.summaries is not a valid table')
     end
 
     return models


### PR DESCRIPTION
### **PR Description:**  

I was not able to use this plugin inside neovim because of this issue. The user facing error is "model not found: gpt-4o

Replaced `iter` with `ipairs` for safer iteration over API response data. Added validation checks to ensure `response.body.data` and `response.body.summaries` are valid tables before iterating. This prevents runtime errors when the response is `nil` or not structured as expected. Improves stability and error handling without breaking functionality.

![Screenshot from 2025-02-23 15-11-36](https://github.com/user-attachments/assets/6b6170c2-95c2-4bf2-ac40-124e812a2aaa)
