### PR TITLE
fix(client): correct history handling for headless ask

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -888,9 +888,20 @@ function M.ask(prompt, config)
         return
       end
 
-      local ask_response = client.ask(client, prompt, {
+      -- Build history, when in headless mode its just current prompt
+      local history
+      if not config.headless then
+        history = M.chat:get_messages()
+      else
+        history = {
+          content = prompt,
+          role = constants.ROLE.USER,
+        }
+      end
+
+      local ask_response = client:ask({
         headless = config.headless,
-        history = M.chat:get_messages(),
+        history = history,
         resources = resolved_resources,
         tools = selected_tools,
         system_prompt = system_prompt,


### PR DESCRIPTION
Refactors ask request construction to properly handle history in headless mode. Removes prompt parameter from internal request generation and ensures the prompt is included as a user message only when appropriate. Also updates token counting and history trimming logic to avoid removing the current prompt in headless scenarios.

Resolves: #1415