### PR TITLE
docs: add missing `,` in default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ Below are all available configuration options with their default values:
     },
     copilot_embeddings = {
     },
-  }
+  },
 
   -- default contexts
   -- see config/contexts.lua for implementation


### PR DESCRIPTION
closes #1023 