### PR TITLE
feat(search)!: use ripgrep when available for file scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Examples:
 ```markdown
 > #buffer
 > #buffer:2
-> #files:*.lua
+> #files:\*.lua
 > #filenames
 > #git:staged
 > #url:https://example.com

--- a/README.md
+++ b/README.md
@@ -46,13 +46,8 @@ CopilotChat.nvim is a Neovim plugin that brings GitHub Copilot Chat capabilities
   - Manual: Download from [lua-tiktoken releases](https://github.com/gptlang/lua-tiktoken/releases) and save as `tiktoken_core.so` in your Lua path
 
 - [git](https://git-scm.com/) - For git diff context features
-
-  - Arch Linux: Install from official repositories
-  - Other systems: Use system package manager or official installer
-
+- [ripgrep](https://github.com/BurntSushi/ripgrep) - For improved search performance
 - [lynx](https://lynx.invisible-island.net/) - For improved URL context features
-  - Arch Linux: Install from official repositories
-  - Other systems: Use system package manager or official installer
 
 ## Integration with pickers
 
@@ -331,7 +326,7 @@ Examples:
 ```markdown
 > #buffer
 > #buffer:2
-> #files:.lua
+> #files:*.lua
 > #filenames
 > #git:staged
 > #url:https://example.com

--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -57,8 +57,6 @@ return {
     input = function(callback, source)
       local cwd = utils.win_cwd(source.winnr)
       local files = utils.scan_dir(cwd, {
-        add_dirs = false,
-        respect_gitignore = true,
         max_files = 1000,
       })
 
@@ -83,7 +81,7 @@ return {
     end,
     resolve = function(input, source)
       return context.files(source.winnr, true, {
-        search_pattern = input and utils.glob_to_regex(input),
+        glob = input,
       })
     end,
   },
@@ -97,7 +95,7 @@ return {
     end,
     resolve = function(input, source)
       return context.files(source.winnr, false, {
-        search_pattern = input and utils.glob_to_regex(input),
+        glob = input,
       })
     end,
   },

--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -72,6 +72,7 @@ local MIN_SYMBOL_SIMILARITY = 0.3
 local MIN_SEMANTIC_SIMILARITY = 0.4
 local MULTI_FILE_THRESHOLD = 5
 local MAX_FILES = 2500
+local MAX_DEPTH = 50
 
 --- Compute the cosine similarity between two vectors
 ---@param a table<number>
@@ -372,7 +373,7 @@ end
 --- Get list of all files in workspace
 ---@param winnr number?
 ---@param with_content boolean?
----@param search_options table?
+---@param search_options CopilotChat.utils.scan_dir_opts?
 ---@return table<CopilotChat.context.embed>
 function M.files(winnr, with_content, search_options)
   local cwd = utils.win_cwd(winnr)
@@ -382,9 +383,8 @@ function M.files(winnr, with_content, search_options)
   local files = utils.scan_dir(
     cwd,
     vim.tbl_extend('force', {
-      add_dirs = false,
-      respect_gitignore = true,
-      max_files = MAX_FILES,
+      max_count = MAX_FILES,
+      max_depth = MAX_DEPTH,
     }, search_options)
   )
 

--- a/lua/CopilotChat/health.lua
+++ b/lua/CopilotChat/health.lua
@@ -72,6 +72,15 @@ function M.check()
     ok('git: ' .. git_version)
   end
 
+  local rg_version = run_command('rg', '--version')
+  if rg_version == false then
+    warn(
+      'rg: missing, optional for improved search performance. See "https://github.com/BurntSushi/ripgrep".'
+    )
+  else
+    ok('rg: ' .. rg_version)
+  end
+
   local lynx_version = run_command('lynx', '-version')
   if lynx_version == false then
     warn(


### PR DESCRIPTION
Adds ripgrep integration to improve search performance when scanning directories. Falls back to the existing scandir implementation when ripgrep is not available. Updates the configuration options to use more consistent naming and adds health check for the ripgrep dependency. Also cleans up installation instructions in README.

BREAKING CHANGE: Due to previous incorrect glob handling,
.lua patterns etc need to be specified as *.lua