### PR TITLE
fix: functions are missing from parse_schema's return

### DIFF
--- a/lua/CopilotChat/functions.lua
+++ b/lua/CopilotChat/functions.lua
@@ -56,9 +56,7 @@ local function filter_schema(tbl, root)
   local result = {}
   for k, v in pairs(tbl) do
     if not utils.empty(v) then
-      if type(v) == 'function' then
-        result[k] = v
-      elseif k ~= 'examples' then
+      if k ~= 'examples' then
         result[k] = type(v) == 'table' and filter_schema(v) or v
       end
     end


### PR DESCRIPTION
I'll use the `file` function's schema as an example of the problem:

```lua
    schema = {
      type = 'object',
      required = { 'path' },
      properties = {
        path = {
          type = 'string',
          description = 'Path to file to include in chat context.',
          enum = function(source)
            local glob = utils.glob(source.cwd(), {
              max_count = 0,
            })
            return glob
          end,
        },
      },
    }
```

At the end of `parse_schema`, the schema is filtered. After this gets called, only `type` and `description` are in the returned schema, but `enum` should be in there too.

```lua
  if schema then
    schema = filter_schema(schema, true)
  end

  return schema
```

Prior to this, completing `#file:` in the picker would give me an input field to type my file path:

<img width="2242" height="354" alt="image" src="https://github.com/user-attachments/assets/9c8319bb-d1d8-4e8d-9c45-fc9806274e1a" />

This change restores the behavior visible in the demo in the README where that file can be picked using `vim.ui.select`:

<img width="2362" height="1444" alt="image" src="https://github.com/user-attachments/assets/bd76979d-cfef-43f9-85c8-c3a72ed88a48" />
