### PR TITLE
fix: improve filename comparison with absolute paths

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -184,7 +184,7 @@ function M.filename_same(file1, file2)
   if not file1 or not file2 then
     return false
   end
-  return vim.fs.normalize(file1) == vim.fs.normalize(file2)
+  return vim.fs.abspath(vim.fs.normalize(file1)) == vim.fs.abspath(vim.fs.normalize(file2))
 end
 
 --- Get the filetype of a file


### PR DESCRIPTION
Uses vim.fs.abspath in filename_same function to properly compare file paths that might be relative or have different representations but point to the same file.