### PR TITLE
refactor(core): add tool_use instructions only when needed

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -564,9 +564,6 @@ function M.resolve_prompt(prompt, config)
     end
 
     config.system_prompt = vim.trim(config.system_prompt) .. '\n' .. M.config.prompts.COPILOT_BASE.system_prompt
-    config.system_prompt = vim.trim(config.system_prompt)
-      .. '\n'
-      .. vim.trim(require('CopilotChat.instructions.tool_use'))
 
     if config.diff == 'unified' then
       config.system_prompt = vim.trim(config.system_prompt)
@@ -828,6 +825,9 @@ function M.ask(prompt, config)
       local selected_tools, prompt = M.resolve_tools(prompt, config)
       local resolved_resources, resolved_tools, prompt = M.resolve_functions(prompt, config)
       local selected_model, prompt = M.resolve_model(prompt, config)
+      if not utils.empty(selected_tools) then
+        config.system_prompt = config.system_prompt .. '\n' .. require('CopilotChat.instructions.tool_use')
+      end
 
       prompt = vim.trim(prompt)
 


### PR DESCRIPTION
Previously, tool_use instructions were always appended to the system prompt, even when no tools were selected. This change moves the logic to add tool_use instructions to the ask function, ensuring they are included only when selected_tools is not empty. This optimizes prompt construction and prevents unnecessary instructions from being sent to the model.