### PR TITLE
fix(completion): require tool uri for input completion

### DIFF
--- a/lua/CopilotChat/completion.lua
+++ b/lua/CopilotChat/completion.lua
@@ -146,7 +146,7 @@ function M.complete(without_input)
   if not without_input and vim.startswith(prefix, '#') and vim.endswith(prefix, ':') then
     local found_tool = config.functions[prefix:sub(2, -2)]
     local found_schema = found_tool and functions.parse_schema(found_tool)
-    if found_tool and found_schema then
+    if found_tool and found_schema and found_tool.uri then
       async.run(function()
         local value = functions.enter_input(found_schema, source)
         if not value then


### PR DESCRIPTION
Previously, input completion was triggered for tools without a defined `uri`, which could lead to errors or unexpected behavior. This change ensures that input completion only occurs when both the tool and its schema are present and the tool has a valid `uri` property.