### PR TITLE
feat: add option to disable contexts in prompts

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -25,6 +25,7 @@ local select = require('CopilotChat.select')
 ---@field stream nil|fun(chunk: string, source: CopilotChat.source):string
 ---@field callback nil|fun(response: string, source: CopilotChat.source):string
 ---@field remember_as_sticky boolean?
+---@field include_contexts_in_prompt boolean?
 ---@field selection false|nil|fun(source: CopilotChat.source):CopilotChat.select.selection?
 ---@field window CopilotChat.config.window?
 ---@field show_help boolean?
@@ -70,6 +71,8 @@ return {
   stream = nil, -- Function called when receiving stream updates (returned string is appended to the chat buffer)
   callback = nil, -- Function called when full response is received (retuned string is stored to history)
   remember_as_sticky = true, -- Remember model/agent/context as sticky prompts when asking questions
+
+  include_contexts_in_prompt = true, -- Include contexts in prompt
 
   -- default selection
   selection = function(source)

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -850,9 +850,11 @@ function M.ask(prompt, config)
 
   -- Resolve context name and description
   local contexts = {}
-  for name, context in pairs(M.config.contexts) do
-    if context.description then
-      contexts[name] = context.description
+  if config.include_contexts_in_prompt then
+    for name, context in pairs(M.config.contexts) do
+      if context.description then
+        contexts[name] = context.description
+      end
     end
   end
 


### PR DESCRIPTION
Adds a new configuration option `include_contexts_in_prompt` that allows users to control whether context descriptions should be included when building the prompt for Copilot Chat. This is useful for cases where users want to reduce prompt size or customize how context information is presented to the AI.

The option defaults to true to maintain backward compatibility.