### PR TITLE
docs: remove # prefix from context provider examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ require("CopilotChat").ask("Explain this code", {
     vim.notify("Got response: " .. response:sub(1, 50) .. "...")
     return response
   end,
-  context = "#buffer"
+  context = "buffer"
 })
 
 -- Save and load chat history
@@ -765,7 +765,7 @@ require("CopilotChat").load("my_debugging_session")
 -- Use custom context and model
 require("CopilotChat").ask("How can I optimize this?", {
   model = "gpt-4o",
-  context = {"#buffer", "#git:staged"}
+  context = {"buffer", "git:staged"}
 })
 ```
 


### PR DESCRIPTION
The examples in README.md were incorrectly showing context providers with a # prefix in the code snippets. This commit updates the examples to show the correct format without the # character.