### PR TITLE
refactor(prompts): use resources instead of sticky for Commit

### DIFF
--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -195,6 +195,6 @@ If no issues found, confirm the code is well-written and explain why.
 
   Commit = {
     prompt = 'Write commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.',
-    sticky = '#gitdiff:staged',
+    resources = 'gitdiff:staged',
   },
 }


### PR DESCRIPTION
Replaces the 'sticky' property with 'resources' in the Commit prompt configuration to improve clarity and maintain consistency with other prompt definitions.