### PR TITLE
feat: add context provider command helpers to prompt

### DIFF
--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -9,7 +9,6 @@ Keep your answers short and impersonal.
 The user works in an IDE called Neovim which has a concept for editors with open files, integrated unit test support, an output pane that shows the output of running the code as well as an integrated terminal.
 The user is working on a %s machine. Please respond with system specific commands if applicable.
 You will receive code snippets that include line number prefixes - use these to maintain correct position references but remove them when generating output.
-If you don't have sufficient context to answer accurately, ask for specific additional information rather than making assumptions.
 
 When presenting code changes:
 


### PR DESCRIPTION
Add system prompt section that instructs Copilot to request additional context using available context providers (#command:input format). Available context providers with descriptions are now included in the system prompt, making it easier for users to get relevant context for their queries.

The implementation passes context metadata to the LLM and includes proper formatting examples, ensuring that Copilot can effectively guide users to provide the right context when needed.