### PR TITLE
fix: allow using system prompt name as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ Below are all available configuration options with their default values:
 
   -- Shared config starts here (can be passed to functions at runtime and configured via setup function)
 
-  system_prompt = prompts.COPILOT_INSTRUCTIONS.system_prompt, -- System prompt to use (can be specified manually in prompt via /).
+  system_prompt = 'COPILOT_INSTRUCTIONS', -- System prompt to use (can be specified manually in prompt via /).
 
   model = 'gpt-4o', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
   agent = 'copilot', -- Default agent to use, see ':CopilotChatAgents' for available agents (can be specified manually in prompt via @).

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -1,4 +1,3 @@
-local prompts = require('CopilotChat.config.prompts')
 local select = require('CopilotChat.select')
 
 ---@class CopilotChat.config.window
@@ -56,7 +55,7 @@ return {
 
   -- Shared config starts here (can be passed to functions at runtime and configured via setup function)
 
-  system_prompt = prompts.COPILOT_INSTRUCTIONS.system_prompt, -- System prompt to use (can be specified manually in prompt via /).
+  system_prompt = 'COPILOT_INSTRUCTIONS', -- System prompt to use (can be specified manually in prompt via /).
 
   model = 'gpt-4o', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
   agent = 'none', -- Default agent to use, see ':CopilotChatAgents' for available agents (can be specified manually in prompt via @).
@@ -122,7 +121,7 @@ return {
   contexts = require('CopilotChat.config.contexts'),
 
   -- default prompts
-  prompts = prompts,
+  prompts = require('CopilotChat.config.prompts'),
 
   -- default mappings
   mappings = require('CopilotChat.config.mappings'),

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -320,7 +320,12 @@ function M.resolve_prompt(prompt, config)
     return inner_config, inner_prompt
   end
 
-  return resolve(config or M.config, prompt or '')
+  config = vim.tbl_deep_extend('force', M.config, config or {})
+  config, prompt = resolve(config, prompt or '')
+  if prompts_to_use[config.system_prompt] then
+    config.system_prompt = prompts_to_use[config.system_prompt].system_prompt
+  end
+  return config, prompt
 end
 
 --- Resolve the context embeddings from the prompt.


### PR DESCRIPTION
Previously system_prompt could only be set using the full prompt object path. Now users can simply specify the prompt name as a string, and the system will resolve it to the actual prompt content automatically.