### PR TITLE
refactor: replace vim.fn functions with vim.fs equivalents

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -425,7 +425,6 @@ function Client:ask(prompt, opts)
 
   notify.publish(notify.STATUS, 'Generating request')
 
-  async.util.scheduler()
   local references = {}
   for _, embed in ipairs(embeddings) do
     table.insert(references, {

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -184,7 +184,7 @@ function M.filename_same(file1, file2)
   if not file1 or not file2 then
     return false
   end
-  return vim.fn.fnamemodify(file1, ':p') == vim.fn.fnamemodify(file2, ':p')
+  return vim.fs.normalize(file1) == vim.fs.normalize(file2)
 end
 
 --- Get the filetype of a file
@@ -216,7 +216,7 @@ end
 ---@param filepath string The file path
 ---@return string
 function M.filename(filepath)
-  return vim.fn.fnamemodify(filepath, ':t')
+  return vim.fs.basename(filepath)
 end
 
 --- Get the file path


### PR DESCRIPTION
Remove dependency on vim.fn.fnamemodify for file operations by using the more modern vim.fs API instead. This change:
- replaces vim.fn.fnamemodify with vim.fs.normalize for path comparison
- replaces vim.fn.fnamemodify with vim.fs.basename for filename extraction
- removes unnecessary async scheduler call in client.lua

Part of the effort to reduce reliance on Vim functions.