### PR TITLE
Respect &splitbelow and &splitright

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -305,6 +305,8 @@ function Chat:open(config)
     end
     if vim.api.nvim_get_option_value('splitright', {}) then
       cmd = 'botright ' .. cmd
+    else
+      cmd = 'topleft ' .. cmd
     end
     vim.cmd(cmd)
     self.winnr = vim.api.nvim_get_current_win()

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -313,7 +313,9 @@ function Chat:open(config)
     if height ~= 0 then
       cmd = height .. cmd
     end
-    cmd = 'botright ' .. cmd
+    if vim.api.nvim_get_option('splitbelow') then
+      cmd = 'botright ' .. cmd
+    end
     vim.cmd(cmd)
     self.winnr = vim.api.nvim_get_current_win()
     vim.api.nvim_set_current_win(orig)

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -303,7 +303,9 @@ function Chat:open(config)
     if width ~= 0 then
       cmd = width .. cmd
     end
-    cmd = 'botright ' .. cmd
+    if vim.api.nvim_get_option('splitbelow') then
+      cmd = 'botright ' .. cmd
+    end
     vim.cmd(cmd)
     self.winnr = vim.api.nvim_get_current_win()
     vim.api.nvim_set_current_win(orig)

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -317,6 +317,8 @@ function Chat:open(config)
     end
     if vim.api.nvim_get_option_value('splitbelow', {}) then
       cmd = 'botright ' .. cmd
+    else
+      cmd = 'topleft ' .. cmd
     end
     vim.cmd(cmd)
     self.winnr = vim.api.nvim_get_current_win()

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -303,7 +303,7 @@ function Chat:open(config)
     if width ~= 0 then
       cmd = width .. cmd
     end
-    if vim.api.nvim_get_option('splitbelow') then
+    if vim.api.nvim_get_option_value('splitbelow', {}) then
       cmd = 'botright ' .. cmd
     end
     vim.cmd(cmd)
@@ -315,7 +315,7 @@ function Chat:open(config)
     if height ~= 0 then
       cmd = height .. cmd
     end
-    if vim.api.nvim_get_option('splitbelow') then
+    if vim.api.nvim_get_option_value('splitbelow', {}) then
       cmd = 'botright ' .. cmd
     end
     vim.cmd(cmd)

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -303,7 +303,7 @@ function Chat:open(config)
     if width ~= 0 then
       cmd = width .. cmd
     end
-    if vim.api.nvim_get_option_value('splitbelow', {}) then
+    if vim.api.nvim_get_option_value('splitright', {}) then
       cmd = 'botright ' .. cmd
     end
     vim.cmd(cmd)


### PR DESCRIPTION
This commit changes the split behavior to respect to the value of
&splitbelow and &splitright, which are both disabled by default.

This behavior was introduced in #950.