### PR TITLE
refactor(client): use provider resolver instead of static table

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1200,7 +1200,9 @@ function M.setup(config)
 
   -- Load the providers
   client:stop()
-  client:load_providers(M.config.providers)
+  client:add_providers(function()
+    return M.config.providers
+  end)
 
   if M.config.debug then
     M.log_level('debug')


### PR DESCRIPTION
Refactors the client to use a provider resolver function instead of a static providers table. This allows providers to be dynamically resolved when needed, improving flexibility and reducing the need to reload providers manually. Updates all internal references and replaces load_providers with add_providers.