### PR TITLE
fix: improve error logging for failed context resolution

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -370,7 +370,7 @@ function M.resolve_context(prompt, config)
         end
       end
     else
-      log.error('Failed to resolve context: ' .. context_data.name)
+      log.error('Failed to resolve context: ' .. context_data.name, resolved_embeddings)
     end
   end
 


### PR DESCRIPTION
Include resolved embeddings data in error logs when context resolution fails. This additional information will help with debugging context resolution issues by providing more details about what was attempted.