### PR TITLE
fix: update sticky reference for commit messages

### DIFF
--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -204,6 +204,6 @@ return {
 
   Commit = {
     prompt = 'Write commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.',
-    sticky = '#git:staged',
+    sticky = '#gitdiff:staged',
   },
 }


### PR DESCRIPTION
Changes the commit prompt's sticky reference from '#git:staged' to '#gitdiff:staged' to properly match the expected format for retrieving staged changes when generating commit messages.