### PR TITLE
fix(info): show resource uri instead of name in preview

### DIFF
--- a/lua/CopilotChat/completion.lua
+++ b/lua/CopilotChat/completion.lua
@@ -185,7 +185,6 @@ end
 --- Omnifunc for the chat window completion.
 ---@param findstart integer 0 or 1, decides behavior
 ---@param base integer findstart=0, text to match against
----@param _ any
 ---@return number|table
 function M.omnifunc(findstart, base)
   assert(base)

--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -133,7 +133,6 @@ end
 ---@field yank_diff CopilotChat.config.mapping.yank_diff|false|nil
 ---@field show_diff CopilotChat.config.mapping.show_diff|false|nil
 ---@field show_info CopilotChat.config.mapping|false|nil
----@field show_context CopilotChat.config.mapping|false|nil
 ---@field show_help CopilotChat.config.mapping|false|nil
 return {
   complete = {
@@ -513,7 +512,7 @@ return {
         for _, resource in ipairs(resolved_resources) do
           local resource_lines = vim.split(resource.data, '\n')
           local preview = vim.list_slice(resource_lines, 1, math.min(10, #resource_lines))
-          local header = string.format('**%s** (%s lines)', resource.name, #resource_lines)
+          local header = string.format('**%s** (%s lines)', resource.uri, #resource_lines)
           if #resource_lines > 10 then
             header = header .. ' (truncated)'
           end


### PR DESCRIPTION
Previously, the resource preview header displayed the resource name, which could be missing. This change updates the header to show the resource URI, providing clearer context. Also, removes unused type annotations for improved code clarity.