### PR TITLE
fix(files): generate absolute paths in code blocks

### DIFF
--- a/lua/CopilotChat/config/prompts.lua
+++ b/lua/CopilotChat/config/prompts.lua
@@ -61,18 +61,18 @@ Steps for presenting code changes:
    ```
 
 2. Examples:
-   ```lua path=lua/CopilotChat/init.lua start_line=40 end_line=50
+   ```lua path={DIR}/lua/CopilotChat/init.lua start_line=40 end_line=50
    local function example()
      print("This is an example function.")
    end
    ```
 
-   ```python path=scripts/example.py start_line=10 end_line=15
+   ```python path={DIR}/scripts/example.py start_line=10 end_line=15
    def example_function():
        print("This is an example function.")
    ```
 
-   ```json path=config/settings.json start_line=5 end_line=8
+   ```json path={DIR}/config/settings.json start_line=5 end_line=8
    {
      "setting": "value",
      "enabled": true
@@ -80,6 +80,7 @@ Steps for presenting code changes:
    ```
 
 3. Requirements for code content:
+   - Always use the absolute file path in the code block header. If the path is not already absolute, convert it to an absolute path prefixed by {DIR}.
    - Keep changes minimal and focused to produce short diffs
    - Include complete replacement code for the specified line range
    - Proper indentation matching the source

--- a/lua/CopilotChat/utils/files.lua
+++ b/lua/CopilotChat/utils/files.lua
@@ -257,7 +257,7 @@ function M.filename_same(file1, file2)
   if not file1 or not file2 then
     return false
   end
-  return vim.fn.fnamemodify(file1, ':p') == vim.fn.fnamemodify(file2, ':p')
+  return vim.fs.normalize(file1) == vim.fs.normalize(file2)
 end
 
 --- Get the filetype of a file


### PR DESCRIPTION
Update code block examples in prompts to use absolute file paths with {DIR} prefix. Refactor filename comparison to use vim.fs.normalize for consistency and reliability.

Closes #1377