### PR TITLE
fix: ignore SSE comments in parsing stream response

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -619,7 +619,8 @@ function Client:ask(prompt, opts)
   local function parse_stream_line(line, job)
     line = vim.trim(line)
 
-    if vim.startswith(line, 'event:') then
+    -- Ignore SSE event names and comments
+    if vim.startswith(line, 'event:') or vim.startswith(line, ':') then
       return
     end
 


### PR DESCRIPTION
According to SSE specification, lines starting with colon (:) are considered comments and should be ignored. This fixes the stream parser to properly handle these lines when processing responses from Copilot.

Closes #944