### PR TITLE
fix: clear config when resetting chat

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -431,6 +431,7 @@ end
 
 function Chat:clear()
   self:validate()
+  self.config = {}
   self.references = {}
   self.token_count = nil
   self.token_max_count = nil


### PR DESCRIPTION
When clearing the chat with the clear method, ensure the config is also reset to an empty table along with references and token counts. This prevents stale configuration from persisting across chat resets.