### PR TITLE
fix(chat): ensure user prompt is wrapped in a list

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -894,8 +894,10 @@ function M.ask(prompt, config)
         history = M.chat:get_messages()
       else
         history = {
-          content = prompt,
-          role = constants.ROLE.USER,
+          {
+            content = prompt,
+            role = constants.ROLE.USER,
+          },
         }
       end
 


### PR DESCRIPTION
Previously, the user prompt was not wrapped in a table when initializing the chat history, which could cause issues when the code expects a list of messages. This change ensures the prompt is always provided as a list with the correct structure.

Closes #1426