### PR TITLE
fix(readme): remove Tab mapping in normal mode for chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Default mappings in the chat interface:
 
 | Insert  | Normal  | Action                                     |
 | ------- | ------- | ------------------------------------------ |
-| `<Tab>` | `<Tab>` | Trigger/accept completion menu for tokens  |
+| `<Tab>` | -       | Trigger/accept completion menu for tokens  |
 | `<C-c>` | `q`     | Close the chat window                      |
 | `<C-l>` | `<C-l>` | Reset and clear the chat window            |
 | `<C-s>` | `<CR>`  | Submit the current prompt                  |


### PR DESCRIPTION
The Tab key was incorrectly documented as working in normal mode for triggering/accepting the completion menu for tokens in the chat interface. This commit corrects the documentation to show that Tab is only available in insert mode.