### PR TITLE
feat: detect .h files as c filetype

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -339,6 +339,10 @@ function M.filetype(filename)
       return 'sh'
     end
 
+    if vim.endswith(filename, '.h') then
+      return 'c'
+    end
+
     -- weird TypeScript bug for vim.filetype.match
     -- see: https://github.com/neovim/neovim/issues/27265
     if vim.endswith(filename, '.ts') then


### PR DESCRIPTION
This change adds filetype detection for .h header files to be recognized as C language files, improving syntax highlighting and language-specific features for C header files in the CopilotChat plugin.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Closes #1043