### PR TITLE
refactor: optimize code outline generation with caching

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -285,7 +285,7 @@ end
 ---@param str string The string to hash
 ---@return string
 function M.quick_hash(str)
-  return #str .. str:sub(1, 32) .. str:sub(-32)
+  return #str .. str:sub(1, 64) .. str:sub(-64)
 end
 
 --- Make a string from arguments


### PR DESCRIPTION
Improve outline generation performance by:
- Creating a separate outline cache to avoid redundant processing
- Converting M.get_outline to a local function with cleaner return values
- Generating outlines on-demand during embedding filtering
- Improving cache key generation with longer hash samples
- Refactoring file and buffer handling to simplify data flow

This change reduces processing overhead by only creating outlines when needed and avoiding duplicate work through targeted caching.