### PR TITLE
feat(doc): mark integrations APIs as deprecated

### DIFF
--- a/lua/CopilotChat/actions.lua
+++ b/lua/CopilotChat/actions.lua
@@ -9,6 +9,7 @@ local M = {}
 --- User prompt actions
 ---@param config CopilotChat.config.shared?: The chat configuration
 ---@return CopilotChat.integrations.actions?: The prompt actions
+---@deprecated Use |CopilotChat.select_prompt| instead
 function M.prompt_actions(config)
   local actions = {}
   for name, prompt in pairs(chat.prompts()) do
@@ -25,6 +26,7 @@ end
 --- Pick an action from a list of actions
 ---@param pick_actions CopilotChat.integrations.actions?: A table with the actions to pick from
 ---@param opts table?: vim.ui.select options
+---@deprecated Use |CopilotChat.select_prompt| instead
 function M.pick(pick_actions, opts)
   if not pick_actions or not pick_actions.actions or vim.tbl_isempty(pick_actions.actions) then
     return

--- a/lua/CopilotChat/integrations/fzflua.lua
+++ b/lua/CopilotChat/integrations/fzflua.lua
@@ -7,6 +7,7 @@ local M = {}
 --- Pick an action from a list of actions
 ---@param pick_actions CopilotChat.integrations.actions?: A table with the actions to pick from
 ---@param opts table?: fzf-lua options
+---@deprecated Use |CopilotChat.select_prompt| instead
 function M.pick(pick_actions, opts)
   if not pick_actions or not pick_actions.actions or vim.tbl_isempty(pick_actions.actions) then
     return

--- a/lua/CopilotChat/integrations/snacks.lua
+++ b/lua/CopilotChat/integrations/snacks.lua
@@ -7,6 +7,7 @@ local M = {}
 --- Pick an action from a list of actions
 ---@param pick_actions CopilotChat.integrations.actions?: A table with the actions to pick from
 ---@param opts table?: snacks options
+---@deprecated Use |CopilotChat.select_prompt| instead
 function M.pick(pick_actions, opts)
   if not pick_actions or not pick_actions.actions or vim.tbl_isempty(pick_actions.actions) then
     return

--- a/lua/CopilotChat/integrations/telescope.lua
+++ b/lua/CopilotChat/integrations/telescope.lua
@@ -13,6 +13,7 @@ local M = {}
 --- Pick an action from a list of actions
 ---@param pick_actions CopilotChat.integrations.actions?: A table with the actions to pick from
 ---@param opts table?: Telescope options
+---@deprecated Use |CopilotChat.select_prompt| instead
 function M.pick(pick_actions, opts)
   if not pick_actions or not pick_actions.actions or vim.tbl_isempty(pick_actions.actions) then
     return


### PR DESCRIPTION
Add @deprecated tags to integration-related functions, directing users to use the newer CopilotChat.select_prompt interface instead. This improves API consistency and prepares for future changes.