### PR TITLE
feat: add configuration to select_prompt function

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,19 +643,23 @@ Types of copilot highlights:
 local chat = require("CopilotChat")
 
 -- Window Management
-chat.open()     -- Open chat window
-chat.open({     -- Open with custom options
+
+-- Open chat window with optional config
+chat.open({
   window = {
     layout = 'float',
     title = 'Custom Chat',
   },
 })
+
 chat.close()    -- Close chat window
 chat.toggle()   -- Toggle chat window
 chat.reset()    -- Reset chat window
+chat.stop()     -- Stop current output
 
 -- Chat Interaction
-chat.ask("Explain this code.")  -- Basic question
+
+-- Ask a question with optional config
 chat.ask("Explain this code.", {
   selection = require("CopilotChat.select").buffer,
   context = { 'buffers', 'files' },
@@ -663,6 +667,20 @@ chat.ask("Explain this code.", {
     print("Response:", response)
   end,
 })
+
+chat.select_model() -- Open model selector
+chat.select_agent() -- Open agent selector
+
+-- Open prompt selector with optional config
+chat.select_prompt({
+    callback = function(response)
+        print("Response:", response)
+    end,
+})
+
+-- History Management
+chat.save("my_chat", "my_history_path") -- Save chat history with optional history path
+chat.load("my_chat", "my_history_path") -- Load chat history with optional history path
 
 -- Utilities
 chat.response()  -- Get last response

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -627,7 +627,8 @@ function M.select_agent()
 end
 
 --- Select a prompt template to use.
-function M.select_prompt()
+---@param config CopilotChat.config.shared?
+function M.select_prompt(config)
   local prompts = M.prompts()
   local keys = vim.tbl_keys(prompts)
   table.sort(keys)
@@ -652,7 +653,10 @@ function M.select_prompt()
     end,
   }, function(choice)
     if choice then
-      M.ask(prompts[choice.name].prompt, prompts[choice.name])
+      M.ask(
+        prompts[choice.name].prompt,
+        vim.tbl_extend('force', prompts[choice.name], config or {})
+      )
     end
   end)
 end


### PR DESCRIPTION
Updates the select_prompt function to accept an optional configuration parameter that can be passed to the ask method. This allows specifying additional settings like callbacks when using prompt templates.

Also improves documentation in README.md with more detailed explanations and examples of new functionality.