### PR TITLE
feat(resources)!: add option to enable resource processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,10 +445,12 @@ Below are all available configuration options with their default values:
   tools = nil, -- Default tool or array of tools (or groups) to share with LLM (can be specified manually in prompt via @).
   sticky = nil, -- Default sticky prompt or array of sticky prompts to use at start of every new chat (can be specified manually in prompt via >).
 
+  resource_processing = false, -- Enable intelligent resource processing (skips unnecessary resources to save tokens)
+
   temperature = 0.1, -- Result temperature
   headless = false, -- Do not write to chat buffer and use history (useful for using custom processing)
   callback = nil, -- Function called when full response is received
-  remember_as_sticky = true, -- Remember model as sticky prompts when asking questions
+  remember_as_sticky = true, -- Remember config as sticky prompts when asking questions
 
   -- default selection
   -- see select.lua for implementation

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -17,6 +17,7 @@
 ---@field model string?
 ---@field tools string|table<string>|nil
 ---@field sticky string|table<string>|nil
+---@field resource_processing boolean?
 ---@field temperature number?
 ---@field headless boolean?
 ---@field callback nil|fun(response: string, source: CopilotChat.source)
@@ -57,10 +58,12 @@ return {
   tools = nil, -- Default tool or array of tools (or groups) to share with LLM (can be specified manually in prompt via @).
   sticky = nil, -- Default sticky prompt or array of sticky prompts to use at start of every new chat (can be specified manually in prompt via >).
 
+  resource_processing = false, -- Enable intelligent resource processing (skips unnecessary resources to save tokens)
+
   temperature = 0.1, -- Result temperature
   headless = false, -- Do not write to chat buffer and use history (useful for using custom processing)
   callback = nil, -- Function called when full response is received
-  remember_as_sticky = true, -- Remember model as sticky prompts when asking questions
+  remember_as_sticky = true, -- Remember config as sticky prompts when asking questions
 
   -- default selection
   selection = require('CopilotChat.select').visual,

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -903,11 +903,15 @@ function M.ask(prompt, config)
   local ok, err = pcall(async.run, function()
     local selected_tools, resolved_resources, resolved_tools, prompt = M.resolve_functions(prompt, config)
     local selected_model, prompt = M.resolve_model(prompt, config)
-    local query_ok, processed_resources = pcall(resources.process_resources, prompt, selected_model, resolved_resources)
-    if query_ok then
-      resolved_resources = processed_resources
-    else
-      log.warn('Failed to process resources', processed_resources)
+
+    if config.resource_processing then
+      local query_ok, processed_resources =
+        pcall(resources.process_resources, prompt, selected_model, resolved_resources)
+      if query_ok then
+        resolved_resources = processed_resources
+      else
+        log.warn('Failed to process resources', processed_resources)
+      end
     end
 
     prompt = vim.trim(prompt)


### PR DESCRIPTION
This adds option to enable resource processing, disabled by default.

BREAKING CHANGE: intelligent resource processing is now disabled by default,
use config.resource_processing: true to reenable