### PR TITLE
fix(functions): use vim.filetype.match for non bulk file reads

### DIFF
--- a/lua/CopilotChat/config/functions.lua
+++ b/lua/CopilotChat/config/functions.lua
@@ -37,6 +37,7 @@ return {
     },
 
     resolve = function(input)
+      utils.schedule_main()
       local data, mimetype = resources.get_file(input.path)
       if not data then
         error('File not found: ' .. input.path)

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -214,15 +214,7 @@ end
 ---@param filename string The file name
 ---@return string|nil
 function M.filetype(filename)
-  local filetype = require('plenary.filetype')
-  local ft = filetype.detect(filename, {
-    fs_access = false,
-  })
-
-  if ft == '' then
-    return nil
-  end
-  return ft
+  return vim.filetype.match({ filename = filename })
 end
 
 --- Get the mimetype from filetype
@@ -445,8 +437,22 @@ M.curl_post = async.wrap(function(url, opts, callback)
 end, 3)
 
 local function filter_files(files, max_count)
+  local filetype = require('plenary.filetype')
+
   files = vim.tbl_filter(function(file)
-    return file ~= '' and M.filetype(file) ~= nil
+    if file == nil or file == '' then
+      return false
+    end
+
+    local ft = filetype.detect(file, {
+      fs_access = false,
+    })
+
+    if ft == '' or not ft then
+      return false
+    end
+
+    return true
   end, files)
   if max_count and max_count > 0 then
     files = vim.list_slice(files, 1, max_count)


### PR DESCRIPTION
To improve accuracy, use vim.filetype.match instead of plenary filetype when not filtering lists of files.

Closes #1181