### PR TITLE
feat(docs): add selection source to function table

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ All predefined functions belong to the `copilot` group.
 | `grep`        | Searches for a pattern across files in workspace | `#grep:TODO`           |
 | `quickfix`    | Includes content of files in quickfix list       | `#quickfix`            |
 | `register`    | Provides access to specified Vim register        | `#register:+`          |
+| `selection`   | Includes the current visual selection            | `#selection`           |
 | `url`         | Fetches content from a specified URL             | `#url:https://...`     |
 
 ## Predefined Prompts


### PR DESCRIPTION
Documented the new `selection` source in the function table, clarifying its usage for including the current visual selection. This improves discoverability and helps users understand available sources.