### PR TITLE
Feat/dynamic system prompt

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -125,4 +125,3 @@ return {
   -- default mappings
   mappings = require('CopilotChat.config.mappings'),
 }
-

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -1148,4 +1148,3 @@ function M.setup(config)
 end
 
 return M
-


### PR DESCRIPTION
Supersedes the previous PR that attemped to solve #1285 

With this modifications, if the "system instructions" are in the file `.github/instructions.md`, the user can configure `CopilotChat.nvim` this way:

```lua
    system_prompt = function()
      local file_path = vim.fn.getcwd() .. '/.github/instructions.md'
      if vim.fn.filereadable(file_path) == 0 then
        return "You are an AI programming assistant."
      end
      local file_content = vim.fn.readfile(file_path)
      return table.concat(file_content, '\n')
    end
```

Closes #1285