### PR TITLE
fix(utils): always exit insert mode in return_to_normal_mode

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -174,9 +174,8 @@ function M.return_to_normal_mode()
   local mode = vim.fn.mode():lower()
   if mode:find('v') then
     vim.cmd([[execute "normal! \<Esc>"]])
-  elseif mode ~= 'n' then
-    vim.cmd('stopinsert')
   end
+  vim.cmd('stopinsert')
 end
 
 --- Debounce a function


### PR DESCRIPTION
Previously, return_to_normal_mode only exited insert mode if not already in normal mode. This change ensures that 'stopinsert' is always called, making the function more reliable when switching modes, especially after visual selections. This improves consistency in mode transitions.

Fixes #1307