### PR TITLE
refactor(utils): remove custom glob to pattern logic

### DIFF
--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -1,54 +1,6 @@
 local utils = require('CopilotChat.utils')
 
 describe('CopilotChat.utils', function()
-  local cases = {
-    { glob = '', expected = '^$' },
-    { glob = 'abc', expected = '^abc$' },
-    { glob = 'ab#/.', expected = '^ab%#%/%.$' },
-    { glob = '\\\\\\ab\\c\\', expected = '^%\\abc\\$' },
-
-    { glob = 'abc.*', expected = '^abc%..*$', matches = { 'abc.txt', 'abc.' }, not_matches = { 'abc' } },
-    { glob = '??.txt', expected = '^..%.txt$' },
-
-    { glob = 'a[]', expected = '[^]' },
-    { glob = 'a[^]b', expected = '^ab$' },
-    { glob = 'a[!]b', expected = '^ab$' },
-    { glob = 'a[a][b]z', expected = '^a[a][b]z$' },
-    { glob = 'a[a-f]z', expected = '^a[a-f]z$' },
-    { glob = 'a[a-f0-9]z', expected = '^a[a-f0-9]z$' },
-    { glob = 'a[a-f0-]z', expected = '^a[a-f0%-]z$' },
-    { glob = 'a[!a-f]z', expected = '^a[^a-f]z$' },
-    { glob = 'a[^a-f]z', expected = '^a[^a-f]z$' },
-    { glob = 'a[\\!\\^\\-z\\]]z', expected = '^a[%!%^%-z%]]z$' },
-    { glob = 'a[\\a-\\f]z', expected = '^a[a-f]z$' },
-
-    { glob = 'a[', expected = '[^]' },
-    { glob = 'a[a-', expected = '[^]' },
-    { glob = 'a[a-b', expected = '[^]' },
-    { glob = 'a[!', expected = '[^]' },
-    { glob = 'a[!a', expected = '[^]' },
-    { glob = 'a[!a-', expected = '[^]' },
-    { glob = 'a[!a-b', expected = '[^]' },
-    { glob = 'a[!a-b\\]', expected = '[^]' },
-  }
-
-  for _, case in ipairs(cases) do
-    it('glob_to_pattern: ' .. case.glob, function()
-      local pattern = utils.glob_to_pattern(case.glob)
-      assert.equals(case.expected, pattern)
-      if case.matches then
-        for _, str in ipairs(case.matches) do
-          assert.is_true(str:match(pattern) ~= nil)
-        end
-      end
-      if case.not_matches then
-        for _, str in ipairs(case.not_matches) do
-          assert.is_false(str:match(pattern) ~= nil)
-        end
-      end
-    end)
-  end
-
   it('empty', function()
     assert.is_true(utils.empty(nil))
     assert.is_true(utils.empty(''))


### PR DESCRIPTION
Replace custom glob pattern conversion and scandir fallback with native vim.lpeg and vim.uv.fs_scandir for file matching. This simplifies code, removes redundant logic, and improves compatibility. Also remove related unit tests for glob_to_pattern.

Closes #1331
Closes #1332