### PR TITLE
refactor!: centralize sticky prompt and selection handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,11 +453,6 @@ Below are all available configuration options with their default values:
   headless = false, -- Do not write to chat buffer and use history(useful for using callback for custom processing)
   callback = nil, -- Callback to use when ask response is received
 
-  -- default selection
-  selection = function(source)
-    return select.visual(source) or select.buffer(source)
-  end,
-
   -- default window options
   window = {
     layout = 'vertical', -- 'vertical', 'horizontal', 'float', 'replace'
@@ -499,6 +494,12 @@ Below are all available configuration options with their default values:
   error_header = '# Error ', -- Header to use for errors
   separator = '───', -- Separator to use in chat
 
+  -- default selection
+  -- see config/select.lua for implementation
+  selection = function(source)
+    return select.visual(source) or select.buffer(source)
+  end,
+
   -- default providers
   -- see config/providers.lua for implementation
   providers = {
@@ -535,10 +536,12 @@ Below are all available configuration options with their default values:
   -- see config/prompts.lua for implementation
   prompts = {
     Explain = {
-      prompt = '> /COPILOT_EXPLAIN\n\nWrite an explanation for the selected code as paragraphs of text.',
+      prompt = 'Write an explanation for the selected code as paragraphs of text.',
+      sticky = '/COPILOT_EXPLAIN',
     },
     Review = {
-      prompt = '> /COPILOT_REVIEW\n\nReview the selected code.',
+      prompt = 'Review the selected code.',
+      sticky = '/COPILOT_REVIEW',
     },
     Fix = {
       prompt = 'There is a problem in this code. Identify the issues and rewrite the code with fixes. Explain what was wrong and how your changes address the problems.',
@@ -553,7 +556,8 @@ Below are all available configuration options with their default values:
       prompt = 'Please generate tests for my code.',
     },
     Commit = {
-      prompt = '> #git:staged\n\nWrite commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.',
+      prompt = 'Write commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.',
+      sticky = '#git:staged',
     },
   },
 

--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -14,7 +14,6 @@
 ---@class CopilotChat.Client.agent : CopilotChat.Provider.agent
 ---@field provider string
 
-local async = require('plenary.async')
 local log = require('plenary.log')
 local tiktoken = require('CopilotChat.tiktoken')
 local notify = require('CopilotChat.notify')

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -22,7 +22,6 @@ local select = require('CopilotChat.select')
 ---@field temperature number?
 ---@field headless boolean?
 ---@field callback fun(response: string, source: CopilotChat.source)?
----@field selection false|nil|fun(source: CopilotChat.source):CopilotChat.select.selection?
 ---@field window CopilotChat.config.window?
 ---@field show_help boolean?
 ---@field show_folds boolean?
@@ -47,6 +46,7 @@ local select = require('CopilotChat.select')
 ---@field answer_header string?
 ---@field error_header string?
 ---@field separator string?
+---@field selection false|nil|fun(source: CopilotChat.source):CopilotChat.select.selection?
 ---@field providers table<string, CopilotChat.Provider>?
 ---@field contexts table<string, CopilotChat.config.context>?
 ---@field prompts table<string, CopilotChat.config.prompt|string>?
@@ -65,11 +65,6 @@ return {
   temperature = 0.1, -- GPT result temperature
   headless = false, -- Do not write to chat buffer and use history(useful for using callback for custom processing)
   callback = nil, -- Callback to use when ask response is received
-
-  -- default selection
-  selection = function(source)
-    return select.visual(source) or select.buffer(source)
-  end,
 
   -- default window options
   window = {
@@ -112,6 +107,11 @@ return {
   answer_header = '## Copilot ', -- Header to use for AI answers
   error_header = '## Error ', -- Header to use for errors
   separator = '───', -- Separator to use in chat
+
+  -- default selection
+  selection = function(source)
+    return select.visual(source) or select.buffer(source)
+  end,
 
   -- default providers
   providers = require('CopilotChat.config.providers'),

--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -96,11 +96,13 @@ return {
   },
 
   Explain = {
-    prompt = '> /COPILOT_EXPLAIN\n\nWrite an explanation for the selected code as paragraphs of text.',
+    prompt = 'Write an explanation for the selected code as paragraphs of text.',
+    sticky = '/COPILOT_EXPLAIN',
   },
 
   Review = {
-    prompt = '> /COPILOT_REVIEW\n\nReview the selected code.',
+    prompt = 'Review the selected code.',
+    sticky = '/COPILOT_REVIEW',
     callback = function(response, source)
       local diagnostics = {}
       for line in response:gmatch('[^\r\n]+') do
@@ -159,6 +161,7 @@ return {
   },
 
   Commit = {
-    prompt = '> #git:staged\n\nWrite commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.',
+    prompt = 'Write commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.',
+    sticky = '#git:staged',
   },
 }

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -353,7 +353,8 @@ function Chat:load_history(history)
   end
 end
 
-function Chat:clear_prompt()
+---@return CopilotChat.ui.Chat.Section?
+function Chat:get_prompt()
   if not self:visible() then
     return
   end
@@ -364,9 +365,25 @@ function Chat:clear_prompt()
     return
   end
 
+  return section
+end
+
+---@param prompt string?
+function Chat:set_prompt(prompt)
+  if not self:visible() then
+    return
+  end
+
+  local section = self:get_prompt()
+  if not section then
+    return
+  end
+
+  local modifiable = vim.bo[self.bufnr].modifiable
   vim.bo[self.bufnr].modifiable = true
-  vim.api.nvim_buf_set_lines(self.bufnr, section.start_line - 1, section.end_line, false, {})
-  vim.bo[self.bufnr].modifiable = false
+  local lines = prompt and vim.split('\n' .. prompt, '\n') or {}
+  vim.api.nvim_buf_set_lines(self.bufnr, section.start_line - 1, section.end_line, false, lines)
+  vim.bo[self.bufnr].modifiable = modifiable
 end
 
 ---@return boolean


### PR DESCRIPTION
This refactoring improves the CopilotChat plugin's state management by:
- Adding `insert_sticky` function to centralize sticky prompt management
- Creating `set_selection` to provide a cleaner API for selection handling
- Consolidating highlight management in `update_highlights`
- Standardizing function signatures and return values
- Improving `Chat:set_prompt` functionality
- Removing redundant code for better maintainability

BREAKING CHANGES:
- `M.resolve_prompt` now returns config first and prompt second
- `M.update_selection` removed in favor of new `M.set_selection` function
- `M.resolve_embeddings` renamed to `M.resolve_context`
- Selection setting now only configurable in global config, not per-operation
- `get_selection` no longer accepts a config parameter
- Selection handling moved from dynamic config to static global config
- Changed sticky format and processing approach
- Prompts in config now use explicit `sticky` property instead of prefixing

Closes #716 