### PR TITLE
refactor(prompts)!: support template substitution in system_prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Define your own prompts in the configuration:
       system_prompt = 'You are fascinated by pirates, so please respond in pirate speak.',
     },
     NiceInstructions = {
-      system_prompt = 'You are a nice coding tutor, so please respond in a friendly and helpful manner.' .. require('CopilotChat.config.prompts').COPILOT_BASE.system_prompt,
+      system_prompt = 'You are a nice coding tutor, so please respond in a friendly and helpful manner. {BASE_INSTRUCTIONS}',
     }
   }
 }

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -21,7 +21,7 @@
 ---@field language string?
 ---@field temperature number?
 ---@field headless boolean?
----@field callback nil|fun(response: string, source: CopilotChat.source)
+---@field callback nil|fun(response: CopilotChat.client.Message, source: CopilotChat.source)
 ---@field remember_as_sticky boolean?
 ---@field selection false|nil|fun(source: CopilotChat.source):CopilotChat.select.Selection?
 ---@field window CopilotChat.config.Window?

--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -1,4 +1,12 @@
-local COPILOT_BASE = [[
+---@class CopilotChat.config.prompts.Prompt : CopilotChat.config.Shared
+---@field prompt string?
+---@field description string?
+---@field mapping string?
+
+---@type table<string, CopilotChat.config.prompts.Prompt>
+return {
+  COPILOT_BASE = {
+    system_prompt = [[
 When asked for your name, you must respond with "GitHub Copilot".
 Follow the user's requirements carefully & to the letter.
 Keep your answers short and impersonal.
@@ -72,15 +80,20 @@ When presenting code changes:
 4. Address any diagnostics issues when fixing code.
 5. If multiple changes are needed, present them as separate code blocks.
 </editFileInstructions>
-]]
+]],
+  },
 
-local COPILOT_INSTRUCTIONS = [[
+  COPILOT_INSTRUCTIONS = {
+    system_prompt = [[
 You are a code-focused AI programming assistant that specializes in practical software engineering solutions.
-]] .. COPILOT_BASE
 
-local COPILOT_EXPLAIN = [[
+{COPILOT_BASE}
+]],
+  },
+
+  COPILOT_EXPLAIN = {
+    system_prompt = [[
 You are a programming instructor focused on clear, practical explanations.
-]] .. COPILOT_BASE .. [[
 
 When explaining code:
 - Provide concise high-level overview first
@@ -90,11 +103,16 @@ When explaining code:
 - Focus on complex parts rather than basic syntax
 - Use short paragraphs with clear structure
 - Mention performance considerations where relevant
-]]
 
-local COPILOT_REVIEW = [[
+{COPILOT_BASE}
+]],
+  },
+
+  COPILOT_REVIEW = {
+    system_prompt = [[
 You are a code reviewer focused on improving code quality and maintainability.
-]] .. COPILOT_BASE .. [[
+
+{COPILOT_BASE}
 
 Format each issue you find precisely as:
 line=<line_number>: <issue_description>
@@ -117,39 +135,17 @@ Multiple issues on one line should be separated by semicolons.
 End with: "**`To clear buffer highlights, please ask a different question.`**"
 
 If no issues found, confirm the code is well-written and explain why.
-]]
-
----@class CopilotChat.config.prompts.Prompt : CopilotChat.config.Shared
----@field prompt string?
----@field description string?
----@field mapping string?
-
----@type table<string, CopilotChat.config.prompts.Prompt>
-return {
-  COPILOT_BASE = {
-    system_prompt = COPILOT_BASE,
-  },
-
-  COPILOT_INSTRUCTIONS = {
-    system_prompt = COPILOT_INSTRUCTIONS,
-  },
-
-  COPILOT_EXPLAIN = {
-    system_prompt = COPILOT_EXPLAIN,
-  },
-
-  COPILOT_REVIEW = {
-    system_prompt = COPILOT_REVIEW,
+]],
   },
 
   Explain = {
     prompt = 'Write an explanation for the selected code as paragraphs of text.',
-    system_prompt = 'COPILOT_EXPLAIN',
+    system_prompt = '{COPILOT_EXPLAIN}',
   },
 
   Review = {
     prompt = 'Review the selected code.',
-    system_prompt = 'COPILOT_REVIEW',
+    system_prompt = '{COPILOT_REVIEW}',
     callback = function(response, source)
       local diagnostics = {}
       for line in response:gmatch('[^\r\n]+') do


### PR DESCRIPTION
Refactor prompt configuration to allow template substitution in system_prompt strings using curly braces (e.g. {COPILOT_BASE}). This enables more flexible and composable prompt definitions. Also update callback signature to use the full response object. Update README to reflect new prompt usage.

BREAKING CHANGE: callback receives the full response object instead of just content.