### PR TITLE
fix: disable auto-completion without proper completeopt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ CopilotChat.nvim is a Neovim plugin that brings GitHub Copilot Chat capabilities
 - [curl](https://curl.se/) - Version 8.0.0+ recommended for best compatibility
 - [Copilot chat in the IDE](https://github.com/settings/copilot) enabled in GitHub settings
 
-> [!NOTE]  
-> For Neovim < 0.11.0, add `noinsert` and `popup` to your `completeopt` for proper chat completion behavior.
+> [!WARNING]
+> For Neovim < 0.11.0, add `noinsert` and `popup` to your `completeopt` otherwise autocompletion will not work.
 
 ## Optional Dependencies
 

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1118,6 +1118,15 @@ function M.setup(config)
         vim.api.nvim_create_autocmd('TextChangedI', {
           buffer = bufnr,
           callback = function()
+            local completeopt = vim.opt.completeopt:get()
+            if
+              not vim.tbl_contains(completeopt, 'noinsert')
+              or not vim.tbl_contains(completeopt, 'popup')
+            then
+              -- Don't trigger completion if completeopt is not set to noinsert,popup
+              return
+            end
+
             local line = vim.api.nvim_get_current_line()
             local cursor = vim.api.nvim_win_get_cursor(0)
             local col = cursor[2]


### PR DESCRIPTION
Prevents completion from triggering automatically in chat buffers when
required completeopt settings ('noinsert' and 'popup') are missing.
This resolves issues where completion would behave unexpectedly.

Also updates the warning message in README.md to clarify this requirement.