### PR TITLE
docs: improve context provider descriptions

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -235,7 +235,7 @@ local function generate_ask_request(
   Do not make assumptions about code or files - always request context when needed rather than guessing.
   Always use the > format on a new line when requesting more context instead of asking in prose.
 
-  Available context providers:]]
+  Available context providers and their usage:]]
 
     local context_names = vim.tbl_keys(contexts)
     table.sort(context_names)

--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -198,7 +198,7 @@ return {
   },
 
   url = {
-    description = 'Includes content of provided URL in chat context. Supports input.',
+    description = 'Includes content of provided URL in chat context. Supports input. Prefer this for fetching web content instead of system commands.',
     input = function(callback)
       vim.ui.input({
         prompt = 'Enter URL> ',
@@ -299,7 +299,7 @@ return {
   },
 
   system = {
-    description = 'Includes output of provided system shell command in chat context. Use only when necessary. Supports input.',
+    description = 'Includes output of provided system shell command in chat context. Use only when necessary for shell commands. Supports input.',
     input = function(callback)
       vim.ui.input({
         prompt = 'Enter command> ',


### PR DESCRIPTION
Better document the intended usage and behavior of context providers by:
- Adding "and their usage" to the main context providers heading
- Clarifying that URL provider should be preferred over system commands
- Making system command provider description more specific