### PR TITLE
feat(chat): add streaming callback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,8 +460,9 @@ Below are all available configuration options with their default values:
   sticky = nil, -- Default sticky prompt or array of sticky prompts to use at start of every new chat.
 
   temperature = 0.1, -- GPT result temperature
-  headless = false, -- Do not write to chat buffer and use history(useful for using callback for custom processing)
-  callback = nil, -- Callback to use when ask response is received
+  headless = false, -- Do not write to chat buffer and use history (useful for using custom processing)
+  stream = nil, -- Function called when receiving stream updates (returned string is appended to the chat buffer)
+  callback = nil, -- Function called when full response is received (retuned string is stored to history)
   remember_as_sticky = true, -- Remember model/agent/context as sticky prompts when asking questions
 
   -- default selection
@@ -748,6 +749,7 @@ require("CopilotChat").open()
 require("CopilotChat").ask("Explain this code", {
   callback = function(response)
     vim.notify("Got response: " .. response:sub(1, 50) .. "...")
+    return response
   end,
   context = "#buffer"
 })

--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -1,6 +1,6 @@
 ---@class CopilotChat.Client.ask
 ---@field load_history boolean
----@field store_history boolean
+---@field summarize_history boolean
 ---@field contexts table<string, string>?
 ---@field selection CopilotChat.select.selection?
 ---@field embeddings table<CopilotChat.context.embed>?
@@ -530,7 +530,7 @@ function Client:ask(prompt, opts)
 
     -- If we're over history limit, trigger summarization
     if history_tokens > history_limit then
-      if opts.store_history and #history >= 4 then
+      if opts.summarize_history and #history >= 4 then
         self:summarize_history(opts.model)
 
         -- Recalculate history and tokens
@@ -755,18 +755,6 @@ function Client:ask(prompt, opts)
     return
   end
 
-  if opts.store_history then
-    table.insert(self.history, {
-      content = prompt,
-      role = 'user',
-    })
-
-    table.insert(self.history, {
-      content = response_text,
-      role = 'assistant',
-    })
-  end
-
   return response_text, references:values(), last_message and last_message.total_tokens or 0, max_tokens
 end
 
@@ -943,7 +931,7 @@ Ensure all critical code samples, commands, and configuration snippets are prese
 
   local response = self:ask('Create a technical summary of our conversation for future context', {
     load_history = true,
-    store_history = false,
+    summarize_history = false,
     model = model,
     temperature = 0,
     system_prompt = system_prompt,

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -20,7 +20,8 @@ local select = require('CopilotChat.select')
 ---@field sticky string|table<string>|nil
 ---@field temperature number?
 ---@field headless boolean?
----@field callback fun(response: string, source: CopilotChat.source)?
+---@field stream nil|fun(chunk: string, source: CopilotChat.source):string
+---@field callback nil|fun(response: string, source: CopilotChat.source):string
 ---@field remember_as_sticky boolean?
 ---@field selection false|nil|fun(source: CopilotChat.source):CopilotChat.select.selection?
 ---@field window CopilotChat.config.window?
@@ -63,8 +64,9 @@ return {
   sticky = nil, -- Default sticky prompt or array of sticky prompts to use at start of every new chat.
 
   temperature = 0.1, -- GPT result temperature
-  headless = false, -- Do not write to chat buffer and use history(useful for using callback for custom processing)
-  callback = nil, -- Callback to use when ask response is received
+  headless = false, -- Do not write to chat buffer and use history (useful for using custom processing)
+  stream = nil, -- Function called when receiving stream updates (returned string is appended to the chat buffer)
+  callback = nil, -- Function called when full response is received (retuned string is stored to history)
   remember_as_sticky = true, -- Remember model/agent/context as sticky prompts when asking questions
 
   -- default selection

--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -141,6 +141,7 @@ return {
         end
       end
       vim.diagnostic.set(vim.api.nvim_create_namespace('copilot-chat-diagnostics'), source.bufnr, diagnostics)
+      return response
     end,
   },
 


### PR DESCRIPTION
Add stream callback function to process tokens as they are received from Copilot while callback function is used to process the complete final response. Both functions can modify the text that gets displayed and stored in history.

This separates streaming token processing from final response handling, giving more control over how chat outputs are processed and displayed.