### PR TITLE
fix(ui): do not allow empty separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Below are all available configuration options with their default values:
   show_help = true, -- Shows help message as virtual lines when waiting for user input
   show_folds = true, -- Shows folds for sections in chat
   highlight_selection = true, -- Highlight selection
-  highlight_headers = true, -- Highlight headers in chat, disable if using markdown renderers (like render-markdown.nvim)
+  highlight_headers = true, -- Highlight headers in chat
   auto_follow_cursor = true, -- Auto-follow cursor in chat
   auto_insert_mode = false, -- Automatically enter insert mode when opening window and on new prompt
   insert_at_end = false, -- Move cursor to end of buffer when inserting text

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -86,7 +86,7 @@ return {
   show_help = true, -- Shows help message as virtual lines when waiting for user input
   show_folds = true, -- Shows folds for sections in chat
   highlight_selection = true, -- Highlight selection
-  highlight_headers = true, -- Highlight headers in chat, disable if using markdown renderers (like render-markdown.nvim)
+  highlight_headers = true, -- Highlight headers in chat
   auto_follow_cursor = true, -- Auto-follow cursor in chat
   auto_insert_mode = false, -- Automatically enter insert mode when opening window and on new prompt
   insert_at_end = false, -- Move cursor to end of buffer when inserting text

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1162,7 +1162,8 @@ end
 --- Set up the plugin
 ---@param config CopilotChat.config.Config?
 function M.setup(config)
-  M.config = vim.tbl_deep_extend('force', require('CopilotChat.config'), config or {})
+  local default_config = require('CopilotChat.config')
+  M.config = vim.tbl_deep_extend('force', default_config, config or {})
   state.highlights_loaded = false
 
   -- Save proxy and insecure settings
@@ -1179,6 +1180,13 @@ function M.setup(config)
     M.log_level('debug')
   else
     M.log_level(M.config.log_level)
+  end
+
+  if not M.config.separator or M.config.separator == '' then
+    log.warn(
+      'Empty separator is not allowed, using default separator instead. Set `separator` in config to change this.'
+    )
+    M.config.separator = default_config.separator
   end
 
   if M.chat then


### PR DESCRIPTION
This even working before was a miracle, the plugin is fairly reliant on separator not being empty string