### PR TITLE
fix(os): use vim.uv.os_uname for OS detection

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -586,7 +586,7 @@ function M.resolve_prompt(prompt, config)
         .. vim.trim(require('CopilotChat.instructions.edit_file_block'))
     end
 
-    config.system_prompt = config.system_prompt:gsub('{OS_NAME}', jit.os)
+    config.system_prompt = config.system_prompt:gsub('{OS_NAME}', vim.uv.os_uname().sysname)
     config.system_prompt = config.system_prompt:gsub('{LANGUAGE}', config.language)
     config.system_prompt = config.system_prompt:gsub('{DIR}', state.source.cwd())
   end

--- a/lua/CopilotChat/tiktoken.lua
+++ b/lua/CopilotChat/tiktoken.lua
@@ -6,13 +6,14 @@ local class = require('CopilotChat.utils.class')
 --- Get the library extension based on the operating system
 --- @return string
 local function get_lib_extension()
-  if jit.os:lower() == 'mac' or jit.os:lower() == 'osx' then
+  local os_name = vim.uv.os_uname().sysname:lower()
+  if os_name:find('darwin') then
     return '.dylib'
-  end
-  if jit.os:lower() == 'windows' then
+  elseif os_name:find('windows') then
     return '.dll'
+  else
+    return '.so'
   end
-  return '.so'
 end
 
 --- Load tiktoken data from cache or download it


### PR DESCRIPTION
Replace usage of jit.os with vim.uv.os_uname().sysname to not rely on neovim builds with LuaJIT