### PR TITLE
feat: use model name and versioning for model selection and switch to gpt-4o-2024-11-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ Below are all available configuration options with their default values:
 
   system_prompt = 'COPILOT_INSTRUCTIONS', -- System prompt to use (can be specified manually in prompt via /).
 
-  model = 'gpt-4o', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
+  model = 'gpt-4o-2024-11-20', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
   agent = 'copilot', -- Default agent to use, see ':CopilotChatAgents' for available agents (can be specified manually in prompt via @).
   context = nil, -- Default context or array of contexts to use (can be specified manually in prompt via #).
   sticky = nil, -- Default sticky prompt or array of sticky prompts to use at start of every new chat.

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -58,7 +58,7 @@ return {
 
   system_prompt = 'COPILOT_INSTRUCTIONS', -- System prompt to use (can be specified manually in prompt via /).
 
-  model = 'gpt-4o', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
+  model = 'gpt-4o-2024-11-20', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
   agent = 'none', -- Default agent to use, see ':CopilotChatAgents' for available agents (can be specified manually in prompt via @).
   context = nil, -- Default context or array of contexts to use (can be specified manually in prompt via #).
   sticky = nil, -- Default sticky prompt or array of sticky prompts to use at start of every new chat.

--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -186,18 +186,14 @@ M.copilot = {
       end)
       :totable()
 
-    local version_map = {}
+    local name_map = {}
     for _, model in ipairs(models) do
-      if not version_map[model.version] or #model.id < #version_map[model.version] then
-        version_map[model.version] = model.id
+      if not name_map[model.name] or model.version > name_map[model.name].version then
+        name_map[model.name] = model
       end
     end
 
-    models = vim.tbl_map(function(id)
-      return vim.tbl_filter(function(model)
-        return model.id == id
-      end, models)[1]
-    end, vim.tbl_values(version_map))
+    models = vim.tbl_values(name_map)
 
     for _, model in ipairs(models) do
       if not model.policy then

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -733,7 +733,7 @@ function M.select_model()
     vim.ui.select(choices, {
       prompt = 'Select a model> ',
       format_item = function(item)
-        local out = string.format('%s (%s)', item.id, item.provider)
+        local out = string.format('%s (%s:%s)', item.name, item.provider, item.id)
         if item.selected then
           out = '* ' .. out
         end
@@ -764,7 +764,7 @@ function M.select_agent()
     vim.ui.select(choices, {
       prompt = 'Select an agent> ',
       format_item = function(item)
-        local out = string.format('%s (%s)', item.id, item.provider)
+        local out = string.format('%s (%s:%s)', item.name, item.provider, item.id)
         if item.selected then
           out = '* ' .. out
         end


### PR DESCRIPTION
Update model selection logic to use model names with versioning instead of just IDs. This improves user experience by showing more descriptive model names in the selection UI and ensures the latest version of each model is preferred when filtering available models.

Also updates the default model to the latest gpt-4o-2024-11-20 version.

Related https://github.com/CopilotC-Nvim/CopilotChat.nvim/issues/1052#issuecomment-2751530966