### PR TITLE
refactor(diff): improve line matching and replacement logic

### DIFF
--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -772,6 +772,17 @@ function M.empty(v)
   return false
 end
 
+--- Split text into lines
+---@param text string The text to split
+---@return string[] A table of lines
+function M.split_lines(text)
+  if not text or text == '' then
+    return {}
+  end
+
+  return vim.split(text, '\r?\n', { trimempty = false })
+end
+
 --- Convert glob pattern to regex pattern
 --- https://github.com/davidm/lua-glob-pattern/blob/master/lua/globtopattern.lua
 ---@param g string The glob pattern


### PR DESCRIPTION
Refactors diff application logic to use a new utils.split_lines function for consistent line splitting. Applies diffs from bottom to top to preserve line numbering and ensures correct replacement of lines in buffers. This improves accuracy when applying multiple diffs to the same file and enhances code readability.