### PR TITLE
feat(functions): use cwd for file and grep commands

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -794,7 +794,8 @@ function Chat:render()
     if self.config.auto_fold and self:visible() then
       if message.role ~= constants.ROLE.ASSISTANT and message.section and i < #self.messages then
         vim.api.nvim_win_call(self.winnr, function()
-          if vim.fn.foldclosed(message.section.start_line) == -1 then
+          local fold_level = vim.fn.foldlevel(message.section.start_line)
+          if fold_level > 0 and vim.fn.foldclosed(message.section.start_line) == -1 then
             vim.api.nvim_cmd({ cmd = 'foldclose', range = { message.section.start_line } }, {})
           end
         end)

--- a/lua/CopilotChat/utils/files.lua
+++ b/lua/CopilotChat/utils/files.lua
@@ -70,9 +70,8 @@ M.glob = async.wrap(function(path, opts, callback)
     end
 
     table.insert(cmd, '--files')
-    table.insert(cmd, path)
 
-    vim.system(cmd, { text = true }, function(result)
+    vim.system(cmd, { cwd = path, text = true }, function(result)
       local files = {}
       if result and result.code == 0 and result.stdout ~= '' then
         files = filter_files(vim.split(result.stdout, '\n'), opts.max_count)
@@ -179,8 +178,6 @@ M.grep = async.wrap(function(path, opts, callback)
       table.insert(cmd, '-e')
       table.insert(cmd, "'" .. opts.pattern .. "'")
     end
-
-    table.insert(cmd, path)
   elseif vim.fn.executable('grep') == 1 then
     table.insert(cmd, 'grep')
     table.insert(cmd, '-rli')
@@ -189,8 +186,6 @@ M.grep = async.wrap(function(path, opts, callback)
       table.insert(cmd, '-e')
       table.insert(cmd, "'" .. opts.pattern .. "'")
     end
-
-    table.insert(cmd, path)
   end
 
   if M.empty(cmd) then
@@ -198,7 +193,7 @@ M.grep = async.wrap(function(path, opts, callback)
     return
   end
 
-  vim.system(cmd, { text = true }, function(result)
+  vim.system(cmd, { cwd = path, text = true }, function(result)
     local files = {}
     if result and result.code == 0 and result.stdout ~= '' then
       files = filter_files(vim.split(result.stdout, '\n'), opts.max_count)


### PR DESCRIPTION
Refactor file and grep picker utilities to use the working directory (cwd) instead of passing the path as a command argument. This improves the picker display.

Also, update chat auto-fold logic to only close folds if a fold exists at the target line, preventing unnecessary foldclose calls.

Closes #1108