### PR TITLE
fix: use --max-depth arg name for ripgrep <14 compat

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -443,7 +443,7 @@ M.scan_dir = async.wrap(function(path, opts, callback)
     end
 
     if opts.max_depth then
-      table.insert(cmd, '-d')
+      table.insert(cmd, '--max-depth')
       table.insert(cmd, tostring(opts.max_depth))
     end
 


### PR DESCRIPTION
Closes https://github.com/CopilotC-Nvim/CopilotChat.nvim/issues/1071

I found this when trying to add a #files context, and I only have ripgrep 13.x installed on my system.