### PR TITLE
perf(core): do not require calling setup(), add lazy initialization

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -211,7 +211,7 @@ end
 
 --- Set a provider resolver on the client
 ---@param resolver function: A function that returns a table of providers
-function Client:add_providers(resolver)
+function Client:set_providers(resolver)
   self.provider_resolver = resolver
 end
 

--- a/lua/CopilotChat/health.lua
+++ b/lua/CopilotChat/health.lua
@@ -57,11 +57,11 @@ function M.check()
     error('nvim: unsupported, please upgrade to 0.10.0 or later. See "https://neovim.io/".')
   end
 
-  local setup_called = require('CopilotChat').config ~= nil
-  if setup_called then
-    ok('setup: called')
+  local initialized = require('CopilotChat').initialized
+  if initialized then
+    ok('initialized: true')
   else
-    error('setup: not called, required for plugin to work. See `:h CopilotChat-installation`.')
+    error('initialized: false, something went wrong. See `:h CopilotChat-installation`.')
   end
 
   local testfile = os.tmpname()

--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -1,4 +1,3 @@
-local log = require('plenary.log')
 local notify = require('CopilotChat.notify')
 local utils = require('CopilotChat.utils')
 local curl = require('CopilotChat.utils.curl')


### PR DESCRIPTION
Refactored plugin initialization to use lazy loading via metatable, setting an `initialized` flag and moving setup logic to `init()`. Replaced `add_providers` with `set_providers` for clarity. Improved health check to verify initialization. Cleaned up chat state handling and logging logic for better reliability and maintainability.