### PR TITLE
feat: add description field to prompt items

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -749,6 +749,7 @@ function M.select_prompt(config)
     :map(function(name)
       return {
         name = name,
+        description = prompts[name].description,
         prompt = prompts[name].prompt,
       }
     end)
@@ -760,7 +761,7 @@ function M.select_prompt(config)
   vim.ui.select(choices, {
     prompt = 'Select prompt action> ',
     format_item = function(item)
-      return string.format('%s: %s', item.name, item.prompt:gsub('\n', ' '))
+      return string.format('%s: %s', item.name, item.description or item.prompt:gsub('\n', ' '))
     end,
   }, function(choice)
     if choice then


### PR DESCRIPTION
Add a description field to prompt items and prefer displaying it over the raw prompt in the UI selection menu. This improves readability and user experience by showing more concise descriptions instead of potentially long prompts.

![image](https://github.com/user-attachments/assets/bbd63b33-a607-4cf1-9318-92cde24adce6)