### PR TITLE
feat!: mark async functions with annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,9 +665,9 @@ local chat = require("CopilotChat")
 chat.ask(prompt, config)      -- Ask a question with optional config
 chat.response()               -- Get the last response text
 chat.resolve_prompt()         -- Resolve prompt references
-chat.resolve_context()        -- Resolve context embeddings
-chat.resolve_agent()          -- Resolve agent from prompt
-chat.resolve_model()          -- Resolve model from prompt
+chat.resolve_context()        -- Resolve context embeddings (WARN: async, requires plenary.async.run)
+chat.resolve_agent()          -- Resolve agent from prompt (WARN: async, requires plenary.async.run)
+chat.resolve_model()          -- Resolve model from prompt (WARN: async, requires plenary.async.run)
 
 -- Window Management
 chat.open(config)             -- Open chat window with optional config
@@ -689,7 +689,7 @@ chat.prompts()                -- Get all available prompts
 -- Completion
 chat.trigger_complete()       -- Trigger completion in chat window
 chat.complete_info()          -- Get completion info for custom providers
-chat.complete_items(callback) -- Get completion items asynchronously
+chat.complete_items()         -- Get completion items (WARN: async, requires plenary.async.run)
 
 -- History Management
 chat.save(name, history_path) -- Save chat history

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -322,6 +322,7 @@ end
 --- Send curl get request
 ---@param url string The url
 ---@param opts table? The options
+---@async
 M.curl_get = async.wrap(function(url, opts, callback)
   local args = {
     on_error = function(err)
@@ -359,6 +360,7 @@ end, 3)
 --- Send curl post request
 ---@param url string The url
 ---@param opts table? The options
+---@async
 M.curl_post = async.wrap(function(url, opts, callback)
   local args = {
     callback = callback,
@@ -411,6 +413,7 @@ end, 3)
 --- Scan a directory
 ---@param path string The directory path
 ---@param opts table The options
+---@async
 M.scan_dir = async.wrap(function(path, opts, callback)
   scandir.scan_dir_async(
     path,
@@ -428,6 +431,7 @@ end, 3)
 --- Get last modified time of a file
 ---@param path string The file path
 ---@return number?
+---@async
 M.file_mtime = function(path)
   local err, stat = async.uv.fs_stat(path)
   if err or not stat then
@@ -438,6 +442,7 @@ end
 
 --- Read a file
 ---@param path string The file path
+---@async
 M.read_file = function(path)
   local err, fd = async.uv.fs_open(path, 'r', 438)
   if err or not fd then
@@ -460,12 +465,14 @@ end
 
 --- Call a system command
 ---@param cmd table The command
+---@async
 M.system = async.wrap(function(cmd, callback)
   vim.system(cmd, { text = true }, callback)
 end, 2)
 
 --- Schedule a function only when needed (not on main thread)
 ---@param callback function The callback
+---@async
 M.schedule_main = async.wrap(function(callback)
   if vim.in_fast_event() then
     -- In a fast event, need to schedule


### PR DESCRIPTION
Mark async functions with proper `---@async` annotations to clearly indicate which functions require running in an async context. Update complete_items to return directly instead of using a callback pattern, improving code clarity and consistency with other async functions.

Functions now properly indicate when they require plenary.async.run in the API documentation.

BREAKING CHANGE: chat.complete_items() is now async instead of using callback