### PR TITLE
fix: remove requirement for popup in completeopt

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ CopilotChat.nvim is a Neovim plugin that brings GitHub Copilot Chat capabilities
 - [Copilot chat in the IDE](https://github.com/settings/copilot) enabled in GitHub settings
 
 > [!WARNING]
-> For Neovim < 0.11.0, add `noinsert` and `popup` to your `completeopt` otherwise autocompletion will not work.
+> For Neovim < 0.11.0, add `noinsert` to your `completeopt` otherwise chat autocompletion will not work.
 
 ## Optional Dependencies
 

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1160,11 +1160,8 @@ function M.setup(config)
           buffer = bufnr,
           callback = function()
             local completeopt = vim.opt.completeopt:get()
-            if
-              not vim.tbl_contains(completeopt, 'noinsert')
-              or not vim.tbl_contains(completeopt, 'popup')
-            then
-              -- Don't trigger completion if completeopt is not set to noinsert,popup
+            if not vim.tbl_contains(completeopt, 'noinsert') then
+              -- Don't trigger completion if completeopt is not set to noinsert
               return
             end
 
@@ -1181,19 +1178,11 @@ function M.setup(config)
           end,
         })
 
-        -- Add popup and noinsert completeopt if not present
+        -- Add noinsert completeopt if not present
         if vim.fn.has('nvim-0.11.0') == 1 then
           local completeopt = vim.opt.completeopt:get()
-          local updated = false
           if not vim.tbl_contains(completeopt, 'noinsert') then
-            updated = true
             table.insert(completeopt, 'noinsert')
-          end
-          if not vim.tbl_contains(completeopt, 'popup') then
-            updated = true
-            table.insert(completeopt, 'popup')
-          end
-          if updated then
             vim.bo[bufnr].completeopt = table.concat(completeopt, ',')
           end
         end


### PR DESCRIPTION
The plugin previously required both 'noinsert' and 'popup' in completeopt for chat autocompletion to work. This change simplifies the requirements by only checking for 'noinsert', making the plugin more flexible and compatible with different Neovim configurations.

The code has been updated to:
- Remove popup requirement check in completion callback
- Remove automatic popup setting in completeopt
- Update documentation to reflect the changes