### PR TITLE
refactor: expose COPILOT_BASE prompt as base prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ System prompts define the AI model's behavior. Reference them with `/PROMPT_NAME
 
 | Prompt                 | Description                                |
 | ---------------------- | ------------------------------------------ |
+| `COPILOT_BASE`         | All prompts should be built on top of this |
 | `COPILOT_INSTRUCTIONS` | Base instructions                          |
 | `COPILOT_EXPLAIN`      | Adds coding tutor behavior                 |
 | `COPILOT_REVIEW`       | Adds code review behavior with diagnostics |
@@ -243,6 +244,9 @@ Define your own system prompts in the configuration (similar to `prompts`):
   prompts = {
     Yarrr = {
       system_prompt = 'You are fascinated by pirates, so please respond in pirate speak.',
+    },
+    NiceInstructions = {
+      system_prompt = 'You are a nice coding tutor, so please respond in a friendly and helpful manner.' .. require('CopilotChat.config.prompts').COPILOT_BASE.system_prompt,
     }
   }
 }

--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -1,4 +1,4 @@
-local base = string.format(
+local COPILOT_BASE = string.format(
   [[
 When asked for your name, you must respond with "GitHub Copilot".
 Follow the user's requirements carefully & to the letter.
@@ -33,11 +33,11 @@ When presenting code changes:
 
 local COPILOT_INSTRUCTIONS = [[
 You are a code-focused AI programming assistant that specializes in practical software engineering solutions.
-]] .. base
+]] .. COPILOT_BASE
 
 local COPILOT_EXPLAIN = [[
 You are a programming instructor focused on clear, practical explanations.
-]] .. base .. [[
+]] .. COPILOT_BASE .. [[
 
 When explaining code:
 - Provide concise high-level overview first
@@ -51,7 +51,7 @@ When explaining code:
 
 local COPILOT_REVIEW = [[
 You are a code reviewer focused on improving code quality and maintainability.
-]] .. base .. [[
+]] .. COPILOT_BASE .. [[
 
 Format each issue you find precisely as:
 line=<line_number>: <issue_description>
@@ -83,6 +83,10 @@ If no issues found, confirm the code is well-written and explain why.
 
 ---@type table<string, CopilotChat.config.prompt>
 return {
+  COPILOT_BASE = {
+    system_prompt = COPILOT_BASE,
+  },
+
   COPILOT_INSTRUCTIONS = {
     system_prompt = COPILOT_INSTRUCTIONS,
   },


### PR DESCRIPTION
Extract the base prompt into COPILOT_BASE to allow custom prompts to be built on top of it. This enables users to extend the base behavior while maintaining core Copilot functionality.

The change includes:
- Renamed local 'base' to 'COPILOT_BASE'
- Exposed COPILOT_BASE in the returned prompts table
- Updated documentation to reflect the new base prompt
- Added example of extending base prompt in custom configurations