### PR TITLE
feat(providers)!: new github models api, in-built authorization without copilot.vim dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,15 @@ CopilotChat.nvim is a Neovim plugin that brings GitHub Copilot Chat capabilities
 - [Neovim 0.10.0+](https://neovim.io/) - Older versions are not officially supported
 - [curl](https://curl.se/) - Version 8.0.0+ recommended for best compatibility
 - [Copilot chat in the IDE](https://github.com/settings/copilot) enabled in GitHub settings
+- [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) - Plugin dependency
 
 > [!WARNING]
 > For Neovim < 0.11.0, add `noinsert` or `noselect` to your `completeopt` otherwise chat autocompletion will not work.
 > For best autocompletion experience, also add `popup` to your `completeopt` (even on Neovim 0.11.0+).
 
 ## Optional Dependencies
+
+- [copilot.vim](https://github.com/github/copilot.vim) - For `:Copilot setup` authorization, otherwise in-built method i used
 
 - [tiktoken_core](https://github.com/gptlang/lua-tiktoken) - For accurate token counting
   - Arch Linux: Install [`luajit-tiktoken-bin`](https://aur.archlinux.org/packages/luajit-tiktoken-bin) or [`lua51-tiktoken-bin`](https://aur.archlinux.org/packages/lua51-tiktoken-bin) from AUR
@@ -72,7 +75,6 @@ return {
   {
     "CopilotC-Nvim/CopilotChat.nvim",
     dependencies = {
-      { "github/copilot.vim" }, -- or zbirenbaum/copilot.lua
       { "nvim-lua/plenary.nvim", branch = "master" }, -- for curl, log and async functions
     },
     build = "make tiktoken",
@@ -92,7 +94,6 @@ Similar to the lazy setup, you can use the following configuration:
 
 ```vim
 call plug#begin()
-Plug 'github/copilot.vim'
 Plug 'nvim-lua/plenary.nvim'
 Plug 'CopilotC-Nvim/CopilotChat.nvim'
 call plug#end()
@@ -112,9 +113,7 @@ EOF
 mkdir -p ~/.config/nvim/pack/copilotchat/start
 cd ~/.config/nvim/pack/copilotchat/start
 
-git clone https://github.com/github/copilot.vim
 git clone https://github.com/nvim-lua/plenary.nvim
-
 git clone https://github.com/CopilotC-Nvim/CopilotChat.nvim
 ```
 
@@ -392,8 +391,8 @@ Providers are modules that implement integration with different AI providers.
 ### Built-in Providers
 
 - `copilot` - Default GitHub Copilot provider used for chat
-- `github_models` - Provider for GitHub Marketplace models
-- `copilot_embeddings` - Provider for Copilot embeddings, not standalone
+- `github_models` - Provider for GitHub Marketplace models (disabled by default, enable it via `providers.github_models.disabled = false`)
+- `copilot_embeddings` - Provider for Copilot embeddings, not standalone, used by `copilot` and `github_models` providers
 
 ### Provider Interface
 

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -893,6 +893,7 @@ function M.ask(prompt, config)
     end
 
     M.chat:start()
+    M.chat:append('\n')
 
     local sticky = {}
     local in_code_block = false

--- a/lua/CopilotChat/notify.lua
+++ b/lua/CopilotChat/notify.lua
@@ -3,6 +3,7 @@ local log = require('plenary.log')
 local M = {}
 
 M.STATUS = 'status'
+M.MESSAGE = 'message'
 
 M.listeners = {}
 

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -1,5 +1,6 @@
 local Overlay = require('CopilotChat.ui.overlay')
 local Spinner = require('CopilotChat.ui.spinner')
+local notify = require('CopilotChat.notify')
 local utils = require('CopilotChat.utils')
 local class = utils.class
 
@@ -94,6 +95,11 @@ local Chat = class(function(self, headers, separator, help, on_buf_create)
         self.chat_overlay:restore(self.winnr, self.bufnr)
       end,
     })
+  end)
+
+  notify.listen(notify.MESSAGE, function(msg)
+    utils.schedule_main()
+    self:append('\n' .. msg .. '\n')
   end)
 end, Overlay)
 

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -615,6 +615,29 @@ function M.read_file(path)
   return data
 end
 
+--- Write data to a file
+---@param path string The file path
+---@param data string The data to write
+---@return boolean
+function M.write_file(path, data)
+  M.schedule_main()
+  vim.fn.mkdir(vim.fn.fnamemodify(path, ':p:h'), 'p')
+
+  local err, fd = async.uv.fs_open(path, 'w', 438)
+  if err or not fd then
+    return false
+  end
+
+  local err = async.uv.fs_write(fd, data, 0)
+  if err then
+    async.uv.fs_close(fd)
+    return false
+  end
+
+  async.uv.fs_close(fd)
+  return true
+end
+
 --- Call a system command
 ---@param cmd table The command
 ---@async


### PR DESCRIPTION
- Switch to new github models api. This brings device code as prerequisite so add support for retrieving device code as well
- With device code flow, add support for it for regular copilot auth as well
- Disable github_models provider by default as now it requires device code flow

BREAKING CHANGE: github_models provider is now disabled by default, enable with `providers.github_models.disabled = false

Closes #1140

<img width="1271" height="336" alt="image" src="https://github.com/user-attachments/assets/4179fcba-e204-44b6-950e-c557650fd8c8" />
