### PR TITLE
feat: add remember_as_sticky config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Below are all available configuration options with their default values:
   temperature = 0.1, -- GPT result temperature
   headless = false, -- Do not write to chat buffer and use history(useful for using callback for custom processing)
   callback = nil, -- Callback to use when ask response is received
+  remember_as_sticky = true, -- Remember model/agent/context as sticky prompts when asking questions
 
   -- default window options
   window = {

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -22,6 +22,7 @@ local select = require('CopilotChat.select')
 ---@field temperature number?
 ---@field headless boolean?
 ---@field callback fun(response: string, source: CopilotChat.source)?
+---@field remember_as_sticky boolean?
 ---@field window CopilotChat.config.window?
 ---@field show_help boolean?
 ---@field show_folds boolean?
@@ -65,6 +66,7 @@ return {
   temperature = 0.1, -- GPT result temperature
   headless = false, -- Do not write to chat buffer and use history(useful for using callback for custom processing)
   callback = nil, -- Callback to use when ask response is received
+  remember_as_sticky = true, -- Remember model/agent/context as sticky prompts when asking questions
 
   -- default window options
   window = {

--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -173,7 +173,7 @@ return {
   },
 
   toggle_sticky = {
-    normal = 'gr',
+    normal = 'grr',
     callback = function()
       local section = copilot.chat:get_closest_section()
       if not section or section.answer then
@@ -222,6 +222,38 @@ return {
         to_insert
       )
       vim.api.nvim_win_set_cursor(0, cursor)
+    end,
+  },
+
+  clear_stickies = {
+    normal = 'grx',
+    callback = function()
+      local section = copilot.chat:get_closest_section()
+      if not section or section.answer then
+        return
+      end
+
+      local lines = vim.split(section.content, '\n')
+      local new_lines = {}
+      local changed = false
+
+      for _, line in ipairs(lines) do
+        if not vim.startswith(vim.trim(line), '> ') then
+          table.insert(new_lines, line)
+        else
+          changed = true
+        end
+      end
+
+      if changed then
+        vim.api.nvim_buf_set_lines(
+          copilot.chat.bufnr,
+          section.start_line,
+          section.end_line - 1,
+          false,
+          new_lines
+        )
+      end
     end,
   },
 

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -53,15 +53,19 @@ local function insert_sticky(prompt, config, override_sticky)
 
   lines = vim.split(vim.trim(table.concat(lines, '\n')), '\n')
 
-  if config.model and config.model ~= M.config.model then
+  if config.remember_as_sticky and config.model and config.model ~= M.config.model then
     stickies:set('$' .. config.model, true)
   end
 
-  if config.agent and config.agent ~= M.config.agent then
+  if config.remember_as_sticky and config.agent and config.agent ~= M.config.agent then
     stickies:set('@' .. config.agent, true)
   end
 
-  if config.context and not vim.deep_equal(config.context, M.config.context) then
+  if
+    config.remember_as_sticky
+    and config.context
+    and not vim.deep_equal(config.context, M.config.context)
+  then
     if type(config.context) == 'table' then
       ---@diagnostic disable-next-line: param-type-mismatch
       for _, context in ipairs(config.context) do


### PR DESCRIPTION
Add configuration option to control whether model/agent/context are
remembered as sticky prompts when asking questions. This provides more
control over the persistence behavior.

Also added a 'grx' shortcut to clear all sticky prompts and changed
the toggle sticky keymap from 'gr' to 'grr' to avoid conflicts.

Closes #910