### PR TITLE
style: improve context provider help text formatting

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -225,13 +225,14 @@ For example:
 Do not make assumptions about code or files - always request context when needed rather than guessing.
 Always use the > format on a new line when requesting more context instead of asking in prose.
 
-Available context providers and their usage:
-]]
+Available context providers and their usage:]]
+
     local context_names = vim.tbl_keys(contexts)
     table.sort(context_names)
     for _, name in ipairs(context_names) do
       local description = contexts[name]
-      help_text = help_text .. '\n' .. string.format(' - #%s: %s', name, description)
+      description = description:gsub('\n', '\n   ')
+      help_text = help_text .. '\n\n - #' .. name .. ': ' .. description
     end
 
     if system_prompt ~= '' then


### PR DESCRIPTION
Enhances readability of the context provider documentation by:
- Adding blank lines between each provider description
- Properly indenting multi-line descriptions with consistent spacing
- Maintaining consistent formatting across all provider help text

This change makes the help text more scannable and easier to read for users.