### PR TITLE
refactor: replace vim.loop with vim.uv and simplify file checks

### DIFF
--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -14,7 +14,7 @@ Keep your answers short and impersonal.
 The user works in an IDE called Neovim which has a concept for editors with open files, integrated unit test support, an output pane that shows the output of running the code as well as an integrated terminal.
 The user is working on a %s machine. Please respond with system specific commands if applicable.
 ]],
-  vim.loop.os_uname().sysname
+  vim.uv.os_uname().sysname
 )
 
 local COPILOT_INSTRUCTIONS = [[

--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -1,4 +1,3 @@
-local async = require('plenary.async')
 local utils = require('CopilotChat.utils')
 
 ---@class CopilotChat.Provider.model
@@ -58,18 +57,18 @@ local cached_github_token = nil
 
 local function config_path()
   local config = vim.fs.normalize('$XDG_CONFIG_HOME')
-  if config and utils.file_exists(config) then
+  if config and vim.uv.fs_stat(config) then
     return config
   end
   if vim.fn.has('win32') > 0 then
     config = vim.fs.normalize('$LOCALAPPDATA')
-    if not config or not utils.file_exists(config) then
+    if not config or not vim.uv.fs_stat(config) then
       config = vim.fs.normalize('$HOME/AppData/Local')
     end
   else
     config = vim.fs.normalize('$HOME/.config')
   end
-  if config and utils.file_exists(config) then
+  if config and vim.uv.fs_stat(config) then
     return config
   end
 end

--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -21,7 +21,7 @@ local function load_tiktoken_data(tokenizer)
   vim.fn.mkdir(tostring(cache_dir), 'p')
   local cache_path = cache_dir .. '/' .. tiktoken_url:match('.+/(.+)')
 
-  if utils.file_exists(cache_path) then
+  if vim.uv.fs_stat(cache_path) then
     return cache_path
   end
 

--- a/lua/CopilotChat/ui/spinner.lua
+++ b/lua/CopilotChat/ui/spinner.lua
@@ -38,7 +38,7 @@ function Spinner:start()
     return
   end
 
-  self.timer = vim.loop.new_timer()
+  self.timer = vim.uv.new_timer()
   self.timer:start(
     0,
     100,

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -425,13 +425,6 @@ M.scan_dir = async.wrap(function(path, opts, callback)
   )
 end, 3)
 
---- Check if a file exists
----@param path string The file path
-M.file_exists = function(path)
-  local err, stat = async.uv.fs_stat(path)
-  return err == nil and stat ~= nil
-end
-
 --- Get last modified time of a file
 ---@param path string The file path
 ---@return number?


### PR DESCRIPTION
Replace deprecated vim.loop with vim.uv throughout the codebase. Remove custom file_exists utility function in favor of direct vim.uv.fs_stat calls for file existence checks.

This change improves code consistency and leverages built-in Neovim API functions rather than custom implementations.