### PR TITLE
perf: lower big file threshold for better performance

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -29,7 +29,7 @@ local class = utils.class
 --- Constants
 local CONTEXT_FORMAT = '[#file:%s](#file:%s-context)'
 local LINE_CHARACTERS = 100
-local BIG_FILE_THRESHOLD = 2000 * LINE_CHARACTERS
+local BIG_FILE_THRESHOLD = 1000 * LINE_CHARACTERS
 local BIG_EMBED_THRESHOLD = 200 * LINE_CHARACTERS
 local TRUNCATED = '... (truncated)'
 


### PR DESCRIPTION
Lower the threshold for what is considered a big file from 2000 to 1000 line characters. This change helps improve performance by reducing the amount of content that needs to be processed for large files.