### PR TITLE
docs: remove selection from chat.ask example

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,7 +674,6 @@ chat.stop()     -- Stop current output
 
 -- Ask a question with optional config
 chat.ask("Explain this code.", {
-  selection = require("CopilotChat.select").buffer,
   context = { 'buffers', 'files' },
   callback = function(response)
     print("Response:", response)


### PR DESCRIPTION
The example in the README now better reflects the current API by removing the explicit selection parameter from the chat.ask configuration object.