### PR TITLE
fix(ui): improve help rendering and treesitter usage

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -621,7 +621,9 @@ function Chat:create()
   self.spinner.bufnr = bufnr
 
   vim.schedule(function()
-    pcall(vim.treesitter.start, bufnr)
+    if not vim.treesitter.get_parser(bufnr, 'markdown', {}) then
+      pcall(vim.treesitter.start, bufnr)
+    end
   end)
 
   vim.api.nvim_create_autocmd({ 'TextChanged', 'InsertLeave' }, {
@@ -906,7 +908,7 @@ function Chat:render()
         end
         msg = msg .. self.token_count .. '/' .. self.token_max_count .. ' tokens used'
       end
-      self:show_help(msg, message.section.start_line - 1)
+      self:show_help(msg, message.section.start_line)
     end
 
     -- Auto fold non-assistant messages if enabled

--- a/lua/CopilotChat/ui/overlay.lua
+++ b/lua/CopilotChat/ui/overlay.lua
@@ -143,6 +143,7 @@ function Overlay:show_help(msg, pos)
     id = 1,
     hl_mode = 'combine',
     priority = 100,
+    virt_lines_above = true,
     virt_lines = vim.tbl_map(function(t)
       return { { t, 'CopilotChatHelp' } }
     end, vim.split(msg, '\n')),


### PR DESCRIPTION
- Avoid starting treesitter if markdown parser already exists
- Fix help message line positioning in chat
- Render help virtual lines above for better visibility