### PR TITLE
refactor(ui): remove redundant spinner checks in chat

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -464,19 +464,12 @@ function Chat:start()
     utils.return_to_normal_mode()
   end
 
-  if self.spinner then
-    self.spinner:start()
-  end
-
+  self.spinner:start()
   vim.bo[self.bufnr].modifiable = false
 end
 
 --- Finish writing to the chat window.
 function Chat:finish()
-  if not self.spinner then
-    return
-  end
-
   self.spinner:finish()
   vim.bo[self.bufnr].modifiable = true
   if self.config.auto_insert_mode and self:focused() then


### PR DESCRIPTION
Simplifies Chat:start and Chat:finish by removing unnecessary checks for self.spinner. Assumes spinner is always present, streamlining the code and reducing conditional branches.