### PR TITLE
fix: clear memory when resetting the client

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -880,6 +880,7 @@ end
 function Client:reset()
   local stopped = self:stop()
   self.history = {}
+  self.memory = nil
   return stopped
 end
 


### PR DESCRIPTION
Ensures that client memory is properly cleared when calling the reset method.