### PR TITLE
test: add mock for plenary.filetype module

### DIFF
--- a/test/plugin_spec.lua
+++ b/test/plugin_spec.lua
@@ -9,6 +9,7 @@ package.loaded['plenary.async'] = {
 package.loaded['plenary.curl'] = {}
 package.loaded['plenary.log'] = {}
 package.loaded['plenary.scandir'] = {}
+package.loaded['plenary.filetype'] = {}
 
 describe('CopilotChat plugin', function()
   it('should be able to load', function()


### PR DESCRIPTION
Add missing mock for the plenary.filetype module in the test suite to ensure tests can run properly without the actual dependency.