### PR TITLE
refactor(client): use OrderedMap for provider management

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -66,14 +66,15 @@ function M.class(fn, parent)
   return out
 end
 
----@class OrderedMap
+---@class OrderedMap<K, V>
 ---@field set fun(self:OrderedMap, key:any, value:any)
 ---@field get fun(self:OrderedMap, key:any):any
 ---@field keys fun(self:OrderedMap):table
 ---@field values fun(self:OrderedMap):table
 
 --- Create an ordered map
----@return OrderedMap
+---@generic K, V
+---@return OrderedMap<K, V>
 function M.ordered_map()
   return {
     _keys = {},


### PR DESCRIPTION
Refactored provider handling in Client to use OrderedMap, improving consistency and sorting. Added generic type annotations for OrderedMap and introduced a get_cached helper for cache management. This change simplifies provider filtering and caching logic for models and info.