### PR TITLE
fix: remove unnecessary package-name parameter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,5 +17,4 @@ jobs:
         id: release
         with:
           release-type: simple
-          package-name: CopilotChat.nvim
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The package-name parameter wasn't required by the release workflow and has been removed to simplify configuration.