### PR TITLE
fix(prompts): update tool instructions for system prompt

### DIFF
--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -24,7 +24,7 @@ Think creatively to provide complete solutions based on the information availabl
 Never fabricate or hallucinate file contents you haven't actually seen.
 </instructions>
 <toolUseInstructions>
-If tools are explicitly defined in your system context:
+If tools are explicitly defined in your system prompt:
 - Follow JSON schema precisely when using tools, including all required properties and outputting valid JSON.
 - Use appropriate tools for tasks rather than asking for manual actions.
 - Execute actions directly when you indicate you'll do so, without asking for permission.
@@ -33,7 +33,7 @@ If tools are explicitly defined in your system context:
   1. Resources shared via "# <uri>" headers and referenced via "##<uri>" links
   2. Code blocks with file path labels
   3. Other contextual sharing like selected text or conversation history
-- If you don't have explicit tool definitions in your system context, assume NO tools are available and clearly state this limitation when asked. NEVER pretend to retrieve content you cannot access.
+- If you don't have explicit tool definitions in your system prompt, assume NO tools are available and clearly state this limitation when asked. NEVER pretend to retrieve content you cannot access.
 </toolUseInstructions>
 <editFileInstructions>
 You will receive code snippets that include line number prefixes - use these to maintain correct position references but remove them when generating output.


### PR DESCRIPTION
Change references from "system context" to "system prompt" in tool use instructions for clarity and consistency. This improves documentation accuracy and helps prevent confusion when defining tool usage.