### PR TITLE
refactor(chat): unify message/block API for cursor access

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,8 +458,10 @@ window:visible()             -- Check if chat window is visible
 window:focused()             -- Check if chat window is focused
 
 -- Message Management
-window:get_message(role)                       -- Get last chat message by role (user, assistant, tool)
+window:get_message(role, cursor)               -- Get chat message by role, either last or closest to cursor
 window:add_message({ role, content }, replace) -- Add or replace a message in chat
+window:remove_message(role, cursor)            -- Remove chat message by role, either last or closest to cursor
+window:get_block(role, cursor)                 -- Get code block by role, either last or closest to cursor
 window:add_sticky(sticky)                      -- Add sticky prompt to chat message
 
 -- Content Management
@@ -473,9 +475,7 @@ window:follow()              -- Move cursor to end of chat content
 window:focus()               -- Focus the chat window
 
 -- Advanced Features
-window:get_closest_message(role) -- Get message closest to cursor
-window:get_closest_block(role)   -- Get code block closest to cursor
-window:overlay(opts)             -- Show overlay with specified options
+window:overlay(opts)         -- Show overlay with specified options
 ```
 
 ## Example Usage

--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -162,7 +162,7 @@ return {
     normal = '<CR>',
     insert = '<C-s>',
     callback = function()
-      local message = copilot.chat:get_closest_message('user')
+      local message = copilot.chat:get_message('user', true)
       if not message then
         return
       end
@@ -234,7 +234,7 @@ return {
     normal = '<C-y>',
     insert = '<C-y>',
     callback = function(source)
-      local diff = get_diff(copilot.chat:get_closest_block())
+      local diff = get_diff(copilot.chat:get_block('assistant', true))
       diff = prepare_diff_buffer(diff, source)
       if not diff then
         return
@@ -249,7 +249,7 @@ return {
   jump_to_diff = {
     normal = 'gj',
     callback = function(source)
-      local diff = get_diff(copilot.chat:get_closest_block())
+      local diff = get_diff(copilot.chat:get_block('assistant', true))
       diff = prepare_diff_buffer(diff, source)
       if not diff then
         return
@@ -326,7 +326,7 @@ return {
     normal = 'gy',
     register = '"', -- Default register to use for yanking
     callback = function()
-      local block = copilot.chat:get_closest_block()
+      local block = copilot.chat:get_block('assistant', true)
       if not block then
         return
       end
@@ -339,7 +339,7 @@ return {
     normal = 'gd',
     full_diff = false, -- Show full diff instead of unified diff when showing diff window
     callback = function(source)
-      local diff = get_diff(copilot.chat:get_closest_block())
+      local diff = get_diff(copilot.chat:get_block('assistant', true))
       diff = prepare_diff_buffer(diff, source)
       if not diff then
         return
@@ -356,7 +356,7 @@ return {
         -- Apply all diffs from same file
         if #modified > 0 then
           -- Find all diffs from the same file in this section
-          local message = copilot.chat:get_closest_message('assistant')
+          local message = copilot.chat:get_message('assistant', true)
           local section = message and message.section
           local same_file_diffs = {}
           if section then
@@ -429,7 +429,7 @@ return {
   show_info = {
     normal = 'gc',
     callback = function(source)
-      local message = copilot.chat:get_closest_message('user')
+      local message = copilot.chat:get_message('user', true)
       if not message then
         return
       end


### PR DESCRIPTION
Refactored chat window API to use `get_message(role, cursor)` and `get_block(role, cursor)` for both last and cursor-closest access. Removed legacy `get_closest_message` and `get_closest_block` methods. Updated mappings and documentation to reflect unified API. This simplifies usage and improves consistency for message/block retrieval and removal actions.