### PR TITLE
feat(mappings): use C-Space as default completion trigger instead of Tab

### DIFF
--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -137,7 +137,7 @@ end
 ---@field show_help CopilotChat.config.mapping|false|nil
 return {
   complete = {
-    insert = '<Tab>',
+    insert = '<C-Space>',
     callback = function()
       copilot.trigger_complete()
     end,


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat(mappings)!: use C-Space as default completion trigger instead of Tab

To prevent conflicts with copilot.vim and copilot.lua by default, confusing people
END_COMMIT_OVERRIDE