### PR TITLE
fix: move plenary import into function

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -1,7 +1,6 @@
 local async = require('plenary.async')
 local curl = require('plenary.curl')
 local scandir = require('plenary.scandir')
-local filetype = require('plenary.filetype')
 
 local M = {}
 M.timers = {}
@@ -236,6 +235,7 @@ end
 ---@param filename string The file name
 ---@return string|nil
 function M.filetype(filename)
+  local filetype = require('plenary.filetype')
   local ft = filetype.detect(filename, {
     fs_access = false,
   })


### PR DESCRIPTION
Commit cf02033 broke test detection in Neotest. When another plugin calls `require("plenary.filetype")` before Neotest does, it seems that Neotest cannot successfully complete the call to
`require("neotest.lib").treesitter.parse_positions` and does not find any tests.

This seem like a bug in either plenary or Neotest and this commit is merely a workaround.

Related issues:
- https://github.com/nvim-neotest/neotest/issues/502
- https://github.com/CopilotC-Nvim/CopilotChat.nvim/issues/1099