### PR TITLE
fix(ui): increase separator virt_text priority

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -794,7 +794,7 @@ function Chat:render()
           { string.rep(self.separator, vim.go.columns - #header_value - 1), 'CopilotChatSeparator' },
         },
         virt_text_pos = 'overlay',
-        priority = 300,
+        priority = 2000, -- High priority to override other plugins if enabled
         strict = false,
       })
 


### PR DESCRIPTION
Set the separator virtual text priority to 2000 to ensure it overrides other plugins' virtual text overlays in the chat UI (render-markdown.nvim uses 1000)

See #1423