### PR TITLE
fix(utils): `glob_to_regex` recursion matching

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -545,7 +545,7 @@ function M.glob_to_regex(glob)
   pattern = pattern
     :gsub('%*%*/%*', '.*') -- **/* -> .*
     :gsub('%*%*', '.*') -- ** -> .*
-    :gsub('%*', '[^/]*') -- * -> [^/]*
+    :gsub('([^%.])%*', '%1[^/]*') -- * -> [^/]* (when not preceded by .)
     :gsub('%?', '.') -- ? -> .
 
   return pattern .. '$'


### PR DESCRIPTION
When I use `**/*` pattern in the glob, it doesn't match the files in the subdirectories.

This is because `**/*` is first replaced with `.*` by `:gsub('%*%*/%*', '.*')`.

Then `:gsub('%*', '[^/]*')` kicks in and replaces that `*` with `[^/]*`. So, files in the subdirectories aren't getting matched.

Changed `:gsub('%*', '[^/]*')` to `:gsub('([^%.])%*', '%1[^/]*')`, so that `*` will only get replaced with it's not having a `.` before it.