### PR TITLE
fix: check if window is valid before calling get_cursor

### DIFF
--- a/lua/CopilotChat/completion.lua
+++ b/lua/CopilotChat/completion.lua
@@ -167,6 +167,10 @@ function M.complete(without_input)
       local items = M.items()
       utils.schedule_main()
 
+      if not vim.api.nvim_win_is_valid(win) then
+        return
+      end
+
       local row_changed = vim.api.nvim_win_get_cursor(win)[1] ~= row
       local mode = vim.api.nvim_get_mode().mode
       if row_changed or not (mode == 'i' or mode == 'ic') then


### PR DESCRIPTION
Fixes issue when toggling on/off the floating chat window quickly, which sometimes causes the program to attempt a scheduled write on an invalid window:

<img width="1923" height="298" alt="image" src="https://github.com/user-attachments/assets/a185d70f-29b8-4b2d-896a-62439ee36693" />

my config for reference:
```lua
{
	model = "gpt-5-mini",
	temperature = 0.1,
	window = {
		layout = "float",
		width = 1,
		height = 1,
		row = 9999999,
		blend = 10,
	},
	auto_insert_mode = true,
	mappings = {
		close = {
			normal = "<Esc>",
			insert = "<C-c>",
			callback = function()
				chat.save(vim.fn.sha256(vim.fn.getcwd()))
				chat.close()
			end,
		},
	},
})

vim.keymap.set({ "n", "v", "i" }, "<A-C>", function()
	chat.toggle()
end, { noremap = true, silent = true, desc = "Copilot Chat: Toggle" })


```
