### PR TITLE
refactor: use utils functions for filename handling

### DIFF
--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -172,7 +172,7 @@ local function data_ranked_by_symbols(query, data, min_similarity)
   local max_score = 0
 
   for _, entry in ipairs(data) do
-    local basename = vim.fn.fnamemodify(entry.filename, ':t'):gsub('%..*$', '')
+    local basename = utils.filename(entry.filename):gsub('%..*$', '')
 
     -- Get trigrams for basename and compound version
     local file_trigrams = get_trigrams(basename)

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -13,6 +13,7 @@
 ---@field bufnr number
 ---@field diagnostics table<CopilotChat.select.selection.diagnostic>?
 
+local utils = require('CopilotChat.utils')
 local M = {}
 
 --- Get diagnostics in a given range
@@ -70,7 +71,7 @@ function M.visual(source)
 
   return {
     content = lines_content,
-    filename = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ':p:.'),
+    filename = utils.filepath(vim.api.nvim_buf_get_name(bufnr)),
     filetype = vim.bo[bufnr].filetype,
     start_line = start_line,
     end_line = finish_line,
@@ -91,7 +92,7 @@ function M.buffer(source)
 
   local out = {
     content = table.concat(lines, '\n'),
-    filename = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ':p:.'),
+    filename = utils.filepath(vim.api.nvim_buf_get_name(bufnr)),
     filetype = vim.bo[bufnr].filetype,
     start_line = 1,
     end_line = #lines,
@@ -116,7 +117,7 @@ function M.line(source)
 
   local out = {
     content = line,
-    filename = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ':p:.'),
+    filename = utils.filepath(vim.api.nvim_buf_get_name(bufnr)),
     filetype = vim.bo[bufnr].filetype,
     start_line = cursor[1],
     end_line = cursor[1],
@@ -152,7 +153,7 @@ function M.unnamed(source)
 
   return {
     content = lines_content,
-    filename = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ':p:.'),
+    filename = utils.filepath(vim.api.nvim_buf_get_name(bufnr)),
     filetype = vim.bo[bufnr].filetype,
     start_line = start_line,
     end_line = finish_line,

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -28,7 +28,7 @@ local function match_header(header)
   for _, pattern in ipairs(HEADER_PATTERNS) do
     local filename, start_line, end_line = header:match(pattern)
     if filename then
-      return vim.fn.fnamemodify(filename, ':p:.'),
+      return utils.filepath(filename),
         tonumber(start_line) or 1,
         tonumber(end_line) or tonumber(start_line) or 1
     end


### PR DESCRIPTION
Replace direct vim.fn.fnamemodify calls with utility functions for consistent filename handling across the codebase. This improves maintainability by centralizing path manipulation logic in utils module.