### PR TITLE
refactor(utils): split curl logic into separate module

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -58,6 +58,7 @@ local constants = require('CopilotChat.constants')
 local notify = require('CopilotChat.notify')
 local tiktoken = require('CopilotChat.tiktoken')
 local utils = require('CopilotChat.utils')
+local curl = require('CopilotChat.utils.curl')
 local class = require('CopilotChat.utils.class')
 local files = require('CopilotChat.utils.files')
 local orderedmap = require('CopilotChat.utils.orderedmap')
@@ -530,7 +531,7 @@ function Client:ask(prompt, opts)
     args.stream = stream_func
   end
 
-  local response, err = utils.curl_post(provider.get_url(options), args)
+  local response, err = curl.post(provider.get_url(options), args)
 
   if not opts.headless then
     if self.current_job ~= job_id then

--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -2,6 +2,7 @@ local plenary_utils = require('plenary.async.util')
 local constants = require('CopilotChat.constants')
 local notify = require('CopilotChat.notify')
 local utils = require('CopilotChat.utils')
+local curl = require('CopilotChat.utils.curl')
 local files = require('CopilotChat.utils.files')
 
 local EDITOR_VERSION = 'Neovim/' .. vim.version().major .. '.' .. vim.version().minor .. '.' .. vim.version().patch
@@ -51,7 +52,7 @@ end
 ---@return string
 local function github_device_flow(tag, client_id, scope)
   local function request_device_code()
-    local res = utils.curl_post('https://github.com/login/device/code', {
+    local res = curl.post('https://github.com/login/device/code', {
       body = {
         client_id = client_id,
         scope = scope,
@@ -67,7 +68,7 @@ local function github_device_flow(tag, client_id, scope)
     while true do
       plenary_utils.sleep(interval * 1000)
 
-      local res = utils.curl_post('https://github.com/login/oauth/access_token', {
+      local res = curl.post('https://github.com/login/oauth/access_token', {
         body = {
           client_id = client_id,
           device_code = device_code,
@@ -212,7 +213,7 @@ local M = {}
 
 M.copilot = {
   get_headers = function()
-    local response, err = utils.curl_get('https://api.github.com/copilot_internal/v2/token', {
+    local response, err = curl.get('https://api.github.com/copilot_internal/v2/token', {
       json_response = true,
       headers = {
         ['Authorization'] = 'Token ' .. get_github_copilot_token('github_copilot'),
@@ -232,8 +233,8 @@ M.copilot = {
       response.body.expires_at
   end,
 
-  get_info = function(headers)
-    local response, err = utils.curl_get('https://api.github.com/copilot_internal/user', {
+  get_info = function()
+    local response, err = curl.get('https://api.github.com/copilot_internal/user', {
       json_response = true,
       headers = {
         ['Authorization'] = 'Token ' .. get_github_copilot_token('github_copilot'),
@@ -283,7 +284,7 @@ M.copilot = {
   end,
 
   get_models = function(headers)
-    local response, err = utils.curl_get('https://api.githubcopilot.com/models', {
+    local response, err = curl.get('https://api.githubcopilot.com/models', {
       json_response = true,
       headers = headers,
     })
@@ -323,7 +324,7 @@ M.copilot = {
 
     for _, model in ipairs(models) do
       if not model.policy then
-        utils.curl_post('https://api.githubcopilot.com/models/' .. model.id .. '/policy', {
+        curl.post('https://api.githubcopilot.com/models/' .. model.id .. '/policy', {
           headers = headers,
           json_request = true,
           body = { state = 'enabled' },
@@ -463,7 +464,7 @@ M.github_models = {
   end,
 
   get_models = function(headers)
-    local response, err = utils.curl_get('https://models.github.ai/catalog/models', {
+    local response, err = curl.get('https://models.github.ai/catalog/models', {
       json_response = true,
       headers = headers,
     })

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -6,6 +6,7 @@ local constants = require('CopilotChat.constants')
 local notify = require('CopilotChat.notify')
 local select = require('CopilotChat.select')
 local utils = require('CopilotChat.utils')
+local curl = require('CopilotChat.utils.curl')
 local orderedmap = require('CopilotChat.utils.orderedmap')
 local files = require('CopilotChat.utils.files')
 
@@ -1003,7 +1004,7 @@ function M.setup(config)
   end
 
   -- Save proxy and insecure settings
-  utils.curl_store_args({
+  curl.store_args({
     insecure = M.config.allow_insecure,
     proxy = M.config.proxy,
   })

--- a/lua/CopilotChat/resources.lua
+++ b/lua/CopilotChat/resources.lua
@@ -1,5 +1,6 @@
 local async = require('plenary.async')
 local utils = require('CopilotChat.utils')
+local curl = require('CopilotChat.utils.curl')
 local files = require('CopilotChat.utils.files')
 local file_cache = {}
 local url_cache = {}
@@ -69,7 +70,7 @@ function M.get_url(url)
       content = out.stdout
     else
       -- Fallback to curl if lynx fails
-      local response = utils.curl_get(url, { raw = { '-L' } })
+      local response = curl.get(url, { raw = { '-L' } })
       if not response or not response.body then
         return nil
       end

--- a/lua/CopilotChat/select.lua
+++ b/lua/CopilotChat/select.lua
@@ -6,32 +6,36 @@
 ---@field filetype string
 ---@field bufnr number
 
-local constants = require('CopilotChat.constants')
+local log = require('plenary.log')
 local utils = require('CopilotChat.utils')
 
 local M = {}
 
+--- Use #selection instead
 ---@deprecated
 function M.visual(_)
-  vim.deprecate('CopilotChat.select.visual', '#selection', '5.0.0', constants.PLUGIN_NAME)
+  log.warn('CopilotChat.select.visual is deprecated, use #selection instead')
   return nil
 end
 
----@deprecated
+--- Use #selection instead
+---@deprecated use #selection instead
 function M.buffer(_)
-  vim.deprecate('CopilotChat.select.buffer', '#selection', '5.0.0', constants.PLUGIN_NAME)
+  log.warn('CopilotChat.select.buffer is deprecated, use #selection instead')
   return nil
 end
 
----@deprecated
+--- Use #selection instead
+---@deprecated use #selection instead
 function M.line(_)
-  vim.deprecate('CopilotChat.select.line', '#selection', '5.0.0', constants.PLUGIN_NAME)
+  log.warn('CopilotChat.select.line is deprecated, use #selection instead')
   return nil
 end
 
----@deprecated
+--- Use #selection instead
+---@deprecated use #selection instead
 function M.unnamed(_)
-  vim.deprecate('CopilotChat.select.unnamed', '#selection', '5.0.0', constants.PLUGIN_NAME)
+  log.warn('CopilotChat.select.unnamed is deprecated, use #selection instead')
   return nil
 end
 

--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -1,5 +1,6 @@
 local notify = require('CopilotChat.notify')
 local utils = require('CopilotChat.utils')
+local curl = require('CopilotChat.utils.curl')
 local class = require('CopilotChat.utils.class')
 
 --- Get the library extension based on the operating system
@@ -30,7 +31,7 @@ local function load_tiktoken_data(tokenizer)
 
   notify.publish(notify.STATUS, 'Downloading tiktoken data from ' .. tiktoken_url)
 
-  utils.curl_get(tiktoken_url, {
+  curl.get(tiktoken_url, {
     output = cache_path,
   })
 

--- a/lua/CopilotChat/utils.lua
+++ b/lua/CopilotChat/utils.lua
@@ -1,26 +1,22 @@
 local async = require('plenary.async')
-local curl = require('plenary.curl')
 local log = require('plenary.log')
 
 local M = {}
 M.timers = {}
 
-M.curl_args = {
-  timeout = 30000,
-  raw = {
-    '--retry',
-    '2',
-    '--retry-delay',
-    '1',
-    '--keepalive-time',
-    '60',
-    '--no-compressed',
-    '--connect-timeout',
-    '10',
-    '--tcp-nodelay',
-    '--no-buffer',
-  },
-}
+--- Use CopilotChat.utils.curl.get instead
+---@deprecated
+function M.curl_get(url, opts)
+  log.warn('M.curl_get is deprecated, use CopilotChat.utils.curl.get instead')
+  return require('CopilotChat.utils.curl').get(url, opts)
+end
+
+--- Use CopilotChat.utils.curl.post instead
+---@deprecated
+function M.curl_post(url, opts)
+  log.warn('M.curl_post is deprecated, use CopilotChat.utils.curl.post instead')
+  return require('CopilotChat.utils.curl').post(url, opts)
+end
 
 --- Convert arguments to a table
 ---@param ... any The arguments
@@ -125,123 +121,6 @@ function M.json_decode(body)
 
   return {}, data
 end
-
---- Store curl global arguments
----@param args table The arguments
----@return table
-function M.curl_store_args(args)
-  M.curl_args = vim.tbl_deep_extend('force', M.curl_args, args)
-  return M.curl_args
-end
-
---- Send curl get request
----@param url string The url
----@param opts table? The options
----@async
-M.curl_get = async.wrap(function(url, opts, callback)
-  log.debug('GET request:', url, opts)
-  local args = {
-    on_error = function(err)
-      log.debug('GET error:', err)
-      callback(nil, err and err.stderr or err)
-    end,
-  }
-
-  args = vim.tbl_deep_extend('force', M.curl_args, args)
-  args = vim.tbl_deep_extend('force', args, opts or {})
-
-  args.callback = function(response)
-    log.debug('GET response:', response)
-    if response and not vim.startswith(tostring(response.status), '20') then
-      callback(response, response.body)
-      return
-    end
-
-    if not args.json_response then
-      callback(response)
-      return
-    end
-
-    local body, err = M.json_decode(tostring(response.body))
-    if err then
-      callback(response, err)
-    else
-      response.body = body
-      callback(response)
-    end
-  end
-
-  curl.get(url, args)
-end, 3)
-
---- Send curl post request
----@param url string The url
----@param opts table? The options
----@async
-M.curl_post = async.wrap(function(url, opts, callback)
-  log.debug('POST request:', url, opts)
-  local args = {
-    on_error = function(err)
-      log.debug('POST error:', err)
-      callback(nil, err and err.stderr or err)
-    end,
-  }
-
-  args = vim.tbl_deep_extend('force', M.curl_args, args)
-  args = vim.tbl_deep_extend('force', args, opts or {})
-
-  local temp_file_path = nil
-
-  args.callback = function(response)
-    log.debug('POST response:', url, response)
-    if temp_file_path then
-      local ok, err = pcall(os.remove, temp_file_path)
-      if not ok then
-        log.debug('Failed to remove temp file:', temp_file_path, err)
-      end
-    end
-    if response and not vim.startswith(tostring(response.status), '20') then
-      callback(response, response.body)
-      return
-    end
-
-    if not args.json_response then
-      callback(response)
-      return
-    end
-
-    local body, err = M.json_decode(tostring(response.body))
-    if err then
-      callback(response, err)
-    else
-      response.body = body
-      callback(response)
-    end
-  end
-
-  if args.json_response then
-    args.headers = vim.tbl_deep_extend('force', args.headers or {}, {
-      Accept = 'application/json',
-    })
-  end
-
-  if args.json_request then
-    args.headers = vim.tbl_deep_extend('force', args.headers or {}, {
-      ['Content-Type'] = 'application/json',
-    })
-
-    temp_file_path = os.tmpname()
-    local f = io.open(temp_file_path, 'w+')
-    if f == nil then
-      error('Could not open file: ' .. temp_file_path)
-    end
-    f:write(vim.json.encode(args.body))
-    f:close()
-    args.body = temp_file_path
-  end
-
-  curl.post(url, args)
-end, 3)
 
 --- Call a system command
 ---@param cmd table The command

--- a/lua/CopilotChat/utils/curl.lua
+++ b/lua/CopilotChat/utils/curl.lua
@@ -1,0 +1,142 @@
+local async = require('plenary.async')
+local curl = require('plenary.curl')
+local log = require('plenary.log')
+local utils = require('CopilotChat.utils')
+
+local M = {}
+
+M.args = {
+  timeout = 30000,
+  raw = {
+    '--retry',
+    '2',
+    '--retry-delay',
+    '1',
+    '--keepalive-time',
+    '60',
+    '--no-compressed',
+    '--connect-timeout',
+    '10',
+    '--tcp-nodelay',
+    '--no-buffer',
+  },
+}
+
+--- Store curl global arguments
+---@param args table The arguments
+---@return table
+function M.store_args(args)
+  M.args = vim.tbl_deep_extend('force', M.args, args)
+  return M.args
+end
+
+--- Send curl get request
+---@param url string The url
+---@param opts table? The options
+---@async
+M.get = async.wrap(function(url, opts, callback)
+  log.debug('GET request:', url, opts)
+  local args = {
+    on_error = function(err)
+      log.debug('GET error:', err)
+      callback(nil, err and err.stderr or err)
+    end,
+  }
+
+  args = vim.tbl_deep_extend('force', M.args, args)
+  args = vim.tbl_deep_extend('force', args, opts or {})
+
+  args.callback = function(response)
+    log.debug('GET response:', response)
+    if response and not vim.startswith(tostring(response.status), '20') then
+      callback(response, response.body)
+      return
+    end
+
+    if not args.json_response then
+      callback(response)
+      return
+    end
+
+    local body, err = utils.json_decode(tostring(response.body))
+    if err then
+      callback(response, err)
+    else
+      response.body = body
+      callback(response)
+    end
+  end
+
+  curl.get(url, args)
+end, 3)
+
+--- Send curl post request
+---@param url string The url
+---@param opts table? The options
+---@async
+M.post = async.wrap(function(url, opts, callback)
+  log.debug('POST request:', url, opts)
+  local args = {
+    on_error = function(err)
+      log.debug('POST error:', err)
+      callback(nil, err and err.stderr or err)
+    end,
+  }
+
+  args = vim.tbl_deep_extend('force', M.args, args)
+  args = vim.tbl_deep_extend('force', args, opts or {})
+
+  local temp_file_path = nil
+
+  args.callback = function(response)
+    log.debug('POST response:', url, response)
+    if temp_file_path then
+      local ok, err = pcall(os.remove, temp_file_path)
+      if not ok then
+        log.debug('Failed to remove temp file:', temp_file_path, err)
+      end
+    end
+    if response and not vim.startswith(tostring(response.status), '20') then
+      callback(response, response.body)
+      return
+    end
+
+    if not args.json_response then
+      callback(response)
+      return
+    end
+
+    local body, err = utils.json_decode(tostring(response.body))
+    if err then
+      callback(response, err)
+    else
+      response.body = body
+      callback(response)
+    end
+  end
+
+  if args.json_response then
+    args.headers = vim.tbl_deep_extend('force', args.headers or {}, {
+      Accept = 'application/json',
+    })
+  end
+
+  if args.json_request then
+    args.headers = vim.tbl_deep_extend('force', args.headers or {}, {
+      ['Content-Type'] = 'application/json',
+    })
+
+    temp_file_path = os.tmpname()
+    local f = io.open(temp_file_path, 'w+')
+    if f == nil then
+      error('Could not open file: ' .. temp_file_path)
+    end
+    f:write(vim.json.encode(args.body))
+    f:close()
+    args.body = temp_file_path
+  end
+
+  curl.post(url, args)
+end, 3)
+
+return M


### PR DESCRIPTION
Move all curl-related logic from utils.lua to a new utils/curl.lua module. Update all internal references to use the new module. Mark old curl functions in utils.lua as deprecated. This improves code organization and makes curl logic easier to maintain and extend.