### PR TITLE
fix: add error handling for context resolution

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,4 +1,4 @@
-column_width = 100
+column_width = 120
 line_endings = "Unix"
 indent_type = "Spaces"
 indent_width = 2

--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -91,8 +91,7 @@ local function generate_content_block(content, outline, threshold, start_line)
     local total_lines = #lines
     local max_length = #tostring(total_lines)
     for i, line in ipairs(lines) do
-      local formatted_line_number =
-        string.format('%' .. max_length .. 'd', i - 1 + (start_line or 1))
+      local formatted_line_number = string.format('%' .. max_length .. 'd', i - 1 + (start_line or 1))
       lines[i] = formatted_line_number .. ': ' .. line
     end
 
@@ -141,13 +140,7 @@ local function generate_selection_messages(selection)
   local out = string.format('# FILE:%s CONTEXT\n', filename:upper())
   out = out .. "User's active selection:\n"
   if selection.start_line and selection.end_line then
-    out = out
-      .. string.format(
-        'Excerpt from %s, lines %s to %s:\n',
-        filename,
-        selection.start_line,
-        selection.end_line
-      )
+    out = out .. string.format('Excerpt from %s, lines %s to %s:\n', filename, selection.start_line, selection.end_line)
   end
   out = out
     .. string.format(
@@ -158,10 +151,7 @@ local function generate_selection_messages(selection)
 
   if selection.diagnostics then
     out = out
-      .. string.format(
-        "\nDiagnostics in user's active selection:\n%s",
-        generate_diagnostics(selection.diagnostics)
-      )
+      .. string.format("\nDiagnostics in user's active selection:\n%s", generate_diagnostics(selection.diagnostics))
   end
 
   return {
@@ -215,22 +205,14 @@ end
 --- @param prompt string
 --- @param system_prompt string
 --- @param generated_messages table<CopilotChat.Provider.input>
-local function generate_ask_request(
-  history,
-  memory,
-  contexts,
-  prompt,
-  system_prompt,
-  generated_messages
-)
+local function generate_ask_request(history, memory, contexts, prompt, system_prompt, generated_messages)
   local messages = {}
 
   system_prompt = vim.trim(system_prompt)
 
   -- Include context help
   if contexts and not vim.tbl_isempty(contexts) then
-    local help_text =
-      [[When you need additional context, you must request it using context providers in this format:
+    local help_text = [[When you need additional context, you must request it using context providers in this format:
 
 > #<command>:`<input>`
 
@@ -319,17 +301,11 @@ end
 --- @return table<string>
 local function generate_embedding_request(inputs, threshold)
   return vim.tbl_map(function(embedding)
-    local content =
-      generate_content_block(embedding.outline or embedding.content, nil, threshold, -1)
+    local content = generate_content_block(embedding.outline or embedding.content, nil, threshold, -1)
     if embedding.filetype == 'raw' then
       return content
     else
-      return string.format(
-        'File: `%s`\n```%s\n%s\n```',
-        embedding.filename,
-        embedding.filetype,
-        content
-      )
+      return string.format('File: `%s`\n```%s\n%s\n```', embedding.filename, embedding.filetype, content)
     end
   end, inputs)
 end
@@ -362,9 +338,7 @@ function Client:authenticate(provider_name)
   local headers = self.provider_cache[provider_name].headers
   local expires_at = self.provider_cache[provider_name].expires_at
 
-  if
-    provider.get_headers and (not headers or (expires_at and expires_at <= math.floor(os.time())))
-  then
+  if provider.get_headers and (not headers or (expires_at and expires_at <= math.floor(os.time()))) then
     headers, expires_at = provider.get_headers()
     self.provider_cache[provider_name].headers = headers
     self.provider_cache[provider_name].expires_at = expires_at
@@ -515,8 +489,7 @@ function Client:ask(prompt, opts)
 
   local history = {}
   if opts.load_history then
-    history =
-      vim.list_slice(self.history, self.memory and (self.memory.last_summarized_index + 1) or 1)
+    history = vim.list_slice(self.history, self.memory and (self.memory.last_summarized_index + 1) or 1)
   end
 
   local references = utils.ordered_map()
@@ -546,9 +519,7 @@ function Client:ask(prompt, opts)
     local required_tokens = prompt_tokens + system_tokens + selection_tokens + memory_tokens
 
     -- Reserve space for first embedding
-    local reserved_tokens = #embeddings_messages > 0
-        and tiktoken.count(embeddings_messages[1].content)
-      or 0
+    local reserved_tokens = #embeddings_messages > 0 and tiktoken.count(embeddings_messages[1].content) or 0
 
     -- Calculate how many tokens we can use for history
     local history_limit = max_tokens - required_tokens - reserved_tokens
@@ -563,8 +534,7 @@ function Client:ask(prompt, opts)
         self:summarize_history(opts.model)
 
         -- Recalculate history and tokens
-        history =
-          vim.list_slice(self.history, self.memory and (self.memory.last_summarized_index + 1) or 1)
+        history = vim.list_slice(self.history, self.memory and (self.memory.last_summarized_index + 1) or 1)
         history_tokens = 0
         for _, msg in ipairs(history) do
           history_tokens = history_tokens + tiktoken.count(msg.content)
@@ -714,14 +684,7 @@ function Client:ask(prompt, opts)
 
   local headers = self:authenticate(provider_name)
   local request = provider.prepare_input(
-    generate_ask_request(
-      history,
-      self.memory,
-      opts.contexts,
-      prompt,
-      opts.system_prompt,
-      generated_messages
-    ),
+    generate_ask_request(history, self.memory, opts.contexts, prompt, opts.system_prompt, generated_messages),
     options
   )
   local is_stream = request.stream
@@ -804,10 +767,7 @@ function Client:ask(prompt, opts)
     })
   end
 
-  return response_text,
-    references:values(),
-    last_message and last_message.total_tokens or 0,
-    max_tokens
+  return response_text, references:values(), last_message and last_message.total_tokens or 0, max_tokens
 end
 
 --- List available models
@@ -887,8 +847,7 @@ function Client:embed(inputs, model)
     local success = false
     local attempts = 0
     while not success and attempts < 5 do -- Limit total attempts to 5
-      local ok, data =
-        pcall(embed, generate_embedding_request(batch, threshold), self:authenticate(provider_name))
+      local ok, data = pcall(embed, generate_embedding_request(batch, threshold), self:authenticate(provider_name))
 
       if not ok then
         log.debug('Failed to get embeddings: ', data)

--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -55,9 +55,7 @@ return {
       return vim.tbl_map(
         context.get_buffer,
         vim.tbl_filter(function(b)
-          return utils.buf_valid(b)
-            and vim.fn.buflisted(b) == 1
-            and (input == 'listed' or #vim.fn.win_findbuf(b) > 0)
+          return utils.buf_valid(b) and vim.fn.buflisted(b) == 1 and (input == 'listed' or #vim.fn.win_findbuf(b) > 0)
         end, vim.api.nvim_list_bufs())
       )
     end,

--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -50,8 +50,7 @@ local function get_diff(block)
 
     -- If we found a valid buffer, get the reference content
     if bufnr and utils.buf_valid(bufnr) then
-      reference =
-        table.concat(vim.api.nvim_buf_get_lines(bufnr, start_line - 1, end_line, false), '\n')
+      reference = table.concat(vim.api.nvim_buf_get_lines(bufnr, start_line - 1, end_line, false), '\n')
       filetype = vim.bo[bufnr].filetype
     end
   end
@@ -349,9 +348,7 @@ return {
       }
 
       if copilot.config.mappings.show_diff.full_diff then
-        local modified = utils.buf_valid(diff.bufnr)
-            and vim.api.nvim_buf_get_lines(diff.bufnr, 0, -1, false)
-          or {}
+        local modified = utils.buf_valid(diff.bufnr) and vim.api.nvim_buf_get_lines(diff.bufnr, 0, -1, false) or {}
 
         -- Apply all diffs from same file
         if #modified > 0 then

--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -140,11 +140,7 @@ return {
           end
         end
       end
-      vim.diagnostic.set(
-        vim.api.nvim_create_namespace('copilot-chat-diagnostics'),
-        source.bufnr,
-        diagnostics
-      )
+      vim.diagnostic.set(vim.api.nvim_create_namespace('copilot-chat-diagnostics'), source.bufnr, diagnostics)
     end,
   },
 

--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -1,11 +1,6 @@
 local utils = require('CopilotChat.utils')
 
-local EDITOR_VERSION = 'Neovim/'
-  .. vim.version().major
-  .. '.'
-  .. vim.version().minor
-  .. '.'
-  .. vim.version().patch
+local EDITOR_VERSION = 'Neovim/' .. vim.version().major .. '.' .. vim.version().minor .. '.' .. vim.version().patch
 
 local cached_github_token = nil
 
@@ -271,16 +266,11 @@ M.copilot = {
       message = output
     end
 
-    local content = message.message and message.message.content
-      or message.delta and message.delta.content
+    local content = message.message and message.message.content or message.delta and message.delta.content
 
-    local usage = message.usage and message.usage.total_tokens
-      or output.usage and output.usage.total_tokens
+    local usage = message.usage and message.usage.total_tokens or output.usage and output.usage.total_tokens
 
-    local finish_reason = message.finish_reason
-      or message.done_reason
-      or output.finish_reason
-      or output.done_reason
+    local finish_reason = message.finish_reason or message.done_reason or output.finish_reason or output.done_reason
 
     return {
       content = content,
@@ -311,21 +301,20 @@ M.github_models = {
   end,
 
   get_models = function(headers)
-    local response, err =
-      utils.curl_post('https://api.catalog.azureml.ms/asset-gallery/v1.0/models', {
-        headers = headers,
-        json_request = true,
-        json_response = true,
-        body = {
-          filters = {
-            { field = 'freePlayground', values = { 'true' }, operator = 'eq' },
-            { field = 'labels', values = { 'latest' }, operator = 'eq' },
-          },
-          order = {
-            { field = 'displayName', direction = 'asc' },
-          },
+    local response, err = utils.curl_post('https://api.catalog.azureml.ms/asset-gallery/v1.0/models', {
+      headers = headers,
+      json_request = true,
+      json_response = true,
+      body = {
+        filters = {
+          { field = 'freePlayground', values = { 'true' }, operator = 'eq' },
+          { field = 'labels', values = { 'latest' }, operator = 'eq' },
         },
-      })
+        order = {
+          { field = 'displayName', direction = 'asc' },
+        },
+      },
+    })
 
     if err then
       error(err)

--- a/lua/CopilotChat/context.lua
+++ b/lua/CopilotChat/context.lua
@@ -391,11 +391,8 @@ function M.get_buffer(bufnr)
     return nil
   end
 
-  local out = M.get_outline(
-    table.concat(content, '\n'),
-    utils.filepath(vim.api.nvim_buf_get_name(bufnr)),
-    vim.bo[bufnr].filetype
-  )
+  local out =
+    M.get_outline(table.concat(content, '\n'), utils.filepath(vim.api.nvim_buf_get_name(bufnr)), vim.bo[bufnr].filetype)
 
   out.score = 0.1
   out.diagnostics = utils.diagnostics(bufnr)
@@ -426,18 +423,12 @@ function M.get_url(url)
       content = vim.trim(response
         .body
         -- Remove script, style tags and their contents first
-        :gsub(
-          '<script.-</script>',
-          ''
-        )
+        :gsub('<script.-</script>', '')
         :gsub('<style.-</style>', '')
         -- Remove XML/CDATA in one go
         :gsub('<!?%[?[%w%s]*%]?>', '')
         -- Remove all HTML tags (both opening and closing) in one go
-        :gsub(
-          '<%/?%w+[^>]*>',
-          ' '
-        )
+        :gsub('<%/?%w+[^>]*>', ' ')
         -- Handle common HTML entities
         :gsub('&(%w+);', {
           nbsp = ' ',

--- a/lua/CopilotChat/health.lua
+++ b/lua/CopilotChat/health.lua
@@ -74,18 +74,14 @@ function M.check()
 
   local rg_version = run_command('rg', '--version')
   if rg_version == false then
-    warn(
-      'rg: missing, optional for improved search performance. See "https://github.com/BurntSushi/ripgrep".'
-    )
+    warn('rg: missing, optional for improved search performance. See "https://github.com/BurntSushi/ripgrep".')
   else
     ok('rg: ' .. rg_version)
   end
 
   local lynx_version = run_command('lynx', '-version')
   if lynx_version == false then
-    warn(
-      'lynx: missing, optional for improved fetching of url contents. See "https://lynx.invisible-island.net/".'
-    )
+    warn('lynx: missing, optional for improved fetching of url contents. See "https://lynx.invisible-island.net/".')
   else
     ok('lynx: ' .. lynx_version)
   end
@@ -95,9 +91,7 @@ function M.check()
   if lualib_installed('plenary') then
     ok('plenary: installed')
   else
-    error(
-      'plenary: missing, required for http requests and async jobs. Install "nvim-lua/plenary.nvim" plugin.'
-    )
+    error('plenary: missing, required for http requests and async jobs. Install "nvim-lua/plenary.nvim" plugin.')
   end
 
   local has_copilot = lualib_installed('copilot')
@@ -122,9 +116,7 @@ function M.check()
   if lualib_installed('tiktoken_core') then
     ok('tiktoken_core: installed')
   else
-    warn(
-      'tiktoken_core: missing, optional for accurate token counting. See README for installation instructions.'
-    )
+    warn('tiktoken_core: missing, optional for accurate token counting. See README for installation instructions.')
   end
 
   if treesitter_parser_available('markdown') then

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -383,12 +383,17 @@ function M.resolve_context(prompt, config)
         .. context_data.name
         .. (context_data.input and ' with input: ' .. context_data.input or '')
     )
-    for _, embedding in
-      ipairs(context_value.resolve(context_data.input, state.source or {}, prompt))
-    do
-      if embedding then
-        embeddings:set(embedding.filename, embedding)
+
+    local ok, resolved_embeddings =
+      pcall(context_value.resolve, context_data.input, state.source or {}, prompt)
+    if ok then
+      for _, embedding in resolved_embeddings do
+        if embedding then
+          embeddings:set(embedding.filename, embedding)
+        end
       end
+    else
+      log.error('Failed to resolve context: ' .. context_data.name)
     end
   end
 

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -71,11 +71,7 @@ local function insert_sticky(prompt, config, override_sticky)
     stickies:set('/' .. config.system_prompt, true)
   end
 
-  if
-    config.remember_as_sticky
-    and config.context
-    and not vim.deep_equal(config.context, M.config.context)
-  then
+  if config.remember_as_sticky and config.context and not vim.deep_equal(config.context, M.config.context) then
     if type(config.context) == 'table' then
       ---@diagnostic disable-next-line: param-type-mismatch
       for _, context in ipairs(config.context) do
@@ -124,12 +120,7 @@ local function update_highlights()
 
   if M.chat.config.highlight_selection and M.chat:focused() then
     local selection = M.get_selection()
-    if
-      not selection
-      or not utils.buf_valid(selection.bufnr)
-      or not selection.start_line
-      or not selection.end_line
-    then
+    if not selection or not utils.buf_valid(selection.bufnr) or not selection.start_line or not selection.end_line then
       return
     end
 
@@ -260,11 +251,7 @@ local function map_key(name, bufnr, fn)
       if vim.fn.pumvisible() == 1 then
         local used_key = key.insert == M.config.mappings.complete.insert and '<C-y>' or key.insert
         if used_key then
-          vim.api.nvim_feedkeys(
-            vim.api.nvim_replace_termcodes(used_key, true, false, true),
-            'n',
-            false
-          )
+          vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(used_key, true, false, true), 'n', false)
         end
       else
         fn()
@@ -276,9 +263,7 @@ end
 --- Updates the source buffer based on previous or current window.
 local function update_source()
   local use_prev_window = M.chat:focused()
-  M.set_source(
-    use_prev_window and vim.fn.win_getid(vim.fn.winnr('#')) or vim.api.nvim_get_current_win()
-  )
+  M.set_source(use_prev_window and vim.fn.win_getid(vim.fn.winnr('#')) or vim.api.nvim_get_current_win())
 end
 
 --- Resolve the final prompt and config from prompt template.
@@ -379,13 +364,10 @@ function M.resolve_context(prompt, config)
     local context_value = M.config.contexts[context_data.name]
     notify.publish(
       notify.STATUS,
-      'Resolving context: '
-        .. context_data.name
-        .. (context_data.input and ' with input: ' .. context_data.input or '')
+      'Resolving context: ' .. context_data.name .. (context_data.input and ' with input: ' .. context_data.input or '')
     )
 
-    local ok, resolved_embeddings =
-      pcall(context_value.resolve, context_data.input, state.source or {}, prompt)
+    local ok, resolved_embeddings = pcall(context_value.resolve, context_data.input, state.source or {}, prompt)
     if ok then
       for _, embedding in resolved_embeddings do
         if embedding then
@@ -460,11 +442,7 @@ function M.set_source(source_winnr)
   local source_bufnr = vim.api.nvim_win_get_buf(source_winnr)
 
   -- Check if the window is valid to use as a source
-  if
-    source_winnr ~= M.chat.winnr
-    and source_bufnr ~= M.chat.bufnr
-    and vim.fn.win_gettype(source_winnr) == ''
-  then
+  if source_winnr ~= M.chat.winnr and source_bufnr ~= M.chat.bufnr and vim.fn.win_gettype(source_winnr) == '' then
     state.source = {
       bufnr = source_bufnr,
       winnr = source_winnr,
@@ -832,10 +810,7 @@ function M.select_prompt(config)
     end,
   }, function(choice)
     if choice then
-      M.ask(
-        prompts[choice.name].prompt,
-        vim.tbl_extend('force', prompts[choice.name], config or {})
-      )
+      M.ask(prompts[choice.name].prompt, vim.tbl_extend('force', prompts[choice.name], config or {}))
     end
   end)
 end
@@ -914,24 +889,23 @@ function M.ask(prompt, config)
       return
     end
 
-    local ask_ok, response, references, token_count, token_max_count =
-      pcall(client.ask, client, prompt, {
-        load_history = not config.headless,
-        store_history = not config.headless,
-        contexts = contexts,
-        selection = selection,
-        embeddings = filtered_embeddings,
-        system_prompt = system_prompt,
-        model = selected_model,
-        agent = selected_agent,
-        temperature = config.temperature,
-        on_progress = vim.schedule_wrap(function(token)
-          if not config.headless then
-            M.chat:append(token)
-          end
-          has_output = true
-        end),
-      })
+    local ask_ok, response, references, token_count, token_max_count = pcall(client.ask, client, prompt, {
+      load_history = not config.headless,
+      store_history = not config.headless,
+      contexts = contexts,
+      selection = selection,
+      embeddings = filtered_embeddings,
+      system_prompt = system_prompt,
+      model = selected_model,
+      agent = selected_agent,
+      temperature = config.temperature,
+      on_progress = vim.schedule_wrap(function(token)
+        if not config.headless then
+          M.chat:append(token)
+        end
+        has_output = true
+      end),
+    })
 
     utils.schedule_main()
 
@@ -1166,10 +1140,7 @@ function M.setup(config)
           buffer = bufnr,
           callback = function()
             local completeopt = vim.opt.completeopt:get()
-            if
-              not vim.tbl_contains(completeopt, 'noinsert')
-              and not vim.tbl_contains(completeopt, 'noselect')
-            then
+            if not vim.tbl_contains(completeopt, 'noinsert') and not vim.tbl_contains(completeopt, 'noselect') then
               -- Don't trigger completion if completeopt is not set to noinsert or noselect
               return
             end

--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -12,9 +12,7 @@ end
 local function load_tiktoken_data(tokenizer)
   utils.schedule_main()
 
-  local tiktoken_url = 'https://openaipublic.blob.core.windows.net/encodings/'
-    .. tokenizer
-    .. '.tiktoken'
+  local tiktoken_url = 'https://openaipublic.blob.core.windows.net/encodings/' .. tokenizer .. '.tiktoken'
 
   local cache_dir = vim.fn.stdpath('cache')
   vim.fn.mkdir(tostring(cache_dir), 'p')

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -28,9 +28,7 @@ local function match_header(header)
   for _, pattern in ipairs(HEADER_PATTERNS) do
     local filename, start_line, end_line = header:match(pattern)
     if filename then
-      return utils.filepath(filename),
-        tonumber(start_line) or 1,
-        tonumber(end_line) or tonumber(start_line) or 1
+      return utils.filepath(filename), tonumber(start_line) or 1, tonumber(end_line) or tonumber(start_line) or 1
     end
   end
 end
@@ -100,9 +98,7 @@ end, Overlay)
 --- Returns whether the chat window is visible.
 ---@return boolean
 function Chat:visible()
-  return self.winnr
-      and vim.api.nvim_win_is_valid(self.winnr)
-      and vim.api.nvim_win_get_buf(self.winnr) == self.bufnr
+  return self.winnr and vim.api.nvim_win_is_valid(self.winnr) and vim.api.nvim_win_get_buf(self.winnr) == self.bufnr
     or false
 end
 
@@ -131,11 +127,7 @@ function Chat:get_closest_section(type)
       or (type == 'answer' and section.answer)
       or (type == 'question' and not section.answer)
 
-    if
-      matches_type
-      and section.start_line <= cursor_line
-      and section.start_line > max_line_below_cursor
-    then
+    if matches_type and section.start_line <= cursor_line and section.start_line > max_line_below_cursor then
       max_line_below_cursor = section.start_line
       closest_section = section
     end
@@ -267,14 +259,7 @@ function Chat:overlay(opts)
     return
   end
 
-  self.chat_overlay:show(
-    opts.text,
-    self.winnr,
-    opts.filetype,
-    opts.syntax,
-    opts.on_show,
-    opts.on_hide
-  )
+  self.chat_overlay:show(opts.text, self.winnr, opts.filetype, opts.syntax, opts.on_show, opts.on_hide)
 end
 
 --- Open the chat window.
@@ -438,14 +423,7 @@ function Chat:append(str)
   end
 
   local last_line, last_column, _ = self:last()
-  vim.api.nvim_buf_set_text(
-    self.bufnr,
-    last_line,
-    last_column,
-    last_line,
-    last_column,
-    vim.split(str, '\n')
-  )
+  vim.api.nvim_buf_set_text(self.bufnr, last_line, last_column, last_line, last_column, vim.split(str, '\n'))
 
   if should_follow_cursor then
     self:follow()
@@ -489,11 +467,7 @@ end
 ---@protected
 function Chat:validate()
   Overlay.validate(self)
-  if
-    self.winnr
-    and vim.api.nvim_win_is_valid(self.winnr)
-    and vim.api.nvim_win_get_buf(self.winnr) ~= self.bufnr
-  then
+  if self.winnr and vim.api.nvim_win_is_valid(self.winnr) and vim.api.nvim_win_get_buf(self.winnr) ~= self.bufnr then
     vim.api.nvim_win_set_buf(self.winnr, self.bufnr)
   end
 end
@@ -516,12 +490,8 @@ function Chat:render()
       separator_found = true
       if current_section then
         current_section.end_line = l - 1
-        current_section.content = vim.trim(
-          table.concat(
-            vim.list_slice(lines, current_section.start_line, current_section.end_line),
-            '\n'
-          )
-        )
+        current_section.content =
+          vim.trim(table.concat(vim.list_slice(lines, current_section.start_line, current_section.end_line), '\n'))
         table.insert(sections, current_section)
       end
       current_section = {
@@ -533,12 +503,8 @@ function Chat:render()
       separator_found = true
       if current_section then
         current_section.end_line = l - 1
-        current_section.content = vim.trim(
-          table.concat(
-            vim.list_slice(lines, current_section.start_line, current_section.end_line),
-            '\n'
-          )
-        )
+        current_section.content =
+          vim.trim(table.concat(vim.list_slice(lines, current_section.start_line, current_section.end_line), '\n'))
         table.insert(sections, current_section)
       end
       current_section = {
@@ -549,12 +515,8 @@ function Chat:render()
     elseif l == line_count then
       if current_section then
         current_section.end_line = l
-        current_section.content = vim.trim(
-          table.concat(
-            vim.list_slice(lines, current_section.start_line, current_section.end_line),
-            '\n'
-          )
-        )
+        current_section.content =
+          vim.trim(table.concat(vim.list_slice(lines, current_section.start_line, current_section.end_line), '\n'))
         table.insert(sections, current_section)
       end
     end
@@ -601,10 +563,8 @@ function Chat:render()
         }
       elseif line == '```' and current_block then
         current_block.end_line = l - 1
-        current_block.content = table.concat(
-          vim.list_slice(lines, current_block.start_line, current_block.end_line),
-          '\n'
-        )
+        current_block.content =
+          table.concat(vim.list_slice(lines, current_block.start_line, current_block.end_line), '\n')
         table.insert(current_section.blocks, current_block)
         current_block = nil
       end

--- a/lua/CopilotChat/ui/spinner.lua
+++ b/lua/CopilotChat/ui/spinner.lua
@@ -52,20 +52,14 @@ function Spinner:start()
         frame = self.status .. ' ' .. frame
       end
 
-      vim.api.nvim_buf_set_extmark(
-        self.bufnr,
-        self.ns,
-        math.max(0, vim.api.nvim_buf_line_count(self.bufnr) - 1),
-        0,
-        {
-          id = 1,
-          hl_mode = 'combine',
-          priority = 100,
-          virt_text = {
-            { frame, 'CopilotChatStatus' },
-          },
-        }
-      )
+      vim.api.nvim_buf_set_extmark(self.bufnr, self.ns, math.max(0, vim.api.nvim_buf_line_count(self.bufnr) - 1), 0, {
+        id = 1,
+        hl_mode = 'combine',
+        priority = 100,
+        virt_text = {
+          { frame, 'CopilotChatStatus' },
+        },
+      })
 
       self.index = self.index % #spinner_frames + 1
     end)

--- a/plugin/CopilotChat.lua
+++ b/plugin/CopilotChat.lua
@@ -4,10 +4,7 @@ end
 
 local min_version = '0.10.0'
 if vim.fn.has('nvim-' .. min_version) ~= 1 then
-  vim.notify_once(
-    ('CopilotChat.nvim requires Neovim >= %s'):format(min_version),
-    vim.log.levels.ERROR
-  )
+  vim.notify_once(('CopilotChat.nvim requires Neovim >= %s'):format(min_version), vim.log.levels.ERROR)
   return
 end
 
@@ -20,11 +17,7 @@ vim.api.nvim_set_hl(0, 'CopilotChatKeyword', { link = 'Keyword', default = true 
 vim.api.nvim_set_hl(0, 'CopilotChatInput', { link = 'Special', default = true })
 vim.api.nvim_set_hl(0, 'CopilotChatSelection', { link = 'Visual', default = true })
 vim.api.nvim_set_hl(0, 'CopilotChatHeader', { link = '@markup.heading.2.markdown', default = true })
-vim.api.nvim_set_hl(
-  0,
-  'CopilotChatSeparator',
-  { link = '@punctuation.special.markdown', default = true }
-)
+vim.api.nvim_set_hl(0, 'CopilotChatSeparator', { link = '@punctuation.special.markdown', default = true })
 
 -- Setup commands
 vim.api.nvim_create_user_command('CopilotChat', function(args)


### PR DESCRIPTION
Wraps context resolver in pcall to properly handle errors that might occur during context resolution. Previously, any error in the resolver would crash the entire operation. Now, errors are caught and logged, allowing the operation to continue with other context providers.