### PR TITLE
fix: manually trigger BufEnter when restoring buffers

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1104,8 +1104,7 @@ function M.setup(config)
       vim.api.nvim_create_autocmd({ 'BufEnter', 'BufLeave' }, {
         buffer = bufnr,
         callback = function(ev)
-          local is_enter = ev.event == 'BufEnter'
-          if is_enter then
+          if ev.event == 'BufEnter' then
             update_source()
           end
 

--- a/lua/CopilotChat/ui/overlay.lua
+++ b/lua/CopilotChat/ui/overlay.lua
@@ -115,16 +115,23 @@ end
 ---@param bufnr number?
 ---@protected
 function Overlay:restore(winnr, bufnr)
+  bufnr = bufnr or 0
+
   if self.on_hide then
     self.on_hide(self.bufnr)
   end
 
-  vim.api.nvim_win_set_buf(winnr, bufnr or 0)
+  vim.api.nvim_win_set_buf(winnr, bufnr)
   vim.api.nvim_win_set_hl_ns(winnr, 0)
 
   if self.cursor then
     vim.api.nvim_win_set_cursor(winnr, self.cursor)
   end
+
+  -- Manually trigger BufEnter event as nvim_win_set_buf does not trigger it
+  vim.schedule(function()
+    vim.cmd(string.format('doautocmd <nomodeline> BufEnter %s', bufnr))
+  end)
 end
 
 --- Show help message in the overlay


### PR DESCRIPTION
The nvim_win_set_buf API doesn't automatically trigger BufEnter events when switching buffers. This was causing issues with proper state updates in the Copilot Chat UI when navigating between buffers.

This commit adds explicit BufEnter triggering and simplifies some related code to ensure proper event handling.