### PR TITLE
fix(url): ensure main thread scheduling before fetching

### DIFF
--- a/lua/CopilotChat/config/functions.lua
+++ b/lua/CopilotChat/config/functions.lua
@@ -545,6 +545,7 @@ return {
         input.url = 'https://' .. input.url
       end
 
+      utils.schedule_main()
       local data, mimetype = resources.get_url(input.url)
       if not data then
         error('URL not found: ' .. input.url)


### PR DESCRIPTION
Call utils.schedule_main() before fetching URL data to ensure that subsequent operations run on the main thread. This prevents potential issues with asynchronous execution and improves reliability when accessing resources.