### PR TITLE
feat: allow per-chat selection configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Define your own contexts in the configuration with input handling and resolution
 
 ## Selections
 
-Selections determine the source content for chat interactions. Can be configured only globally.
+Selections determine the source content for chat interactions.
 
 Available selections are located in `local select = require("CopilotChat.select")`:
 
@@ -455,6 +455,12 @@ Below are all available configuration options with their default values:
   callback = nil, -- Callback to use when ask response is received
   remember_as_sticky = true, -- Remember model/agent/context as sticky prompts when asking questions
 
+  -- default selection
+  -- see select.lua for implementation
+  selection = function(source)
+    return select.visual(source) or select.buffer(source)
+  end,
+
   -- default window options
   window = {
     layout = 'vertical', -- 'vertical', 'horizontal', 'float', 'replace'
@@ -495,12 +501,6 @@ Below are all available configuration options with their default values:
   answer_header = '# Copilot ', -- Header to use for AI answers
   error_header = '# Error ', -- Header to use for errors
   separator = '───', -- Separator to use in chat
-
-  -- default selection
-  -- see select.lua for implementation
-  selection = function(source)
-    return select.visual(source) or select.buffer(source)
-  end,
 
   -- default providers
   -- see config/providers.lua for implementation

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -23,6 +23,7 @@ local select = require('CopilotChat.select')
 ---@field headless boolean?
 ---@field callback fun(response: string, source: CopilotChat.source)?
 ---@field remember_as_sticky boolean?
+---@field selection false|nil|fun(source: CopilotChat.source):CopilotChat.select.selection?
 ---@field window CopilotChat.config.window?
 ---@field show_help boolean?
 ---@field show_folds boolean?
@@ -47,7 +48,6 @@ local select = require('CopilotChat.select')
 ---@field answer_header string?
 ---@field error_header string?
 ---@field separator string?
----@field selection false|nil|fun(source: CopilotChat.source):CopilotChat.select.selection?
 ---@field providers table<string, CopilotChat.Provider>?
 ---@field contexts table<string, CopilotChat.config.context>?
 ---@field prompts table<string, CopilotChat.config.prompt|string>?
@@ -67,6 +67,11 @@ return {
   headless = false, -- Do not write to chat buffer and use history(useful for using callback for custom processing)
   callback = nil, -- Callback to use when ask response is received
   remember_as_sticky = true, -- Remember model/agent/context as sticky prompts when asking questions
+
+  -- default selection
+  selection = function(source)
+    return select.visual(source) or select.buffer(source)
+  end,
 
   -- default window options
   window = {
@@ -109,11 +114,6 @@ return {
   answer_header = '## Copilot ', -- Header to use for AI answers
   error_header = '## Error ', -- Header to use for errors
   separator = '───', -- Separator to use in chat
-
-  -- default selection
-  selection = function(source)
-    return select.visual(source) or select.buffer(source)
-  end,
 
   -- default providers
   providers = require('CopilotChat.config.providers'),

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -417,7 +417,7 @@ end
 --- Get the selection from the source buffer.
 ---@return CopilotChat.select.selection?
 function M.get_selection()
-  local selection = M.config.selection
+  local selection = M.chat.config.selection or M.config.selection
   local bufnr = state.source and state.source.bufnr
   local winnr = state.source and state.source.winnr
 


### PR DESCRIPTION
Make selection behavior configurable per-chat instance rather than only globally. This enables different selection strategies for different chat sessions while maintaining backward compatibility with the global configuration.

The selection field is moved higher in the config file for better visibility, and documentation is updated to reflect this change.