### PR TITLE
fix(auth): improve token saving and polling logic

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -109,7 +109,11 @@ local Chat = class(function(self, config, on_buf_create)
       self:open(self.config)
     end
 
-    self:overlay({ text = msg })
+    if not msg or msg == '' then
+      self.chat_overlay:restore(self.winnr, self.bufnr)
+    else
+      self:overlay({ text = msg })
+    end
   end)
 end, Overlay)
 

--- a/lua/CopilotChat/utils/files.lua
+++ b/lua/CopilotChat/utils/files.lua
@@ -231,9 +231,6 @@ end
 ---@param data string The data to write
 ---@return boolean
 function M.write_file(path, data)
-  M.schedule_main()
-  vim.fn.mkdir(vim.fn.fnamemodify(path, ':p:h'), 'p')
-
   local err, fd = async.uv.fs_open(path, 'w', 438)
   if err or not fd then
     return false


### PR DESCRIPTION
- Remove redundant directory creation and scheduling from file write
- Ensure token file directory is created only when saving token
- Refactor GitHub device flow polling to use recursion instead of loop
- Add logging for token save location
- Restore chat overlay when message is empty
- Clear status and message notifications after authorization

Closes #1388