### PR TITLE
fix: correct history storage in client

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -696,18 +696,15 @@ function Client:ask(prompt, opts)
   log.debug('Last message: ', last_message)
 
   if opts.store_history then
-    table.insert(history, {
+    table.insert(self.history, {
       content = prompt,
       role = 'user',
     })
 
-    table.insert(history, {
+    table.insert(self.history, {
       content = full_response,
       role = 'assistant',
     })
-
-    self.history = history
-    log.debug('History size increased to: ', #history)
   end
 
   return full_response,

--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -1,5 +1,6 @@
 local async = require('plenary.async')
 local copilot = require('CopilotChat')
+local client = require('CopilotChat.client')
 local utils = require('CopilotChat.utils')
 
 ---@class CopilotChat.config.mappings.diff
@@ -469,6 +470,16 @@ return {
           table.insert(lines, '**System Prompt**')
           table.insert(lines, '```')
           for _, line in ipairs(vim.split(vim.trim(system_prompt), '\n')) do
+            table.insert(lines, line)
+          end
+          table.insert(lines, '```')
+          table.insert(lines, '')
+        end
+
+        if client.memory then
+          table.insert(lines, '**Memory**')
+          table.insert(lines, '```')
+          for _, line in ipairs(vim.split(vim.trim(client.memory.content), '\n')) do
             table.insert(lines, line)
           end
           table.insert(lines, '```')


### PR DESCRIPTION
The commit fixes two issues:
- Updates direct access to history table to use self.history in the client module, removing redundant reassignment
- Adds a display for memory content in the chat overlay when available

This improves both correctness and usability of the Copilot Chat plugin.