### PR TITLE
fix(test): run tests automatically in test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install-pre-commit:
 	pre-commit install
 
 test:
-	nvim --headless --noplugin -u ./scripts/test.lua -c "lua MiniTest.run()"
+	nvim --headless --noplugin -u ./scripts/test.lua
 
 all: luajit
 

--- a/scripts/test.lua
+++ b/scripts/test.lua
@@ -11,4 +11,6 @@ for name, url in pairs({
   vim.opt.runtimepath:append(install_path)
 end
 
-require('mini.test').setup()
+local minitest = require('mini.test')
+minitest.setup()
+minitest.run()


### PR DESCRIPTION
Previously, the Makefile required a command to run tests after loading the test script. Now, the test script itself runs the tests automatically, simplifying the Makefile and ensuring consistent test execution.