### PR TITLE
feat: improve default file scanning arguments

### DIFF
--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -56,7 +56,9 @@ return {
     description = 'Includes content of provided file in chat context. Supports input.',
     input = function(callback, source)
       local cwd = utils.win_cwd(source.winnr)
-      local files = utils.scan_dir(cwd, {})
+      local files = utils.scan_dir(cwd, {
+        max_count = 0,
+      })
 
       utils.schedule_main()
       vim.ui.select(files, {

--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -380,13 +380,7 @@ function M.files(winnr, with_content, search_options)
 
   notify.publish(notify.STATUS, 'Scanning files')
 
-  local files = utils.scan_dir(
-    cwd,
-    vim.tbl_extend('force', {
-      max_count = MAX_FILES,
-      max_depth = MAX_DEPTH,
-    }, search_options)
-  )
+  local files = utils.scan_dir(cwd, search_options)
 
   notify.publish(notify.STATUS, 'Reading files')
 


### PR DESCRIPTION
Define and apply sensible default arguments for file scanning operations across the codebase. This adds a central configuration for max_count, max_depth and no_ignore parameters, making file operations more consistent.

The changes also improve the handling of max_count=0, which now correctly disables the file count limit rather than returning an empty result set.