### PR TITLE
fix: handle cancelled jobs in CopilotChat

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -918,6 +918,11 @@ function M.ask(prompt, config)
       return
     end
 
+    -- If there was no error and no response, it means job was cancelled
+    if response == nil then
+      return
+    end
+
     -- Call the callback function and store to history
     local to_store = not config.headless and response
     if to_store and config.callback then


### PR DESCRIPTION
When a job is cancelled, the response will be nil without any error. This change adds proper handling for this case by returning early when no response is available, preventing potential nil reference errors in the callback processing code.