### PR TITLE
feat: add Windows_NT support in Makefile and dynamic library loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ ifeq ($(UNAME), Linux)
 else ifeq ($(UNAME), Darwin)
     OS := macOS
     EXT := dylib
+else ifeq ($(UNAME), Windows_NT)
+    OS := windows
+    EXT := dll
 else
     $(error Unsupported operating system: $(UNAME))
 endif

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ CopilotChat.nvim is a Neovim plugin that brings GitHub Copilot Chat capabilities
 ## Optional Dependencies
 
 - [tiktoken_core](https://github.com/gptlang/lua-tiktoken) - For accurate token counting
-
   - Arch Linux: Install [`luajit-tiktoken-bin`](https://aur.archlinux.org/packages/luajit-tiktoken-bin) or [`lua51-tiktoken-bin`](https://aur.archlinux.org/packages/lua51-tiktoken-bin) from AUR
   - Via luarocks: `sudo luarocks install --lua-version 5.1 tiktoken_core`
   - Manual: Download from [lua-tiktoken releases](https://github.com/gptlang/lua-tiktoken/releases) and save as `tiktoken_core.so` in your Lua path

--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -2,6 +2,23 @@ local notify = require('CopilotChat.notify')
 local utils = require('CopilotChat.utils')
 local current_tokenizer = nil
 
+--- @return string
+local function get_lib_extension()
+  if jit.os:lower() == 'mac' or jit.os:lower() == 'osx' then
+    return '.dylib'
+  end
+  if jit.os:lower() == 'windows' then
+    return '.dll'
+  end
+  return '.so'
+end
+
+package.cpath = package.cpath
+  .. ';'
+  .. debug.getinfo(1).source:match('@?(.*/)')
+  .. '../../build/?'
+  .. get_lib_extension()
+
 local tiktoken_ok, tiktoken_core = pcall(require, 'tiktoken_core')
 if not tiktoken_ok then
   tiktoken_core = nil


### PR DESCRIPTION
- add windows support in Makefile
- dynamically load `tiktoken_core` lib

**tiktoken_core** works without any shenanigans.

```lua
return {
  "CopilotC-Nvim/CopilotChat.nvim",
  build = "make tiktoken",
}

```

<img width="1377" height="680" alt="image" src="https://github.com/user-attachments/assets/a5620d6e-bda3-4b9d-8df5-52edb6b4f02f" />
