### PR TITLE
feat: add additional binary file types to scan exclusions

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -94,6 +94,22 @@ M.scan_args = {
     'otf',
     'woff',
     'woff2',
+    -- Debug files
+    'pdb',
+    'dSYM',
+    -- Models and data formats
+    'h5',
+    'pb',
+    'onnx',
+    'pt',
+    'safetensors',
+    'hdf5',
+    'parquet',
+    'glb',
+    'gltf',
+    -- Swap/temp files
+    'swp',
+    'swo',
   },
 }
 


### PR DESCRIPTION
Add several new file types to be excluded from scanning operations:
- Debug files (pdb, dSYM)
- ML/Data model formats (h5, pb, onnx, pt, safetensors, etc)
- 3D model formats (glb, gltf)
- Editor swap/temp files (swp, swo)

These exclusions will improve performance and relevance when scanning repositories by ignoring common binary and temporary files.