### PR TITLE
refactor(prompts): use proper fields for prompt settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,11 +542,11 @@ Below are all available configuration options with their default values:
   prompts = {
     Explain = {
       prompt = 'Write an explanation for the selected code as paragraphs of text.',
-      sticky = '/COPILOT_EXPLAIN',
+      system_prompt = 'COPILOT_EXPLAIN',
     },
     Review = {
       prompt = 'Review the selected code.',
-      sticky = '/COPILOT_REVIEW',
+      system_prompt = 'COPILOT_REVIEW',
     },
     Fix = {
       prompt = 'There is a problem in this code. Identify the issues and rewrite the code with fixes. Explain what was wrong and how your changes address the problems.',
@@ -562,7 +562,7 @@ Below are all available configuration options with their default values:
     },
     Commit = {
       prompt = 'Write commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.',
-      sticky = '#git:staged',
+      context = 'git:staged',
     },
   },
 

--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -98,12 +98,12 @@ return {
 
   Explain = {
     prompt = 'Write an explanation for the selected code as paragraphs of text.',
-    sticky = '/COPILOT_EXPLAIN',
+    system_prompt = 'COPILOT_EXPLAIN',
   },
 
   Review = {
     prompt = 'Review the selected code.',
-    sticky = '/COPILOT_REVIEW',
+    system_prompt = 'COPILOT_REVIEW',
     callback = function(response, source)
       local diagnostics = {}
       for line in response:gmatch('[^\r\n]+') do
@@ -163,6 +163,6 @@ return {
 
   Commit = {
     prompt = 'Write commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.',
-    sticky = '#git:staged',
+    context = 'git:staged',
   },
 }

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -63,6 +63,15 @@ local function insert_sticky(prompt, config, override_sticky)
 
   if
     config.remember_as_sticky
+    and config.system_prompt
+    and config.system_prompt ~= M.config.system_prompt
+    and M.config.prompts[config.system_prompt]
+  then
+    stickies:set('/' .. config.system_prompt, true)
+  end
+
+  if
+    config.remember_as_sticky
     and config.context
     and not vim.deep_equal(config.context, M.config.context)
   then
@@ -626,6 +635,10 @@ function M.prompts()
       val = {
         prompt = prompt,
       }
+    end
+
+    if val.system_prompt and M.config.prompts[val.system_prompt] then
+      val.system_prompt = M.config.prompts[val.system_prompt].system_prompt
     end
 
     prompts_to_use[name] = val


### PR DESCRIPTION
Instead of sticky use context/system_prompt and rely on remember_as_sticky configuration for this to be remembered.

Also add support for resolving system_prompts by name