### PR TITLE
feat: add conversation memory summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://github.com/user-attachments/assets/8cad5643-63b2-4641-a5c4-68bc313f20e6
 
 CopilotChat.nvim is a Neovim plugin that brings GitHub Copilot Chat capabilities directly into your editor. It provides:
 
-- 🤖 Native GitHub Copilot Chat integration with official model and agent support (GPT-4o, Claude 3.7 Sonnet, Gemini 2.0 Flash, and more)
+- 🤖 GitHub Copilot Chat integration with official model and agent support (GPT-4o, Claude 3.7 Sonnet, Gemini 2.0 Flash, and more)
 - 💻 Rich workspace context powered by smart embeddings system
 - 🔒 Explicit context sharing - only sends what you specifically request, either as context or selection
 - 🔌 Modular provider architecture supporting both official and custom LLM backends (Ollama, LM Studio, and more)
@@ -26,6 +26,7 @@ CopilotChat.nvim is a Neovim plugin that brings GitHub Copilot Chat capabilities
 - 🎯 Powerful prompt system with composable templates and sticky prompts
 - 🔄 Extensible context providers for granular workspace understanding (buffers, files, git diffs, URLs, and more)
 - ⚡ Efficient token usage with tiktoken optimization
+- 📜 Intelligent chat memory management with automatic summarization to handle lengthy conversations
 
 # Requirements
 

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -837,9 +837,11 @@ function M.ask(prompt, config)
       return
     end
 
+    pcall(client.summarize_memory, client, selected_model)
     local ask_ok, response, references, token_count, token_max_count =
       pcall(client.ask, client, prompt, {
-        headless = config.headless,
+        load_history = not config.headless,
+        store_history = not config.headless,
         selection = selection,
         embeddings = filtered_embeddings,
         system_prompt = system_prompt,
@@ -993,6 +995,7 @@ function M.load(name, history_path)
   client:reset()
   M.chat:clear()
 
+  client.history = history
   for i, message in ipairs(history) do
     if message.role == 'user' then
       if i > 1 then


### PR DESCRIPTION
Implement a memory system that automatically summarizes chat history to maintain context across long conversations while managing token usage. The system:
- Tracks conversation history and generates summaries when needed
- Includes summarized memory in system prompts for context
- Only loads recent messages after the last summarization point
- Optimizes token usage by accounting for memory in calculations

This reduces issues with context length limitations while preserving important information from previous interactions.

Inspired by:
https://github.com/yetone/avante.nvim/pull/1508

as it was pretty good idea, this PR takes it a bit further