### PR TITLE
fix: #1153 use filepath on accept

### DIFF
--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -64,7 +64,7 @@ local function get_diff(block)
     change = block.content,
     reference = reference or '',
     filetype = filetype or '',
-    filename = utils.filename(filename),
+    filename = utils.filepath(filename),
     start_line = start_line,
     end_line = end_line,
     bufnr = bufnr,


### PR DESCRIPTION
Use filepath for the full path when accepting a change.

Fixes #1153 