### PR TITLE
fix(copilot)!: allow overriding headers, api_base

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,10 +417,10 @@ Custom providers can implement these methods:
   embed?: string|function,
 
   -- Optional: Get extra request headers with optional expiration time
-  get_headers?(): table<string,string>, number?,
+  get_headers?(self: CopilotChat.Provider): table<string,string>, number?,
 
   -- Optional: Get API endpoint URL
-  get_url?(opts: CopilotChat.Provider.options): string,
+  get_url?(self: CopilotChat.Provider, opts: CopilotChat.Provider.options): string,
 
   -- Optional: Prepare request input
   prepare_input?(inputs: table<CopilotChat.Provider.input>, opts: CopilotChat.Provider.options): table,
@@ -429,10 +429,10 @@ Custom providers can implement these methods:
   prepare_output?(output: table, opts: CopilotChat.Provider.options): CopilotChat.Provider.output,
 
   -- Optional: Get available models
-  get_models?(headers: table): table<CopilotChat.Provider.model>,
+  get_models?(self: CopilotChat.Provider, headers: table): table<CopilotChat.Provider.model>,
 
   -- Optional: Get available agents
-  get_agents?(headers: table): table<CopilotChat.Provider.agent>,
+  get_agents?(self: CopilotChat.Provider, headers: table): table<CopilotChat.Provider.agent>,
 }
 ```
 

--- a/doc/CopilotChat.txt
+++ b/doc/CopilotChat.txt
@@ -470,10 +470,10 @@ Custom providers can implement these methods:
       embed?: string|function,
     
       -- Optional: Get extra request headers with optional expiration time
-      get_headers?(): table<string,string>, number?,
+      get_headers?(self: CopilotChat.Provider): table<string,string>, number?,
     
       -- Optional: Get API endpoint URL
-      get_url?(opts: CopilotChat.Provider.options): string,
+      get_url?(self: CopilotChat.Provider, opts: CopilotChat.Provider.options): string,
     
       -- Optional: Prepare request input
       prepare_input?(inputs: table<CopilotChat.Provider.input>, opts: CopilotChat.Provider.options): table,
@@ -482,10 +482,10 @@ Custom providers can implement these methods:
       prepare_output?(output: table, opts: CopilotChat.Provider.options): CopilotChat.Provider.output,
     
       -- Optional: Get available models
-      get_models?(headers: table): table<CopilotChat.Provider.model>,
+      get_models?(self: CopilotChat.Provider, headers: table): table<CopilotChat.Provider.model>,
     
       -- Optional: Get available agents
-      get_agents?(headers: table): table<CopilotChat.Provider.agent>,
+      get_agents?(self: CopilotChat.Provider, headers: table): table<CopilotChat.Provider.agent>,
     }
 <
 


### PR DESCRIPTION
We are using organizational version of Github copilot and I used to get unauthorized error, similar to https://github.com/CopilotC-Nvim/CopilotChat.nvim/issues/1052 ,

Digging deeper into the vscode's Copilot-chat extension, I found 2 differences which are required to fix this
1. API calls are made to `api.business.githubcopilot.com`
2. It doesn't work unless I set the headers as
   ```lua
   ["Editor-Version"] = "vscode/1.98.2",
   ["Editor-Plugin-Version"] = "copilot-chat/0.25.1",
   ```

As a solution, this PR implements
1. Use the base URL provided in auth response.
2. Allow overriding the headers.

Note: I haven't tested github_models because they weren't working under my credentials.