### PR TITLE
fix: reset diagnostics when stopping Copilot Chat

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -907,6 +907,7 @@ function M.stop(reset)
   if reset then
     client:reset()
     M.chat:clear()
+    vim.diagnostic.reset(vim.api.nvim_create_namespace('copilot-chat-diagnostics'))
     state.last_prompt = nil
     state.last_response = nil
 


### PR DESCRIPTION
When resetting Copilot Chat state, diagnostics weren't being cleared from the editor, which could lead to stale diagnostic information remaining visible. This change ensures diagnostics created by Copilot Chat are properly removed when stopping or resetting the chat.