### PR TITLE
fix(ui): prevent italics from breaking glob pattern highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ You can customize colors by setting highlight groups in your config:
 -- In your colorscheme or init.lua
 vim.api.nvim_set_hl(0, 'CopilotChatHeader', { fg = '#7C3AED', bold = true })
 vim.api.nvim_set_hl(0, 'CopilotChatSeparator', { fg = '#374151' })
-vim.api.nvim_set_hl(0, 'CopilotChatKeyword', { fg = '#10B981', italic = true })
 ```
 
 Types of copilot highlights:

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -341,7 +341,8 @@ function Chat:open(config)
   end
 
   local ns = vim.api.nvim_create_namespace('copilot-chat-local-hl')
-  vim.api.nvim_set_hl(ns, '@markup.quote.markdown', {})
+  vim.api.nvim_set_hl(ns, '@markup.quote.markdown', {}) -- disable quote block overriding chat keywords
+  vim.api.nvim_set_hl(ns, '@markup.italic.markdown_inline', {}) -- disable italic messing up glob patterns
   vim.api.nvim_win_set_hl_ns(self.winnr, ns)
   vim.api.nvim_win_set_buf(self.winnr, self.bufnr)
   self:render()


### PR DESCRIPTION
Disables the '@markup.italic.markdown_inline' highlight in the chat UI. This prevents markdown italics from interfering with glob pattern highlighting in chat messages.