### PR TITLE
feat(setup): trigger CopilotChatLoaded user autocommand

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1189,7 +1189,6 @@ end
 function M.setup(config)
   local default_config = require('CopilotChat.config')
   M.config = vim.tbl_deep_extend('force', default_config, config or {})
-  state.highlights_loaded = false
 
   -- Save proxy and insecure settings
   utils.curl_store_args({
@@ -1311,6 +1310,8 @@ function M.setup(config)
       end
     end
   end
+
+  vim.api.nvim_exec_autocmds('User', { pattern = 'CopilotChatLoaded' })
 end
 
 return M


### PR DESCRIPTION
Adds a call to vim.api.nvim_exec_autocmds for the 'User' event with the 'CopilotChatLoaded' pattern at the end of the setup function. This allows external plugins or user configs to react when CopilotChat has finished loading. Also removes unused highlights_loaded state assignment.