### PR TITLE
fix(config): correct system_prompt type and callback usage

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -14,7 +14,7 @@
 ---@field blend number?
 
 ---@class CopilotChat.config.Shared
----@field system_prompt string|fun(source: CopilotChat.source):string|nil
+---@field system_prompt nil|string|fun(source: CopilotChat.source):string
 ---@field model string?
 ---@field tools string|table<string>|nil
 ---@field sticky string|table<string>|nil
@@ -53,7 +53,7 @@ return {
 
   -- Shared config starts here (can be passed to functions at runtime and configured via setup function)
 
-  system_prompt = '{COPILOT_INSTRUCTIONS}', -- System prompt to use (can be specified manually in prompt via /).
+  system_prompt = require('CopilotChat.config.prompts').COPILOT_INSTRUCTIONS.system_prompt, -- System prompt to use (can be specified manually in prompt via /).
 
   model = 'gpt-4.1', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
   tools = nil, -- Default tool or array of tools (or groups) to share with LLM (can be specified manually in prompt via @).

--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -148,7 +148,7 @@ If no issues found, confirm the code is well-written and explain why.
     system_prompt = '{COPILOT_REVIEW}',
     callback = function(response, source)
       local diagnostics = {}
-      for line in response:gmatch('[^\r\n]+') do
+      for line in response.content:gmatch('[^\r\n]+') do
         if line:find('^line=') then
           local start_line = nil
           local end_line = nil


### PR DESCRIPTION
Update the type annotation for system_prompt to allow nil and fix its initialization to use the shared prompt. Also, update the callback in prompts.lua to use response.content for line parsing, ensuring correct diagnostics extraction.