### PR TITLE
feat: introduce diagnostics context and prompt

### DIFF
--- a/doc/CopilotChat.txt
+++ b/doc/CopilotChat.txt
@@ -239,15 +239,16 @@ Predefined prompt templates for common tasks. Reference them with `/PromptName`
 in chat, use `:CopilotChat<PromptName>` or `:CopilotChatPrompts` to select
 them:
 
-  Prompt     Description
-  ---------- --------------------------------------------------
-  Explain    Write an explanation for the selected code
-  Review     Review the selected code
-  Fix        Rewrite the code with bug fixes
-  Optimize   Optimize code for performance and readability
-  Docs       Add documentation comments to the code
-  Tests      Generate tests for the code
-  Commit     Write commit message using commitizen convention
+  Prompt      Description
+  ----------  --------------------------------------------------
+  Explain     Write an explanation for the selected code
+  Review      Review the selected code
+  Fix         Rewrite the code with bug fixes
+  Optimize    Optimize code for performance and readability
+  Docs        Add documentation comments to the code
+  Tests       Generate tests for the code
+  Commit      Write commit message using commitizen convention
+  Diagnostics Propose fix for workspace diagnostics
 Define your own prompts in the configuration:
 
 >lua
@@ -363,6 +364,7 @@ Contexts provide additional information to the chat. Add context using
   ----------- --------------- -------------------------------------
   buffer      ✓ (number)      Current or specified buffer content
   buffers     ✓ (type)        All buffers content (listed/all)
+  diagnostics -               All workspace diagnostics
   file        ✓ (path)        Content of specified file
   files       ✓ (glob)        Workspace files
   filenames   ✓ (glob)        Workspace file names

--- a/lua/CopilotChat/config/contexts.lua
+++ b/lua/CopilotChat/config/contexts.lua
@@ -297,6 +297,43 @@ return {
     end,
   },
 
+  diagnostics = {
+    description = 'All workspace diagnostics',
+    resolve = function()
+      local diagnostics = vim.diagnostic.get(nil)
+      local lines = {}
+      local severity_labels = {
+        [vim.diagnostic.severity.ERROR] = 'ERROR',
+        [vim.diagnostic.severity.WARN] = 'WARN',
+        [vim.diagnostic.severity.INFO] = 'INFO',
+        [vim.diagnostic.severity.HINT] = 'HINT',
+      }
+
+      utils.schedule_main()
+
+      for _, d in ipairs(diagnostics) do
+        local filename = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(d.bufnr), ':.')
+        table.insert(
+          lines,
+          string.format(
+            '%s:%d - %s - %s',
+            filename,
+            (d.lnum or 0) + 1,
+            severity_labels[d.severity] or '',
+            d.message or ''
+          )
+        )
+      end
+      return {
+        {
+          content = table.concat(lines, '\n'),
+          filename = 'workspace_diagnostics',
+          filetype = 'text',
+        },
+      }
+    end,
+  },
+
   system = {
     description = [[Includes output of provided system shell command in chat context. Supports input.
 

--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -165,4 +165,9 @@ return {
     prompt = 'Write commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.',
     context = 'git:staged',
   },
+
+  Diagnostics = {
+    prompt = 'Fix all LSP warnings and errors. Show different code patches for each diagnostic.',
+    context = { 'diagnostics', 'buffers' },
+  },
 }


### PR DESCRIPTION
I often find myself wanting to resolve the code diagnostics and manually adding the corresponding error messages and/or buffers to the chat, together with a custom prompt. I thought I could propose to add diagnostics as default context and prompt that the user can select in order to streamline this process.

This PR introduces:

- context: workspace diagnostics for all open buffers
- prompts: instructions for the model to patch each single one independently 