### PR TITLE
refactor: streamline system prompts architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,22 +159,22 @@ Commands are used to control the chat interface:
 
 Default mappings in the chat interface:
 
-| Insert  | Normal  | Action                                             |
-| ------- | ------- | -------------------------------------------------- |
-| `<Tab>` | `<Tab>` | Trigger/accept completion menu for tokens          |
-| `<C-c>` | `q`     | Close the chat window                              |
-| `<C-l>` | `<C-l>` | Reset and clear the chat window                    |
-| `<C-s>` | `<CR>`  | Submit the current prompt                          |
-| -       | `gr`    | Toggle sticky prompt for line under cursor         |
-| `<C-y>` | `<C-y>` | Accept nearest diff                                |
-| -       | `gj`    | Jump to section of nearest diff                    |
-| -       | `gqa`   | Add all answers from chat to quickfix list         |
-| -       | `gqd`   | Add all diffs from chat to quickfix list           |
-| -       | `gy`    | Yank nearest diff to register                      |
-| -       | `gd`    | Show diff between source and nearest diff          |
-| -       | `gi`    | Show info about current chat                       |
-| -       | `gc`    | Show current chat context                          |
-| -       | `gh`    | Show help message                                  |
+| Insert  | Normal  | Action                                     |
+| ------- | ------- | ------------------------------------------ |
+| `<Tab>` | `<Tab>` | Trigger/accept completion menu for tokens  |
+| `<C-c>` | `q`     | Close the chat window                      |
+| `<C-l>` | `<C-l>` | Reset and clear the chat window            |
+| `<C-s>` | `<CR>`  | Submit the current prompt                  |
+| -       | `gr`    | Toggle sticky prompt for line under cursor |
+| `<C-y>` | `<C-y>` | Accept nearest diff                        |
+| -       | `gj`    | Jump to section of nearest diff            |
+| -       | `gqa`   | Add all answers from chat to quickfix list |
+| -       | `gqd`   | Add all diffs from chat to quickfix list   |
+| -       | `gy`    | Yank nearest diff to register              |
+| -       | `gd`    | Show diff between source and nearest diff  |
+| -       | `gi`    | Show info about current chat               |
+| -       | `gc`    | Show current chat context                  |
+| -       | `gh`    | Show help message                          |
 
 The mappings can be customized by setting the `mappings` table in your configuration. Each mapping can have:
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Default mappings in the chat interface:
 | `<C-l>` | `<C-l>` | Reset and clear the chat window                    |
 | `<C-s>` | `<CR>`  | Submit the current prompt                          |
 | -       | `gr`    | Toggle sticky prompt for line under cursor         |
-| `<C-y>` | `<C-y>` | Accept nearest diff (best with `COPILOT_GENERATE`) |
+| `<C-y>` | `<C-y>` | Accept nearest diff                                |
 | -       | `gj`    | Jump to section of nearest diff                    |
 | -       | `gqa`   | Add all answers from chat to quickfix list         |
 | -       | `gqd`   | Add all diffs from chat to quickfix list           |
@@ -235,10 +235,9 @@ System prompts define the AI model's behavior. Reference them with `/PROMPT_NAME
 
 | Prompt                 | Description                                |
 | ---------------------- | ------------------------------------------ |
-| `COPILOT_INSTRUCTIONS` | Base GitHub Copilot instructions           |
+| `COPILOT_INSTRUCTIONS` | Base instructions                          |
 | `COPILOT_EXPLAIN`      | Adds coding tutor behavior                 |
 | `COPILOT_REVIEW`       | Adds code review behavior with diagnostics |
-| `COPILOT_GENERATE`     | Adds code generation behavior and rules    |
 
 Define your own system prompts in the configuration (similar to `prompts`):
 
@@ -541,19 +540,19 @@ Below are all available configuration options with their default values:
       prompt = '> /COPILOT_REVIEW\n\nReview the selected code.',
     },
     Fix = {
-      prompt = '> /COPILOT_GENERATE\n\nThere is a problem in this code. Rewrite the code to show it with the bug fixed.',
+      prompt = 'There is a problem in this code. Identify the issues and rewrite the code with fixes. Explain what was wrong and how your changes address the problems.',
     },
     Optimize = {
-      prompt = '> /COPILOT_GENERATE\n\nOptimize the selected code to improve performance and readability.',
+      prompt = 'Optimize the selected code to improve performance and readability. Explain your optimization strategy and the benefits of your changes.',
     },
     Docs = {
-      prompt = '> /COPILOT_GENERATE\n\nPlease add documentation comments to the selected code.',
+      prompt = 'Please add documentation comments to the selected code.',
     },
     Tests = {
-      prompt = '> /COPILOT_GENERATE\n\nPlease generate tests for my code.',
+      prompt = 'Please generate tests for my code.',
     },
     Commit = {
-      prompt = '> #git:staged\n\nWrite commit message for the change with commitizen convention. Make sure the title has maximum 50 characters and message is wrapped at 72 characters. Wrap the whole message in code block with language gitcommit.',
+      prompt = '> #git:staged\n\nWrite commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.',
     },
   },
 

--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -13,17 +13,38 @@ If you are asked to generate content that is harmful, hateful, racist, sexist, l
 Keep your answers short and impersonal.
 The user works in an IDE called Neovim which has a concept for editors with open files, integrated unit test support, an output pane that shows the output of running the code as well as an integrated terminal.
 The user is working on a %s machine. Please respond with system specific commands if applicable.
+You will receive code snippets that include line number prefixes - use these to maintain correct position references but remove them when generating output.
+
+When presenting code changes:
+
+1. For each change, first provide a header outside code blocks with format:
+   [file:<file_name>](<file_path>) line:<start_line>-<end_line>
+
+2. Then wrap the actual code in triple backticks with the appropriate language identifier.
+
+3. Keep changes minimal and focused to produce short diffs.
+
+4. Include complete replacement code for the specified line range with:
+   - Proper indentation matching the source
+   - All necessary lines (no eliding with comments)
+   - No line number prefixes in the code
+
+5. Address any diagnostics issues when fixing code.
+
+6. If multiple changes are needed, present them as separate blocks with their own headers.
 ]],
   vim.uv.os_uname().sysname
 )
 
 local COPILOT_INSTRUCTIONS = [[
 You are a code-focused AI programming assistant that specializes in practical software engineering solutions.
-You will receive code snippets that include line number prefixes - use these to maintain correct position references but remove them when generating output.
 ]] .. base
 
-local COPILOT_EXPLAIN = [[
+local COPILOT_EXPLAIN = base
+  .. [[
+
 You are a programming instructor focused on clear, practical explanations.
+
 When explaining code:
 - Provide concise high-level overview first
 - Highlight non-obvious implementation details
@@ -32,12 +53,16 @@ When explaining code:
 - Focus on complex parts rather than basic syntax
 - Use short paragraphs with clear structure
 - Mention performance considerations where relevant
-]] .. base
+]]
 
-local COPILOT_REVIEW = COPILOT_INSTRUCTIONS
+local COPILOT_REVIEW = base
   .. [[
-Review the code for readability and maintainability issues. Report problems in this format:
+
+You are a code reviewer focused on improving code quality and maintainability.
+
+Format each issue you find precisely as:
 line=<line_number>: <issue_description>
+OR
 line=<start_line>-<end_line>: <issue_description>
 
 Check for:
@@ -58,34 +83,6 @@ End with: "**`To clear buffer highlights, please ask a different question.`**"
 If no issues found, confirm the code is well-written and explain why.
 ]]
 
-local COPILOT_GENERATE = COPILOT_INSTRUCTIONS
-  .. [[
-Your task is to modify the provided code according to the user's request.
-
-When presenting code changes:
-
-1. For each change, first provide a header outside code blocks with format:
-   [file:<file_name>](<file_path>) line:<start_line>-<end_line>
-
-2. Then wrap the actual code in triple backticks with the appropriate language identifier.
-
-3. Keep changes minimal and focused to produce short diffs.
-
-4. Include complete replacement code for the specified line range with:
-   - Proper indentation matching the source
-   - All necessary lines (no eliding with comments)
-   - No line number prefixes in the code
-
-5. Address any diagnostics issues when fixing code.
-
-6. If multiple changes are needed, present them as separate blocks with their own headers.
-
-7. For long responses:
-   - Complete the current code block
-   - End with "**`[Response truncated] Please ask for the remaining changes.`**"
-   - Continue in the next response
-]]
-
 ---@type table<string, CopilotChat.config.prompt>
 return {
   COPILOT_INSTRUCTIONS = {
@@ -98,10 +95,6 @@ return {
 
   COPILOT_REVIEW = {
     system_prompt = COPILOT_REVIEW,
-  },
-
-  COPILOT_GENERATE = {
-    system_prompt = COPILOT_GENERATE,
   },
 
   Explain = {
@@ -152,19 +145,19 @@ return {
   },
 
   Fix = {
-    prompt = '> /COPILOT_GENERATE\n\nThere is a problem in this code. Rewrite the code to show it with the bug fixed.',
+    prompt = 'There is a problem in this code. Identify the issues and rewrite the code with fixes. Explain what was wrong and how your changes address the problems.',
   },
 
   Optimize = {
-    prompt = '> /COPILOT_GENERATE\n\nOptimize the selected code to improve performance and readability.',
+    prompt = 'Optimize the selected code to improve performance and readability. Explain your optimization strategy and the benefits of your changes.',
   },
 
   Docs = {
-    prompt = '> /COPILOT_GENERATE\n\nPlease add documentation comments to the selected code.',
+    prompt = 'Please add documentation comments to the selected code.',
   },
 
   Tests = {
-    prompt = '> /COPILOT_GENERATE\n\nPlease generate tests for my code.',
+    prompt = 'Please generate tests for my code.',
   },
 
   Commit = {


### PR DESCRIPTION
Integrate code generation instructions directly into base prompt to simplify the system architecture. Remove the separate COPILOT_GENERATE prompt and update all references to it throughout the codebase.

The format instructions for code changes have been moved to the base prompt to ensure consistent formatting across all interaction modes. This change improves maintainability while preserving full functionality.