### PR TITLE
feat: support noselect completeopt setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ CopilotChat.nvim is a Neovim plugin that brings GitHub Copilot Chat capabilities
 - [Copilot chat in the IDE](https://github.com/settings/copilot) enabled in GitHub settings
 
 > [!WARNING]
-> For Neovim < 0.11.0, add `noinsert` to your `completeopt` otherwise chat autocompletion will not work.
+> For Neovim < 0.11.0, add `noinsert` or `noselect` to your `completeopt` otherwise chat autocompletion will not work.
 > For best autocompletion experience, also add `popup` to your `completeopt` (even on Neovim 0.11.0+).
 
 ## Optional Dependencies

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1160,8 +1160,11 @@ function M.setup(config)
           buffer = bufnr,
           callback = function()
             local completeopt = vim.opt.completeopt:get()
-            if not vim.tbl_contains(completeopt, 'noinsert') then
-              -- Don't trigger completion if completeopt is not set to noinsert
+            if
+              not vim.tbl_contains(completeopt, 'noinsert')
+              and not vim.tbl_contains(completeopt, 'noselect')
+            then
+              -- Don't trigger completion if completeopt is not set to noinsert or noselect
               return
             end
 


### PR DESCRIPTION
Allow chat autocompletion to work with either 'noinsert' or 'noselect' in completeopt for Neovim versions below 0.11.0. This provides more flexibility for users who prefer different completion behaviors.