### PR TITLE
fix: use ipairs when iterating over resolved embeddings

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -369,7 +369,7 @@ function M.resolve_context(prompt, config)
 
     local ok, resolved_embeddings = pcall(context_value.resolve, context_data.input, state.source or {}, prompt)
     if ok then
-      for _, embedding in resolved_embeddings do
+      for _, embedding in ipairs(resolved_embeddings) do
         if embedding then
           embeddings:set(embedding.filename, embedding)
         end


### PR DESCRIPTION
The code was incorrectly iterating directly over the resolved_embeddings array, which can lead to improper iteration in Lua. This commit fixes the issue by properly using ipairs() to ensure sequential iteration over numeric indices.