### PR TITLE
refactor: replace plenary scheduler with internal implementation

### DIFF
--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -1,4 +1,3 @@
-local async = require('plenary.async')
 local context = require('CopilotChat.context')
 local utils = require('CopilotChat.utils')
 
@@ -63,7 +62,7 @@ return {
         max_files = 1000,
       })
 
-      async.util.scheduler()
+      utils.schedule_main()
       vim.ui.select(files, {
         prompt = 'Select a file> ',
       }, callback)

--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -354,7 +354,7 @@ return {
         local _, selected_agent = pcall(copilot.resolve_agent, prompt, config)
         local _, selected_model = pcall(copilot.resolve_model, prompt, config)
 
-        async.util.scheduler()
+        utils.schedule_main()
         table.insert(lines, '**Logs**: `' .. chat.config.log_path .. '`')
         table.insert(lines, '**History**: `' .. chat.config.history_path .. '`')
         table.insert(lines, '**Temp Files**: `' .. vim.fn.fnamemodify(os.tmpname(), ':h') .. '`')
@@ -429,7 +429,7 @@ return {
           table.insert(lines, '')
         end
 
-        async.util.scheduler()
+        utils.schedule_main()
         overlay:show(vim.trim(table.concat(lines, '\n')) .. '\n', chat.winnr, 'markdown')
       end)
     end,

--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -412,7 +412,7 @@ function M.files(winnr, with_content, search_options)
 
   -- Read file contents
   if with_content then
-    async.util.scheduler()
+    utils.schedule_main()
 
     files = vim.tbl_filter(
       function(file)
@@ -445,7 +445,7 @@ function M.file(filename)
     return nil
   end
 
-  async.util.scheduler()
+  utils.schedule_main()
   local ft = utils.filetype(filename)
   if not ft then
     return nil
@@ -458,7 +458,7 @@ end
 ---@param bufnr number
 ---@return CopilotChat.context.embed?
 function M.buffer(bufnr)
-  async.util.scheduler()
+  utils.schedule_main()
 
   if not utils.buf_valid(bufnr) then
     return nil
@@ -483,7 +483,7 @@ end
 ---@param buf_type string
 ---@return table<CopilotChat.context.embed>
 function M.buffers(buf_type)
-  async.util.scheduler()
+  utils.schedule_main()
 
   return vim.tbl_map(
     M.buffer,
@@ -593,7 +593,7 @@ end
 ---@param register string
 ---@return CopilotChat.context.embed?
 function M.register(register)
-  async.util.scheduler()
+  utils.schedule_main()
 
   local lines = vim.fn.getreg(register)
   if not lines or lines == '' then
@@ -610,7 +610,7 @@ end
 --- Get the content of the quickfix list
 ---@return table<CopilotChat.context.embed>
 function M.quickfix()
-  async.util.scheduler()
+  utils.schedule_main()
 
   local items = vim.fn.getqflist()
   if not items or #items == 0 then

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -496,7 +496,7 @@ function M.complete_items(callback)
       return a.kind < b.kind
     end)
 
-    async.util.scheduler()
+    utils.schedule_main()
     callback(items)
   end)
 end
@@ -577,7 +577,7 @@ function M.select_model()
       }
     end, models)
 
-    async.util.scheduler()
+    utils.schedule_main()
     vim.ui.select(choices, {
       prompt = 'Select a model> ',
       format_item = function(item)
@@ -608,7 +608,7 @@ function M.select_agent()
       }
     end, agents)
 
-    async.util.scheduler()
+    utils.schedule_main()
     vim.ui.select(choices, {
       prompt = 'Select an agent> ',
       format_item = function(item)
@@ -714,7 +714,7 @@ function M.ask(prompt, config)
       pcall(context.filter_embeddings, prompt, selected_model, config.headless, embeddings)
 
     if not query_ok then
-      async.util.scheduler()
+      utils.schedule_main()
       log.error(filtered_embeddings)
       if not config.headless then
         show_error(filtered_embeddings, has_output)
@@ -739,7 +739,7 @@ function M.ask(prompt, config)
         end),
       })
 
-    async.util.scheduler()
+    utils.schedule_main()
 
     if not ask_ok then
       log.error(response)
@@ -776,7 +776,7 @@ function M.ask(prompt, config)
   end)
 
   if not ok then
-    async.util.scheduler()
+    utils.schedule_main()
     log.error(err)
     if not config.headless then
       show_error(err)

--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -1,4 +1,3 @@
-local async = require('plenary.async')
 local notify = require('CopilotChat.notify')
 local utils = require('CopilotChat.utils')
 local current_tokenizer = nil
@@ -11,7 +10,7 @@ end
 --- Load tiktoken data from cache or download it
 ---@param tokenizer string The tokenizer to load
 local function load_tiktoken_data(tokenizer)
-  async.util.scheduler()
+  utils.schedule_main()
 
   local tiktoken_url = 'https://openaipublic.blob.core.windows.net/encodings/'
     .. tokenizer
@@ -57,7 +56,7 @@ M.load = function(tokenizer)
   local pat_str =
     "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+"
 
-  async.util.scheduler()
+  utils.schedule_main()
   tiktoken_core.new(path, special_tokens, pat_str)
   current_tokenizer = tokenizer
 end

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -344,7 +344,7 @@ M.curl_get = async.wrap(function(url, opts, callback)
       return
     end
 
-    local body, err = M.json_decode(response.body)
+    local body, err = M.json_decode(tostring(response.body))
     if err then
       callback(response, err)
     else
@@ -388,7 +388,7 @@ M.curl_post = async.wrap(function(url, opts, callback)
       return
     end
 
-    local body, err = M.json_decode(response.body)
+    local body, err = M.json_decode(tostring(response.body))
     if err then
       callback(response, err)
     else
@@ -463,6 +463,20 @@ end
 M.system = async.wrap(function(cmd, callback)
   vim.system(cmd, { text = true }, callback)
 end, 2)
+
+--- Schedule a function only when needed (not on main thread)
+---@param callback function The callback
+M.schedule_main = async.wrap(function(callback)
+  if vim.in_fast_event() then
+    -- In a fast event, need to schedule
+    vim.schedule(function()
+      callback()
+    end)
+  else
+    -- Already on main thread, call directly
+    callback()
+  end
+end, 1)
 
 --- Get the info for a key.
 ---@param name string


### PR DESCRIPTION
Remove dependency on plenary.async.util.scheduler() by implementing a custom schedule_main() function that only schedules when necessary. This allows the plugin to work without requiring plenary's scheduling mechanism. Also fixes JSON decoding by ensuring response body is properly converted to string.