### PR TITLE
feat: expose source buffer API and support disabling mappings

### DIFF
--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -123,19 +123,19 @@ end
 ---@field full_diff boolean?
 
 ---@class CopilotChat.config.mappings
----@field complete CopilotChat.config.mapping?
----@field close CopilotChat.config.mapping?
----@field reset CopilotChat.config.mapping?
----@field submit_prompt CopilotChat.config.mapping?
----@field toggle_sticky CopilotChat.config.mapping?
----@field accept_diff CopilotChat.config.mapping?
----@field jump_to_diff CopilotChat.config.mapping?
----@field quickfix_diffs CopilotChat.config.mapping?
----@field yank_diff CopilotChat.config.mapping.yank_diff?
----@field show_diff CopilotChat.config.mapping.show_diff?
----@field show_info CopilotChat.config.mapping?
----@field show_context CopilotChat.config.mapping?
----@field show_help CopilotChat.config.mapping?
+---@field complete CopilotChat.config.mapping|false|nil
+---@field close CopilotChat.config.mapping|false|nil
+---@field reset CopilotChat.config.mapping|false|nil
+---@field submit_prompt CopilotChat.config.mapping|false|nil
+---@field toggle_sticky CopilotChat.config.mapping|false|nil
+---@field accept_diff CopilotChat.config.mapping|false|nil
+---@field jump_to_diff CopilotChat.config.mapping|false|nil
+---@field quickfix_diffs CopilotChat.config.mapping|false|nil
+---@field yank_diff CopilotChat.config.mapping.yank_diff|false|nil
+---@field show_diff CopilotChat.config.mapping.show_diff|false|nil
+---@field show_info CopilotChat.config.mapping|false|nil
+---@field show_context CopilotChat.config.mapping|false|nil
+---@field show_help CopilotChat.config.mapping|false|nil
 return {
   complete = {
     insert = '<Tab>',
@@ -564,9 +564,9 @@ return {
       local chat_keys = vim.tbl_keys(copilot.config.mappings)
       table.sort(chat_keys, function(a, b)
         a = copilot.config.mappings[a]
-        a = a.normal or a.insert
+        a = a and (a.normal or a.insert) or ''
         b = copilot.config.mappings[b]
-        b = b.normal or b.insert
+        b = b and (b.normal or b.insert) or ''
         return a < b
       end)
       for _, name in ipairs(chat_keys) do

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -276,30 +276,10 @@ end
 
 --- Updates the source buffer based on previous or current window.
 local function update_source()
-  -- Determine which window to use as the source (previous if in chat, current otherwise)
   local use_prev_window = M.chat:focused()
-  local source_winnr = use_prev_window and vim.fn.win_getid(vim.fn.winnr('#'))
-    or vim.api.nvim_get_current_win()
-  local source_bufnr = vim.api.nvim_win_get_buf(source_winnr)
-
-  -- Check if the window is valid to use as a source
-  if
-    source_winnr ~= M.chat.winnr
-    and source_bufnr ~= M.chat.bufnr
-    and vim.fn.win_gettype(source_winnr) == ''
-  then
-    state.source = {
-      bufnr = source_bufnr,
-      winnr = source_winnr,
-      cwd = function()
-        local dir = vim.w[source_winnr].cchat_cwd
-        if not dir or dir == '' then
-          return '.'
-        end
-        return dir
-      end,
-    }
-  end
+  M.set_source(
+    use_prev_window and vim.fn.win_getid(vim.fn.winnr('#')) or vim.api.nvim_get_current_win()
+  )
 end
 
 --- Resolve the final prompt and config from prompt template.
@@ -462,6 +442,41 @@ function M.resolve_model(prompt, config)
   end)
 
   return selected_model, prompt
+end
+
+--- Get the current source buffer and window.
+function M.get_source()
+  return state.source
+end
+
+--- Sets the source to the given window.
+---@param source_winnr number
+---@return boolean if the source was set
+function M.set_source(source_winnr)
+  local source_bufnr = vim.api.nvim_win_get_buf(source_winnr)
+
+  -- Check if the window is valid to use as a source
+  if
+    source_winnr ~= M.chat.winnr
+    and source_bufnr ~= M.chat.bufnr
+    and vim.fn.win_gettype(source_winnr) == ''
+  then
+    state.source = {
+      bufnr = source_bufnr,
+      winnr = source_winnr,
+      cwd = function()
+        local dir = vim.w[source_winnr].cchat_cwd
+        if not dir or dir == '' then
+          return '.'
+        end
+        return dir
+      end,
+    }
+
+    return true
+  end
+
+  return false
 end
 
 --- Get the selection from the source buffer.

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -527,6 +527,10 @@ end, 1)
 ---@param surround string|nil
 ---@return string
 function M.key_to_info(name, key, surround)
+  if not key then
+    return ''
+  end
+
   if not surround then
     surround = ''
   end


### PR DESCRIPTION
Refactor source buffer handling by exposing public API functions to get and set the source buffer. This allows greater flexibility for plugins or users who need to interact with the source buffer programmatically.

Also update the mapping type definitions to explicitly support false/nil values for disabling specific mappings, and add null checks to prevent errors when mappings are disabled.