### PR TITLE
feat(ui): show assistant reasoning as virtual text

### DIFF
--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -191,6 +191,7 @@ end
 
 ---@class CopilotChat.config.providers.Output
 ---@field content string
+---@field reasoning string?
 ---@field finish_reason string?
 ---@field total_tokens number?
 ---@field tool_calls table<CopilotChat.client.ToolCall>
@@ -429,6 +430,7 @@ M.copilot = {
 
     local message = choice.message or choice.delta
     local content = message and message.content
+    local reasoning = message and (message.reasoning or message.reasoning_content)
     local usage = choice.usage and choice.usage.total_tokens
     if not usage then
       usage = output.usage and output.usage.total_tokens
@@ -437,6 +439,7 @@ M.copilot = {
 
     return {
       content = content,
+      reasoning = reasoning,
       finish_reason = finish_reason,
       total_tokens = usage,
       tool_calls = tool_calls,
@@ -480,6 +483,7 @@ M.github_models = {
           max_output_tokens = max_output_tokens,
           streaming = vim.tbl_contains(model.capabilities, 'streaming'),
           tools = vim.tbl_contains(model.capabilities, 'tool-calling'),
+          reasoning = vim.tbl_contains(model.capabilities, 'reasoning'),
           version = model.version,
         }
       end)

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -677,6 +677,7 @@ function M.select_model()
         provider = model.provider,
         streaming = model.streaming,
         tools = model.tools,
+        reasoning = model.reasoning,
         selected = model.id == M.config.model,
       }
     end, models)
@@ -700,6 +701,9 @@ function M.select_model()
         end
         if item.tools then
           table.insert(indicators, 'tools')
+        end
+        if item.reasoning then
+          table.insert(indicators, 'reasoning')
         end
 
         if #indicators > 0 then
@@ -865,12 +869,9 @@ function M.ask(prompt, config)
       system_prompt = system_prompt,
       model = selected_model,
       temperature = config.temperature,
-      on_progress = vim.schedule_wrap(function(token)
+      on_progress = vim.schedule_wrap(function(message)
         if not config.headless then
-          M.chat:add_message({
-            content = token,
-            role = 'assistant',
-          })
+          M.chat:add_message(message)
         end
       end),
     })

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -716,8 +716,8 @@ function Chat:render()
   -- Replace self.messages with new_messages (preserving tool_calls, etc.)
   self.messages = new_messages
 
-  -- Show tool call details as virt lines
   for _, message in ipairs(self.messages) do
+    -- Show tool call details as virt lines
     if message.tool_calls and #message.tool_calls > 0 then
       local section = message.section
       if section and section.end_line then
@@ -750,6 +750,25 @@ function Chat:render()
           strict = false,
         })
       end
+    end
+
+    -- Show reasoning as virtual text above assistant messages
+    if
+      message.role == 'assistant'
+      and not utils.empty(message.reasoning)
+      and message.section
+      and message.section.start_line
+    then
+      local virt_lines = {}
+      for _, line in ipairs(vim.split(message.reasoning, '\n')) do
+        table.insert(virt_lines, { { 'Reasoning: ' .. line, 'CopilotChatAnnotation' } })
+      end
+      vim.api.nvim_buf_set_extmark(self.bufnr, highlight_ns, message.section.start_line - 1, 0, {
+        virt_lines = virt_lines,
+        virt_lines_above = true,
+        priority = 100,
+        strict = false,
+      })
     end
   end
 


### PR DESCRIPTION
Adds support for displaying the assistant's reasoning above messages in the chat UI as virtual text. Reasoning is now streamed and stored separately from content, and models with reasoning capability are indicated in the model selector. This improves transparency of model responses and debugging.