### PR TITLE
feat: add CopilotChatPrompts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Commands are used to control the chat interface:
 | `:CopilotChatReset`        | Reset chat window             |
 | `:CopilotChatSave <name>?` | Save chat history             |
 | `:CopilotChatLoad <name>?` | Load chat history             |
+| `:CopilotChatPrompts`      | View/select prompt templates  |
 | `:CopilotChatModels`       | View/select available models  |
 | `:CopilotChatAgents`       | View/select available agents  |
 | `:CopilotChat<PromptName>` | Use specific prompt template  |
@@ -664,16 +665,8 @@ chat.ask("Explain this code.", {
 })
 
 -- Utilities
-chat.prompts()   -- Get all available prompts
 chat.response()  -- Get last response
 chat.log_level("debug")  -- Set log level
-
-
--- Actions
-local actions = require("CopilotChat.actions")
-actions.pick(actions.prompt_actions({
-    selection = require("CopilotChat.select").visual,
-}))
 
 -- Update config
 chat.setup({

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -626,6 +626,37 @@ function M.select_agent()
   end)
 end
 
+--- Select a prompt template to use.
+function M.select_prompt()
+  local prompts = M.prompts()
+  local keys = vim.tbl_keys(prompts)
+  table.sort(keys)
+
+  local choices = vim
+    .iter(keys)
+    :map(function(name)
+      return {
+        name = name,
+        prompt = prompts[name].prompt,
+      }
+    end)
+    :filter(function(choice)
+      return choice.prompt
+    end)
+    :totable()
+
+  vim.ui.select(choices, {
+    prompt = 'Select prompt action> ',
+    format_item = function(item)
+      return string.format('%s: %s', item.name, item.prompt:gsub('\n', ' '))
+    end,
+  }, function(choice)
+    if choice then
+      M.ask(prompts[choice.name].prompt, prompts[choice.name])
+    end
+  end)
+end
+
 --- Ask a question to the Copilot model.
 ---@param prompt string?
 ---@param config CopilotChat.config.shared?
@@ -1025,6 +1056,9 @@ function M.setup(config)
     range = true,
   })
 
+  vim.api.nvim_create_user_command('CopilotChatPrompts', function()
+    M.select_prompt()
+  end, { force = true })
   vim.api.nvim_create_user_command('CopilotChatModels', function()
     M.select_model()
   end, { force = true })


### PR DESCRIPTION
Add new command to easily browse and select from available prompt actions. This replaces the previous manual approach of requiring users to create actions through the API, providing a more user-friendly interface similar to the existing models and agents selection commands.

This is preparation to deprecated CopilotChat.actions and CopilotChat.integrations