### PR TITLE
fix(validation): Ensure If the `terminal buffer` is excluded.

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -210,10 +210,15 @@ function M.kv_list(tbl)
 end
 
 --- Check if a buffer is valid
+--- Check if the buffer is not a terminal
 ---@param bufnr number? The buffer number
 ---@return boolean
 function M.buf_valid(bufnr)
-  return bufnr and vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_is_loaded(bufnr) or false
+  return bufnr
+      and vim.api.nvim_buf_is_valid(bufnr)
+      and vim.api.nvim_buf_is_loaded(bufnr)
+      and vim.bo[bufnr].buftype ~= 'terminal'
+    or false
 end
 
 --- Check if file paths are the same


### PR DESCRIPTION
closes #1091 

### Problem
As I have explained, the current implementation of `utils.buf_valid` is not excluding `terminal buffer`, that is causing the token exceed problem.

### Solution

Added a condition to check if the buffer is `terminal_buffer` using `buftype`.
```lua
--- Check if a buffer is valid
--- Check if the buffer is not a terminal
---@param bufnr number? The buffer number
---@return boolean
function M.buf_valid(bufnr)
  return bufnr
      and vim.api.nvim_buf_is_valid(bufnr)
      and vim.api.nvim_buf_is_loaded(bufnr)
      and vim.bo[bufnr].buftype ~= 'terminal'
    or false
end
```