### PR TITLE
fix(mappings): make sure function resolution is not ran in fast context

### DIFF
--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -337,10 +337,10 @@ return {
       local system_prompt = config.system_prompt
 
       async.run(function()
-        local infos = client:info()
+        local resolved_resources = copilot.resolve_functions(prompt, config)
         local selected_tools = copilot.resolve_tools(prompt, config)
         local selected_model = copilot.resolve_model(prompt, config)
-        local resolved_resources = copilot.resolve_functions(prompt, config)
+        local infos = client:info()
 
         selected_tools = vim.tbl_map(function(tool)
           return tool.name

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -515,7 +515,7 @@ end
 ---@param config CopilotChat.config.Shared?
 ---@return CopilotChat.config.prompts.Prompt, string
 function M.resolve_prompt(prompt, config)
-  if not prompt then
+  if prompt == nil then
     local message = M.chat:get_message(constants.ROLE.USER)
     if message then
       prompt = message.content


### PR DESCRIPTION
functions call get_messages and those use vim.api functions. So move it at start of show_info block