### PR TITLE
fix: properly merge selection configuration

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -417,7 +417,8 @@ end
 --- Get the selection from the source buffer.
 ---@return CopilotChat.select.selection?
 function M.get_selection()
-  local selection = M.chat.config.selection or M.config.selection
+  local config = vim.tbl_deep_extend('force', M.config, M.chat.config)
+  local selection = config.selection
   local bufnr = state.source and state.source.bufnr
   local winnr = state.source and state.source.winnr
 


### PR DESCRIPTION
The change replaces the previous selection config resolver with a deep merge between the global and chat-specific configurations. This ensures all nested configuration values are properly merged instead of just using one or the other.