### PR TITLE
fix(provider): safely call curl.post for model policy

### DIFF
--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -333,7 +333,7 @@ M.copilot = {
 
     for _, model in ipairs(models) do
       if not model.policy then
-        curl.post('https://api.githubcopilot.com/models/' .. model.id .. '/policy', {
+        pcall(curl.post, 'https://api.githubcopilot.com/models/' .. model.id .. '/policy', {
           headers = headers,
           json_request = true,
           body = { state = 'enabled' },


### PR DESCRIPTION
Wrap curl.post in pcall to prevent errors when enabling model policy. This avoids potential crashes if the request fails.