### PR TITLE
feat(ui): add option to control references display mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ Below are all available configuration options with their default values:
   show_folds = true, -- Shows folds for sections in chat
   highlight_selection = true, -- Highlight selection
   highlight_headers = true, -- Highlight headers in chat, disable if using markdown renderers (like render-markdown.nvim)
+  references_display = 'virtual', -- 'virtual', 'write', Display references in chat as virtual text or write to buffer
   auto_follow_cursor = true, -- Auto-follow cursor in chat
   auto_insert_mode = false, -- Automatically enter insert mode when opening window and on new prompt
   insert_at_end = false, -- Move cursor to end of buffer when inserting text

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -2,9 +2,9 @@ local prompts = require('CopilotChat.config.prompts')
 local select = require('CopilotChat.select')
 
 ---@class CopilotChat.config.window
----@field layout string?
----@field relative string?
----@field border string?
+---@field layout 'vertical'|'horizontal'|'float'|'replace'?
+---@field relative 'editor'|'win'|'cursor'|'mouse'?
+---@field border 'none'|'single'|'double'|'rounded'|'solid'|'shadow'?
 ---@field width number?
 ---@field height number?
 ---@field row number?
@@ -28,6 +28,7 @@ local select = require('CopilotChat.select')
 ---@field show_folds boolean?
 ---@field highlight_selection boolean?
 ---@field highlight_headers boolean?
+---@field references_display 'virtual'|'write'?
 ---@field auto_follow_cursor boolean?
 ---@field auto_insert_mode boolean?
 ---@field insert_at_end boolean?
@@ -36,7 +37,7 @@ local select = require('CopilotChat.select')
 --- CopilotChat default configuration
 ---@class CopilotChat.config : CopilotChat.config.shared
 ---@field debug boolean?
----@field log_level string?
+---@field log_level 'trace'|'debug'|'info'|'warn'|'error'|'fatal'?
 ---@field proxy string?
 ---@field allow_insecure boolean?
 ---@field chat_autocomplete boolean?
@@ -89,6 +90,7 @@ return {
   show_folds = true, -- Shows folds for sections in chat
   highlight_selection = true, -- Highlight selection
   highlight_headers = true, -- Highlight headers in chat, disable if using markdown renderers (like render-markdown.nvim)
+  references_display = 'virtual', -- 'virtual', 'write', Display references in chat as virtual text or write to buffer
   auto_follow_cursor = true, -- Auto-follow cursor in chat
   auto_insert_mode = false, -- Automatically enter insert mode when opening window and on new prompt
   insert_at_end = false, -- Move cursor to end of buffer when inserting text

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -761,6 +761,13 @@ function M.ask(prompt, config)
     end
 
     if not config.headless then
+      if not utils.empty(references) and config.references_display == 'write' then
+        state.chat:append('\n\n**`References`**:')
+        for _, ref in ipairs(references) do
+          state.chat:append(string.format('\n[%s](%s)', ref.name, ref.url))
+        end
+      end
+
       finish()
     end
     if config.callback then

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -252,7 +252,7 @@ function Chat:render()
 
     self:show_help(msg, last_section.start_line - last_section.end_line - 1)
 
-    if not utils.empty(self.references) then
+    if not utils.empty(self.references) and self.config.references_display == 'virtual' then
       msg = 'References:\n'
       for _, ref in ipairs(self.references) do
         msg = msg .. '  ' .. ref.name .. '\n'


### PR DESCRIPTION
Add new configuration option `references_display` that allows users to control how references are displayed in chat responses. Two modes are supported:
- 'virtual': displays references as virtual text (default)
- 'write': writes references directly into the chat buffer as markdown links

This gives users more flexibility in how reference information is presented and interacted with in the chat interface.

![image](https://github.com/user-attachments/assets/77a455f5-0776-4e26-81b4-ec1c3a51ffa4)