### PR TITLE
refactor(constants): centralize role and plugin name constants

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -50,8 +50,9 @@
 ---@field reasoning boolean?
 
 local log = require('plenary.log')
-local tiktoken = require('CopilotChat.tiktoken')
+local constants = require('CopilotChat.constants')
 local notify = require('CopilotChat.notify')
+local tiktoken = require('CopilotChat.tiktoken')
 local utils = require('CopilotChat.utils')
 local class = utils.class
 
@@ -124,7 +125,7 @@ local function generate_selection_message(selection)
       selection.start_line,
       selection.end_line
     ),
-    role = 'user',
+    role = constants.ROLE.USER,
   }
 end
 
@@ -140,7 +141,7 @@ local function generate_resource_messages(resources)
     :map(function(resource)
       return {
         content = generate_resource_block(resource.data, resource.mimetype, resource.uri, resource.name, 1, nil),
-        role = 'user',
+        role = constants.ROLE.USER,
       }
     end)
     :totable()
@@ -160,7 +161,7 @@ local function generate_ask_request(prompt, system_prompt, history, generated_me
   if not utils.empty(system_prompt) then
     table.insert(messages, {
       content = system_prompt,
-      role = 'system',
+      role = constants.ROLE.SYSTEM,
     })
   end
 
@@ -172,7 +173,7 @@ local function generate_ask_request(prompt, system_prompt, history, generated_me
   if not utils.empty(prompt) and utils.empty(history) then
     table.insert(messages, {
       content = prompt,
-      role = 'user',
+      role = constants.ROLE.USER,
     })
   end
 
@@ -471,7 +472,7 @@ function Client:ask(prompt, opts)
 
     if opts.on_progress then
       opts.on_progress({
-        role = 'assistant',
+        role = constants.ROLE.ASSISTANT,
         content = out.content or '',
         reasoning = out.reasoning or '',
       })
@@ -597,7 +598,7 @@ function Client:ask(prompt, opts)
 
   return {
     message = {
-      role = 'assistant',
+      role = constants.ROLE.ASSISTANT,
       content = response_text,
       reasoning = response_reasoning,
       tool_calls = #tool_calls:values() > 0 and tool_calls:values() or nil,

--- a/lua/CopilotChat/completion.lua
+++ b/lua/CopilotChat/completion.lua
@@ -1,5 +1,6 @@
 local async = require('plenary.async')
 local client = require('CopilotChat.client')
+local constants = require('CopilotChat.constants')
 local config = require('CopilotChat.config')
 local functions = require('CopilotChat.functions')
 local utils = require('CopilotChat.utils')
@@ -33,10 +34,10 @@ function M.items()
     local kind = ''
     local info = ''
     if prompt.prompt then
-      kind = 'user'
+      kind = constants.ROLE.USER
       info = prompt.prompt
     elseif prompt.system_prompt then
-      kind = 'system'
+      kind = constants.ROLE.SYSTEM
       info = prompt.system_prompt
     end
 
@@ -88,7 +89,7 @@ function M.items()
     items[#items + 1] = {
       word = '@' .. name,
       abbr = name,
-      kind = 'tool',
+      kind = constants.ROLE.TOOL,
       info = tool.description,
       menu = tool.group or '',
       icase = 1,

--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -1,6 +1,7 @@
 local async = require('plenary.async')
 local copilot = require('CopilotChat')
 local client = require('CopilotChat.client')
+local constants = require('CopilotChat.constants')
 local utils = require('CopilotChat.utils')
 
 ---@class CopilotChat.config.mappings.Diff
@@ -162,7 +163,7 @@ return {
     normal = '<CR>',
     insert = '<C-s>',
     callback = function()
-      local message = copilot.chat:get_message('user', true)
+      local message = copilot.chat:get_message(constants.ROLE.USER, true)
       if not message then
         return
       end
@@ -174,7 +175,7 @@ return {
   toggle_sticky = {
     normal = 'grr',
     callback = function()
-      local message = copilot.chat:get_message('user')
+      local message = copilot.chat:get_message(constants.ROLE.USER)
       local section = message and message.section
       if not section then
         return
@@ -205,7 +206,7 @@ return {
   clear_stickies = {
     normal = 'grx',
     callback = function()
-      local message = copilot.chat:get_message('user')
+      local message = copilot.chat:get_message(constants.ROLE.USER)
       local section = message and message.section
       if not section then
         return
@@ -234,7 +235,7 @@ return {
     normal = '<C-y>',
     insert = '<C-y>',
     callback = function(source)
-      local diff = get_diff(copilot.chat:get_block('assistant', true))
+      local diff = get_diff(copilot.chat:get_block(constants.ROLE.ASSISTANT, true))
       diff = prepare_diff_buffer(diff, source)
       if not diff then
         return
@@ -249,7 +250,7 @@ return {
   jump_to_diff = {
     normal = 'gj',
     callback = function(source)
-      local diff = get_diff(copilot.chat:get_block('assistant', true))
+      local diff = get_diff(copilot.chat:get_block(constants.ROLE.ASSISTANT, true))
       diff = prepare_diff_buffer(diff, source)
       if not diff then
         return
@@ -264,7 +265,7 @@ return {
     callback = function()
       local items = {}
       for i, message in ipairs(copilot.chat.messages) do
-        if message.section and message.role == 'assistant' then
+        if message.section and message.role == constants.ROLE.ASSISTANT then
           local prev_message = copilot.chat.messages[i - 1]
           local text = ''
           if prev_message then
@@ -326,7 +327,7 @@ return {
     normal = 'gy',
     register = '"', -- Default register to use for yanking
     callback = function()
-      local block = copilot.chat:get_block('assistant', true)
+      local block = copilot.chat:get_block(constants.ROLE.ASSISTANT, true)
       if not block then
         return
       end
@@ -339,7 +340,7 @@ return {
     normal = 'gd',
     full_diff = false, -- Show full diff instead of unified diff when showing diff window
     callback = function(source)
-      local diff = get_diff(copilot.chat:get_block('assistant', true))
+      local diff = get_diff(copilot.chat:get_block(constants.ROLE.ASSISTANT, true))
       diff = prepare_diff_buffer(diff, source)
       if not diff then
         return
@@ -356,7 +357,7 @@ return {
         -- Apply all diffs from same file
         if #modified > 0 then
           -- Find all diffs from the same file in this section
-          local message = copilot.chat:get_message('assistant', true)
+          local message = copilot.chat:get_message(constants.ROLE.ASSISTANT, true)
           local section = message and message.section
           local same_file_diffs = {}
           if section then
@@ -429,7 +430,7 @@ return {
   show_info = {
     normal = 'gc',
     callback = function(source)
-      local message = copilot.chat:get_message('user', true)
+      local message = copilot.chat:get_message(constants.ROLE.USER, true)
       if not message then
         return
       end

--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -1,3 +1,4 @@
+local constants = require('CopilotChat.constants')
 local notify = require('CopilotChat.notify')
 local utils = require('CopilotChat.utils')
 local plenary_utils = require('plenary.async.util')
@@ -342,8 +343,8 @@ M.copilot = {
       }
 
       if is_o1 then
-        if input.role == 'system' then
-          output.role = 'user'
+        if input.role == constants.ROLE.SYSTEM then
+          output.role = constants.ROLE.USER
         end
       end
 

--- a/lua/CopilotChat/constants.lua
+++ b/lua/CopilotChat/constants.lua
@@ -1,0 +1,10 @@
+return {
+  PLUGIN_NAME = 'CopilotChat',
+
+  ROLE = {
+    USER = 'user',
+    ASSISTANT = 'assistant',
+    SYSTEM = 'system',
+    TOOL = 'tool',
+  },
+}

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -1,5 +1,6 @@
 local Overlay = require('CopilotChat.ui.overlay')
 local Spinner = require('CopilotChat.ui.spinner')
+local constants = require('CopilotChat.constants')
 local notify = require('CopilotChat.notify')
 local utils = require('CopilotChat.utils')
 local class = utils.class
@@ -204,7 +205,7 @@ function Chat:add_sticky(sticky)
     return
   end
 
-  local prompt = self:get_message('user')
+  local prompt = self:get_message(constants.ROLE.USER)
   if not prompt or not prompt.section then
     return
   end
@@ -667,7 +668,7 @@ function Chat:render()
     end
 
     -- Code blocks
-    if current_message and current_message.role == 'assistant' then
+    if current_message and current_message.role == constants.ROLE.ASSISTANT then
       local filetype, filename, start_line, end_line = match_header(line)
       if filetype and filename and not current_block then
         current_block = {
@@ -767,7 +768,7 @@ function Chat:render()
 
     -- Show reasoning as virtual text above assistant messages
     if
-      message.role == 'assistant'
+      message.role == constants.ROLE.ASSISTANT
       and not utils.empty(message.reasoning)
       and message.section
       and message.section.start_line
@@ -787,7 +788,7 @@ function Chat:render()
 
   -- Show help as before, using last user message
   local last_message = self.messages[#self.messages]
-  if last_message and last_message.role == 'user' then
+  if last_message and last_message.role == constants.ROLE.USER then
     local msg = self.config.show_help and self.help or ''
     if self.token_count and self.token_max_count then
       if msg ~= '' then


### PR DESCRIPTION
Move role strings and plugin name to a dedicated constants module. Refactor all usages to reference the new constants. This improves maintainability and reduces duplication across the codebase.