### PR TITLE
fix: improve headless mode handling in callbacks

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -710,11 +710,13 @@ function Client:ask(prompt, opts)
 
   local response, err = utils.curl_post(provider.get_url(options), args)
 
-  if self.current_job ~= job_id then
-    return
-  end
+  if not opts.headless then
+    if self.current_job ~= job_id then
+      return
+    end
 
-  self.current_job = nil
+    self.current_job = nil
+  end
 
   log.debug('Response status:', response.status)
   log.debug('Response body:\n', response.body)

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -895,13 +895,11 @@ function M.ask(prompt, config)
       agent = selected_agent,
       temperature = config.temperature,
       on_progress = vim.schedule_wrap(function(token)
-        local to_print = not config.headless and token
-        if to_print and config.stream then
-          local out = config.stream(token, state.source)
-          if out ~= nil then
-            to_print = out
-          end
+        local out = config.stream and config.stream(token, state.source) or nil
+        if out == nil then
+          out = token
         end
+        local to_print = not config.headless and out
         if to_print and to_print ~= '' then
           M.chat:append(token)
         end
@@ -924,13 +922,11 @@ function M.ask(prompt, config)
     end
 
     -- Call the callback function and store to history
-    local to_store = not config.headless and response
-    if to_store and config.callback then
-      local out = config.callback(response, state.source)
-      if out ~= nil then
-        to_store = out
-      end
+    local out = config.callback and config.callback(response, state.source) or nil
+    if out == nil then
+      out = response
     end
+    local to_store = not config.headless and out
     if to_store and to_store ~= '' then
       table.insert(client.history, {
         content = prompt,

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -334,26 +334,20 @@ end
 function M.filetype(filename)
   local ft = vim.filetype.match({ filename = filename })
 
-  if not ft and vim.endswith(filename, '.sh') then
-    return 'sh'
-  end
-
-  -- weird TypeScript bug for vim.filetype.match
-  -- see: https://github.com/neovim/neovim/issues/27265
-  if not ft then
-    local base_name = vim.fs.basename(filename)
-    local split_name = vim.split(base_name, '%.')
-    if #split_name > 1 then
-      local ext = split_name[#split_name]
-      if ext == 'ts' then
-        ft = 'typescript'
-      end
+  if not ft or ft == '' then
+    if vim.endswith(filename, '.sh') then
+      return 'sh'
     end
-  end
 
-  if ft == '' then
+    -- weird TypeScript bug for vim.filetype.match
+    -- see: https://github.com/neovim/neovim/issues/27265
+    if vim.endswith(filename, '.ts') then
+      return 'typescript'
+    end
+
     return nil
   end
+
   return ft
 end
 


### PR DESCRIPTION
Properly handle headless mode in streaming and completion callbacks. Condition the job tracking logic on headless mode to prevent early termination of headless requests.

Refactor filetype detection to simplify the logic with more consistent handling of edge cases for sh and TypeScript files.

Closes #1026