### PR TITLE
feat(ui): add auto_fold option for chat messages

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -31,6 +31,7 @@
 ---@field highlight_headers boolean?
 ---@field auto_follow_cursor boolean?
 ---@field auto_insert_mode boolean?
+---@field auto_fold boolean?
 ---@field insert_at_end boolean?
 ---@field clear_chat_on_new_prompt boolean?
 
@@ -90,6 +91,7 @@ return {
   highlight_headers = true, -- Highlight headers in chat
   auto_follow_cursor = true, -- Auto-follow cursor in chat
   auto_insert_mode = false, -- Automatically enter insert mode when opening window and on new prompt
+  auto_fold = false, -- Automatically non-assistant messages in chat
   insert_at_end = false, -- Move cursor to end of buffer when inserting text
   clear_chat_on_new_prompt = false, -- Clears chat on every new prompt
 

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -450,6 +450,18 @@ function Chat:add_message(message, replace)
     or current_message.role ~= message.role
     or (message.id and current_message.id ~= message.id)
 
+  if
+    self.config.auto_fold
+    and current_message
+    and current_message.role ~= constants.ROLE.ASSISTANT
+    and message.role ~= constants.ROLE.USER
+    and self:visible()
+  then
+    vim.api.nvim_win_call(self.winnr, function()
+      vim.cmd('normal! zc')
+    end)
+  end
+
   if is_new then
     -- Add appropriate header based on role and generate a new ID if not provided
     message.id = message.id or utils.uuid()
@@ -488,6 +500,12 @@ function Chat:add_message(message, replace)
     -- Append to the current message
     current_message.content = current_message.content .. message.content
     self:append(message.content)
+  end
+
+  if self.config.auto_fold and message.role == constants.ROLE.ASSISTANT and self:visible() then
+    vim.api.nvim_win_call(self.winnr, function()
+      vim.cmd('normal! zo')
+    end)
   end
 end
 


### PR DESCRIPTION
Introduce the `auto_fold` config option to automatically fold non-assistant messages in the chat window and unfold assistant messages. This improves readability and navigation in long chat sessions.

Closes #1300