### PR TITLE
fix: filter out paygo models from Copilot Chat

### DIFF
--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -171,7 +171,7 @@ M.copilot = {
     local models = vim
       .iter(response.body.data)
       :filter(function(model)
-        return model.capabilities.type == 'chat'
+        return model.capabilities.type == 'chat' and not vim.endswith(model.id, 'paygo')
       end)
       :map(function(model)
         return {


### PR DESCRIPTION
These models do not actually work but have same name as non-paygo version (o3-mini)

Closes #1058