### PR TITLE
feat(prompts): support buffer replacement in commit messages

### DIFF
--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -194,7 +194,10 @@ If no issues found, confirm the code is well-written and explain why.
   },
 
   Commit = {
-    prompt = 'Write commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block.',
-    resources = 'gitdiff:staged',
+    prompt = 'Write commit message for the change with commitizen convention. Keep the title under 50 characters and wrap message at 72 characters. Format as a gitcommit code block. If user has COMMIT_EDITMSG opened, generate replacement block for whole buffer.',
+    resources = {
+      'gitdiff:staged',
+      'buffer',
+    },
   },
 }


### PR DESCRIPTION
Extend Commit prompt to handle buffer replacement when COMMIT_EDITMSG is opened. This allows generating commit messages that can fully replace the buffer, improving workflow for staged changes.