### PR TITLE
fix: prevent errors when accessing window config

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -431,7 +431,6 @@ end
 
 function Chat:clear()
   self:validate()
-  self.config = {}
   self.references = {}
   self.token_count = nil
   self.token_max_count = nil
@@ -523,7 +522,7 @@ function Chat:close(bufnr)
     utils.return_to_normal_mode()
   end
 
-  if self.config.window.layout == 'replace' then
+  if self.config.window and self.config.window.layout == 'replace' then
     if bufnr then
       self:restore(self.winnr, bufnr)
     end


### PR DESCRIPTION
Previously, the Chat:clear() method was resetting the entire config object to an empty table, causing potential nil access errors when trying to access config.window.layout. This change:

1. Removes the config reset in the clear() method to preserve settings
2. Adds a nil check when accessing config.window to prevent errors

Closes #895