### PR TITLE
fix: improve buffer handling in diff view

### DIFF
--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -377,16 +377,19 @@ return {
         opts.text = table.concat(modified, '\n')
 
         opts.on_show = function()
-          vim.cmd('diffthis')
-          vim.api.nvim_set_current_win(vim.fn.bufwinid(diff.bufnr))
-          vim.api.nvim_win_set_cursor(0, { diff.start_line, 0 })
-          vim.cmd('diffthis')
-          vim.api.nvim_set_current_win(copilot.chat.winnr)
-          vim.api.nvim_win_set_cursor(copilot.chat.winnr, { diff.start_line, 0 })
+          vim.api.nvim_win_call(vim.fn.bufwinid(diff.bufnr), function()
+            vim.cmd('diffthis')
+          end)
+
+          vim.api.nvim_win_call(copilot.chat.winnr, function()
+            vim.cmd('diffthis')
+          end)
         end
 
         opts.on_hide = function()
-          vim.cmd('diffoff')
+          vim.api.nvim_win_call(copilot.chat.winnr, function()
+            vim.cmd('diffoff')
+          end)
         end
       else
         opts.text = tostring(vim.diff(diff.reference, diff.change, {


### PR DESCRIPTION
Use vim.api.nvim_win_call to properly handle buffer and window context when enabling and disabling diff mode. This ensures commands are run in the correct window context rather than affecting the current one, preventing unexpected side effects.