### PR TITLE
fix: make second part of line matching in diffs optional

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -14,8 +14,8 @@ function CopilotChatFoldExpr(lnum, separator)
 end
 
 local HEADER_PATTERNS = {
-  '%[file:.+%]%((.+)%) line:(%d+)-(%d+)',
-  '%[file:(.+)%] line:(%d+)-(%d+)',
+  '%[file:.+%]%((.+)%) line:(%d+)-?(%d*)',
+  '%[file:(.+)%] line:(%d+)-?(%d*)',
 }
 
 ---@param header? string


### PR DESCRIPTION
so we can match format like line:61 for single line diffs