### PR TITLE
feat: accept a function that returns the layout to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ Below are all available configuration options with their default values:
 
   -- default window options
   window = {
-    layout = 'vertical', -- 'vertical', 'horizontal', 'float', 'replace'
+    layout = 'vertical', -- 'vertical', 'horizontal', 'float', 'replace', or a function that returns the layout
     width = 0.5, -- fractional width of parent, or absolute width in columns when > 1
     height = 0.5, -- fractional height of parent, or absolute height in rows when > 1
     -- Options below only apply to floating windows

--- a/doc/CopilotChat.txt
+++ b/doc/CopilotChat.txt
@@ -531,7 +531,7 @@ Below are all available configuration options with their default values:
     
       -- default window options
       window = {
-        layout = 'vertical', -- 'vertical', 'horizontal', 'float', 'replace'
+        layout = 'vertical', -- 'vertical', 'horizontal', 'float', 'replace', or a function that returns the layout
         width = 0.5, -- fractional width of parent, or absolute width in columns when > 1
         height = 0.5, -- fractional height of parent, or absolute height in rows when > 1
         -- Options below only apply to floating windows

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -1,7 +1,9 @@
 local select = require('CopilotChat.select')
 
+---@alias CopilotChat.config.Layout 'vertical'|'horizontal'|'float'|'replace'
+
 ---@class CopilotChat.config.window
----@field layout? CopilotChat.ui.Chat.Layout|fun():CopilotChat.ui.Chat.Layout
+---@field layout? CopilotChat.config.Layout|fun():CopilotChat.config.Layout
 ---@field relative 'editor'|'win'|'cursor'|'mouse'?
 ---@field border 'none'|'single'|'double'|'rounded'|'solid'|'shadow'?
 ---@field width number?

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -1,7 +1,7 @@
 local select = require('CopilotChat.select')
 
 ---@class CopilotChat.config.window
----@field layout 'vertical'|'horizontal'|'float'|'replace'?
+---@field layout? CopilotChat.ui.Chat.Layout|fun():CopilotChat.ui.Chat.Layout
 ---@field relative 'editor'|'win'|'cursor'|'mouse'?
 ---@field border 'none'|'single'|'double'|'rounded'|'solid'|'shadow'?
 ---@field width number?
@@ -76,7 +76,7 @@ return {
 
   -- default window options
   window = {
-    layout = 'vertical', -- 'vertical', 'horizontal', 'float', 'replace'
+    layout = 'vertical', -- 'vertical', 'horizontal', 'float', 'replace', or a function that returns the layout
     width = 0.5, -- fractional width of parent, or absolute width in columns when > 1
     height = 0.5, -- fractional height of parent, or absolute height in rows when > 1
     -- Options below only apply to floating windows

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -33,8 +33,6 @@ local function match_header(header)
   end
 end
 
----@alias CopilotChat.ui.Chat.Layout 'vertical'|'horizontal'|'float'|'replace'
-
 ---@class CopilotChat.ui.Chat.Section.Block.Header
 ---@field filename string
 ---@field start_line number
@@ -57,7 +55,7 @@ end
 ---@class CopilotChat.ui.Chat : CopilotChat.ui.Overlay
 ---@field winnr number?
 ---@field config CopilotChat.config.shared
----@field layout CopilotChat.ui.Chat.Layout?
+---@field layout CopilotChat.config.Layout?
 ---@field sections table<CopilotChat.ui.Chat.Section>
 ---@field references table<CopilotChat.Provider.reference>
 ---@field token_count number?

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -33,6 +33,8 @@ local function match_header(header)
   end
 end
 
+---@alias CopilotChat.ui.Chat.Layout 'vertical'|'horizontal'|'float'|'replace'
+
 ---@class CopilotChat.ui.Chat.Section.Block.Header
 ---@field filename string
 ---@field start_line number
@@ -55,6 +57,7 @@ end
 ---@class CopilotChat.ui.Chat : CopilotChat.ui.Overlay
 ---@field winnr number?
 ---@field config CopilotChat.config.shared
+---@field layout CopilotChat.ui.Chat.Layout?
 ---@field sections table<CopilotChat.ui.Chat.Section>
 ---@field references table<CopilotChat.Provider.reference>
 ---@field token_count number?
@@ -71,6 +74,7 @@ local Chat = class(function(self, question_header, answer_header, separator, hel
   self.winnr = nil
   self.sections = {}
   self.config = {}
+  self.layout = nil
   self.references = {}
   self.token_count = nil
   self.token_max_count = nil
@@ -268,15 +272,21 @@ function Chat:open(config)
   self:validate()
 
   local window = config.window or {}
+
   local layout = window.layout
+  if type(layout) == 'function' then
+    layout = layout()
+  end
+
   local width = window.width > 1 and window.width or math.floor(vim.o.columns * window.width)
   local height = window.height > 1 and window.height or math.floor(vim.o.lines * window.height)
 
-  if self.config and self.config.window and self.config.window.layout ~= layout then
+  if self.layout ~= layout then
     self:close()
   end
 
   self.config = config
+  self.layout = layout
 
   if self:visible() then
     return
@@ -357,7 +367,7 @@ function Chat:close(bufnr)
     utils.return_to_normal_mode()
   end
 
-  if self.config.window and self.config.window.layout == 'replace' then
+  if self.layout == 'replace' then
     if bufnr then
       self:restore(self.winnr, bufnr)
     end


### PR DESCRIPTION
This resolves #1080.

Example:

```lua
  window = {
    layout = function()
      if vim.o.columns > 2 * vim.o.lines then
        return 'vertical'
      else
        return 'horizontal'
      end
    end
  },
```