### PR TITLE
test(makefile): use --clean for isolated test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install-pre-commit:
 	pre-commit install
 
 test:
-	nvim --headless --noplugin -u ./scripts/test.lua
+	nvim --headless --clean -u ./scripts/test.lua
 
 all: luajit
 


### PR DESCRIPTION
Switches the test target to use `nvim --headless --clean` instead of `--noplugin` to ensure tests run in a fully isolated environment, avoiding interference from user or system configuration. This improves test reliability and consistency.