### PR TITLE
Slight fix for doc (CopilotChat.txt)

### DIFF
--- a/doc/CopilotChat.txt
+++ b/doc/CopilotChat.txt
@@ -373,7 +373,7 @@ Examples:
     > #buffers:visible
     > #diagnostics:current
     > #file:path/to/file.js
-    > #git:staged
+    > #gitdiff:staged
     > #glob:`**/*.lua`
     > #grep:`function setup`
     > #quickfix


### PR DESCRIPTION
Function name for git information has changed from `git:` to `gitdiff:`, but there's a line in documentation that uses the old function name. It is fixed.