### PR TITLE
fix: check for explicit uri input properly

### DIFF
--- a/lua/CopilotChat/functions.lua
+++ b/lua/CopilotChat/functions.lua
@@ -129,12 +129,12 @@ end
 ---@param schema table?
 ---@return table
 function M.parse_input(input, schema)
-  if not schema or not schema.properties then
-    return {}
-  end
-
   if type(input) == 'table' then
     return input
+  end
+
+  if not schema or not schema.properties then
+    return {}
   end
 
   local parts = vim.split(input or '', INPUT_SEPARATOR)


### PR DESCRIPTION
Previous check for empty schema broke this, the check should be done only after input type is checked