### PR TITLE
refactor(context)!: move cwd handling to source object

### DIFF
--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -66,8 +66,7 @@ return {
   file = {
     description = 'Includes content of provided file in chat context. Supports input.',
     input = function(callback, source)
-      local cwd = utils.win_cwd(source.winnr)
-      local files = utils.scan_dir(cwd, {
+      local files = utils.scan_dir(source.cwd(), {
         max_count = 0,
       })
 
@@ -97,8 +96,7 @@ return {
     end,
     resolve = function(input, source)
       local out = {}
-      local cwd = utils.win_cwd(source.winnr)
-      local files = utils.scan_dir(cwd, {
+      local files = utils.scan_dir(source.cwd(), {
         glob = input,
       })
 
@@ -135,8 +133,7 @@ return {
     end,
     resolve = function(input, source)
       local out = {}
-      local cwd = utils.win_cwd(source.winnr)
-      local files = utils.scan_dir(cwd, {
+      local files = utils.scan_dir(source.cwd(), {
         glob = input,
       })
 
@@ -171,11 +168,10 @@ return {
     end,
     resolve = function(input, source)
       input = input or 'unstaged'
-      local cwd = utils.win_cwd(source.winnr)
       local cmd = {
         'git',
         '-C',
-        cwd,
+        source.cwd(),
         'diff',
         '--no-color',
         '--no-ext-diff',

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -17,6 +17,7 @@ local M = {}
 --- @class CopilotChat.source
 --- @field bufnr number
 --- @field winnr number
+--- @field cwd fun():string
 
 --- @class CopilotChat.state
 --- @field source CopilotChat.source?
@@ -290,6 +291,13 @@ local function update_source()
     state.source = {
       bufnr = source_bufnr,
       winnr = source_winnr,
+      cwd = function()
+        local dir = vim.w[source_winnr].cchat_cwd
+        if not dir or dir == '' then
+          return '.'
+        end
+        return dir
+      end,
     }
   end
 end

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -274,22 +274,6 @@ function M.make_string(...)
   return table.concat(t, ' ')
 end
 
---- Get current working directory for target window
----@param winnr number? The buffer number
----@return string
-function M.win_cwd(winnr)
-  if not winnr then
-    return '.'
-  end
-
-  local dir = vim.w[winnr].cchat_cwd
-  if not dir or dir == '' then
-    return '.'
-  end
-
-  return dir
-end
-
 --- Decode json
 ---@param body string The json string
 ---@return table, string?


### PR DESCRIPTION
Move window working directory logic from utils.win_cwd() to a method on the source object. This improves encapsulation by keeping the directory handling logic closer to the source object itself, while maintaining the same functionality.

The new approach uses a cwd() function on the source object that returns the appropriate directory value, simplifying how context providers access the current working directory.