### PR TITLE
fix: filter nil values from modified array

### DIFF
--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -384,6 +384,10 @@ return {
             end
           end
 
+          modified = vim.tbl_filter(function(line)
+            return line ~= nil
+          end, modified)
+
           opts.text = table.concat(modified, '\n')
         else
           opts.text = diff.change


### PR DESCRIPTION
When concatenating the modified array into a string, nil values could cause errors. This change adds a filter step to remove any nil values before concatenation, preventing potential runtime errors.