### PR TITLE
fix(utils): optimize return to normal mode function

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -134,8 +134,9 @@ function M.return_to_normal_mode()
   local mode = vim.fn.mode():lower()
   if mode:find('v') then
     vim.cmd([[execute "normal! \<Esc>"]])
+  elseif mode ~= 'n' then
+    vim.cmd('stopinsert')
   end
-  vim.cmd('stopinsert')
 end
 
 --- Mark a function as deprecated


### PR DESCRIPTION
The function now only calls 'stopinsert' when not already in normal mode, avoiding unnecessary command execution when already in normal mode.