### PR TITLE
refactor(functions)!: unify buffer/selection/diagnostics resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,20 +167,21 @@ When you use `@copilot`, the LLM can call functions like `bash`, `edit`, `file`,
 
 All predefined functions belong to the `copilot` group.
 
-| Function    | Type     | Description                                             | Example Usage         |
-| ----------- | -------- | ------------------------------------------------------- | --------------------- |
-| `bash`      | Tool     | Executes a bash command and returns output              | `@copilot` only       |
-| `buffer`    | Resource | Retrieves content from buffer(s) with diagnostics       | `#buffer:active`      |
-| `clipboard` | Resource | Provides access to system clipboard content             | `#clipboard`          |
-| `edit`      | Tool     | Applies a unified diff to a file                        | `@copilot` only       |
-| `file`      | Resource | Reads content from a specified file path                | `#file:path/to/file`  |
-| `gitdiff`   | Resource | Retrieves git diff information                          | `#gitdiff:staged`     |
-| `glob`      | Resource | Lists filenames matching a pattern in workspace         | `#glob:**/*.lua`      |
-| `grep`      | Resource | Searches for a pattern across files in workspace        | `#grep:TODO`          |
-| `selection` | Resource | Includes the current visual selection with diagnostics  | `#selection`          |
-| `url`       | Resource | Fetches content from a specified URL                    | `#url:https://...`    |
+| Function    | Type     | Description                                            | Example Usage        |
+| ----------- | -------- | ------------------------------------------------------ | -------------------- |
+| `bash`      | Tool     | Executes a bash command and returns output             | `@copilot` only      |
+| `buffer`    | Resource | Retrieves content from buffer(s) with diagnostics      | `#buffer:active`     |
+| `clipboard` | Resource | Provides access to system clipboard content            | `#clipboard`         |
+| `edit`      | Tool     | Applies a unified diff to a file                       | `@copilot` only      |
+| `file`      | Resource | Reads content from a specified file path               | `#file:path/to/file` |
+| `gitdiff`   | Resource | Retrieves git diff information                         | `#gitdiff:staged`    |
+| `glob`      | Resource | Lists filenames matching a pattern in workspace        | `#glob:**/*.lua`     |
+| `grep`      | Resource | Searches for a pattern across files in workspace       | `#grep:TODO`         |
+| `selection` | Resource | Includes the current visual selection with diagnostics | `#selection`         |
+| `url`       | Resource | Fetches content from a specified URL                   | `#url:https://...`   |
 
 **Type Legend:**
+
 - **Resource**: Can be used manually via `#function` syntax
 - **Tool**: Can only be called by LLM via `@copilot` (for safety/complexity reasons)
 

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ EOF
 
 # Sticky prompt that persists
 
-> #buffer:current
+> #buffer:active
 > You are a helpful coding assistant
 ```
 
-When you use `@copilot`, the LLM can call functions like `glob`, `file`, `gitdiff` etc. You'll see the proposed function call and can approve/reject it before execution.
+When you use `@copilot`, the LLM can call functions like `bash`, `edit`, `file`, `glob`, `grep`, `gitdiff` etc. You'll see the proposed function call and can approve/reject it before execution.
 
 # Usage
 
@@ -143,7 +143,6 @@ When you use `@copilot`, the LLM can call functions like `glob`, `file`, `gitdif
 | `<C-l>` | `<C-l>` | Reset and clear the chat window            |
 | `<C-s>` | `<CR>`  | Submit the current prompt                  |
 | -       | `grr`   | Toggle sticky prompt for line under cursor |
-| -       | `grx`   | Clear all sticky prompts in prompt         |
 | `<C-y>` | `<C-y>` | Accept nearest diff                        |
 | -       | `gj`    | Jump to section of nearest diff            |
 | -       | `gqa`   | Add all answers from chat to quickfix list |
@@ -168,20 +167,22 @@ When you use `@copilot`, the LLM can call functions like `glob`, `file`, `gitdif
 
 All predefined functions belong to the `copilot` group.
 
-| Function      | Description                                      | Example Usage          |
-| ------------- | ------------------------------------------------ | ---------------------- |
-| `buffer`      | Retrieves content from a specific buffer         | `#buffer`              |
-| `buffers`     | Fetches content from multiple buffers            | `#buffers:visible`     |
-| `diagnostics` | Collects code diagnostics (errors, warnings)     | `#diagnostics:current` |
-| `file`        | Reads content from a specified file path         | `#file:path/to/file`   |
-| `gitdiff`     | Retrieves git diff information                   | `#gitdiff:staged`      |
-| `gitstatus`   | Retrieves git status information                 | `#gitstatus`           |
-| `glob`        | Lists filenames matching a pattern in workspace  | `#glob:**/*.lua`       |
-| `grep`        | Searches for a pattern across files in workspace | `#grep:TODO`           |
-| `quickfix`    | Includes content of files in quickfix list       | `#quickfix`            |
-| `register`    | Provides access to specified Vim register        | `#register:+`          |
-| `selection`   | Includes the current visual selection            | `#selection`           |
-| `url`         | Fetches content from a specified URL             | `#url:https://...`     |
+| Function    | Type     | Description                                             | Example Usage         |
+| ----------- | -------- | ------------------------------------------------------- | --------------------- |
+| `bash`      | Tool     | Executes a bash command and returns output              | `@copilot` only       |
+| `buffer`    | Resource | Retrieves content from buffer(s) with diagnostics       | `#buffer:active`      |
+| `clipboard` | Resource | Provides access to system clipboard content             | `#clipboard`          |
+| `edit`      | Tool     | Applies a unified diff to a file                        | `@copilot` only       |
+| `file`      | Resource | Reads content from a specified file path                | `#file:path/to/file`  |
+| `gitdiff`   | Resource | Retrieves git diff information                          | `#gitdiff:staged`     |
+| `glob`      | Resource | Lists filenames matching a pattern in workspace         | `#glob:**/*.lua`      |
+| `grep`      | Resource | Searches for a pattern across files in workspace        | `#grep:TODO`          |
+| `selection` | Resource | Includes the current visual selection with diagnostics  | `#selection`          |
+| `url`       | Resource | Fetches content from a specified URL                    | `#url:https://...`    |
+
+**Type Legend:**
+- **Resource**: Can be used manually via `#function` syntax
+- **Tool**: Can only be called by LLM via `@copilot` (for safety/complexity reasons)
 
 ## Predefined Prompts
 

--- a/lua/CopilotChat/config/functions.lua
+++ b/lua/CopilotChat/config/functions.lua
@@ -2,6 +2,44 @@ local resources = require('CopilotChat.resources')
 local utils = require('CopilotChat.utils')
 local files = require('CopilotChat.utils.files')
 
+--- Get diagnostics for a buffer and format them as text
+---@param bufnr number
+---@param start_line number?
+---@param end_line number?
+---@return string
+local function get_diagnostics_text(bufnr, start_line, end_line)
+  local diagnostics = vim.diagnostic.get(bufnr, {
+    severity = { min = vim.diagnostic.severity.HINT },
+  })
+
+  if #diagnostics == 0 then
+    return ''
+  end
+
+  local diag_lines = { '\n--- Diagnostics ---' }
+  for _, diag in ipairs(diagnostics) do
+    local diag_lnum = diag.lnum + 1
+    -- If range is specified, filter diagnostics within range
+    if not start_line or (diag_lnum >= start_line and diag_lnum <= end_line) then
+      local severity = vim.diagnostic.severity[diag.severity] or 'UNKNOWN'
+      local line_text = vim.api.nvim_buf_get_lines(bufnr, diag.lnum, diag.lnum + 1, false)[1] or ''
+      table.insert(
+        diag_lines,
+        string.format(
+          '%s line=%d-%d: %s\n  > %s',
+          severity,
+          diag.lnum + 1,
+          diag.end_lnum and (diag.end_lnum + 1) or (diag.lnum + 1),
+          diag.message,
+          line_text
+        )
+      )
+    end
+  end
+
+  return #diag_lines > 1 and table.concat(diag_lines, '\n') or ''
+end
+
 ---@class CopilotChat.config.functions.Function
 ---@field description string?
 ---@field schema table?
@@ -45,6 +83,198 @@ return {
           name = input.path,
           mimetype = mimetype,
           data = data,
+        },
+      }
+    end,
+  },
+
+  url = {
+    group = 'copilot',
+    uri = 'https://{url}',
+    description = 'Fetches content from a specified URL. Useful for referencing documentation, examples, or other online resources.',
+
+    schema = {
+      type = 'object',
+      required = { 'url' },
+      properties = {
+        url = {
+          type = 'string',
+          description = 'URL to include in chat context.',
+        },
+      },
+    },
+
+    resolve = function(input)
+      if not input.url:match('^https?://') then
+        input.url = 'https://' .. input.url
+      end
+
+      utils.schedule_main()
+      local data, mimetype = resources.get_url(input.url)
+      if not data then
+        error('URL not found: ' .. input.url)
+      end
+
+      return {
+        {
+          uri = input.url,
+          mimetype = mimetype,
+          data = data,
+        },
+      }
+    end,
+  },
+
+  buffer = {
+    group = 'copilot',
+    uri = 'neovim://buffer/{scope}',
+    description = 'Retrieves content from buffer(s) with diagnostics. Scope can be a buffer number, filename, or one of: active, visible, listed, quickfix.',
+
+    schema = {
+      type = 'object',
+      required = { 'scope' },
+      properties = {
+        scope = {
+          type = 'string',
+          description = 'Buffer scope: active (current), visible (shown in windows), listed (all listed buffers), quickfix (buffers in quickfix list), or a specific buffer number/filename.',
+          enum = function()
+            local opts = {
+              { display = 'active (current buffer)', value = 'active' },
+              { display = 'visible (all visible buffers)', value = 'visible' },
+              { display = 'listed (all listed buffers)', value = 'listed' },
+              { display = 'quickfix (buffers in quickfix)', value = 'quickfix' },
+            }
+
+            for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+              if utils.buf_valid(buf) and vim.fn.buflisted(buf) == 1 then
+                local name = vim.api.nvim_buf_get_name(buf)
+                if name and name ~= '' then
+                  local display_name = vim.fn.fnamemodify(name, ':~:.')
+                  table.insert(opts, { display = display_name, value = name })
+                end
+              end
+            end
+            return opts
+          end,
+          default = 'active',
+        },
+      },
+    },
+
+    resolve = function(input, source)
+      utils.schedule_main()
+      local scope = input.scope or 'active'
+      local buffers = {}
+
+      -- Determine which buffers to include based on scope
+      if scope == 'active' then
+        if source and source.bufnr and utils.buf_valid(source.bufnr) then
+          buffers = { source.bufnr }
+        end
+      elseif scope == 'visible' then
+        buffers = vim.tbl_filter(function(b)
+          return utils.buf_valid(b) and vim.fn.buflisted(b) == 1 and #vim.fn.win_findbuf(b) > 0
+        end, vim.api.nvim_list_bufs())
+      elseif scope == 'listed' then
+        buffers = vim.tbl_filter(function(b)
+          return utils.buf_valid(b) and vim.fn.buflisted(b) == 1
+        end, vim.api.nvim_list_bufs())
+      elseif scope == 'quickfix' then
+        local items = vim.fn.getqflist()
+        local file_to_bufnr = {}
+        for _, item in ipairs(items) do
+          local filename = item.filename or vim.api.nvim_buf_get_name(item.bufnr)
+          if filename and item.bufnr and utils.buf_valid(item.bufnr) then
+            file_to_bufnr[filename] = item.bufnr
+          end
+        end
+        buffers = vim.tbl_values(file_to_bufnr)
+      elseif tonumber(scope) then
+        local bufnr = tonumber(scope)
+        if utils.buf_valid(bufnr) then
+          buffers = { bufnr }
+        end
+      end
+
+      if #buffers == 0 then
+        error('No buffers found for input: ' .. scope)
+      end
+
+      local results = {}
+      for _, bufnr in ipairs(buffers) do
+        local name = vim.api.nvim_buf_get_name(bufnr)
+        local data, mimetype = resources.get_buffer(bufnr)
+        if data then
+          local diag_text = get_diagnostics_text(bufnr)
+          if diag_text ~= '' then
+            data = data .. diag_text
+          end
+
+          table.insert(results, {
+            uri = 'buffer://' .. bufnr,
+            name = name,
+            mimetype = mimetype,
+            data = data,
+          })
+        end
+      end
+
+      return results
+    end,
+  },
+
+  selection = {
+    group = 'copilot',
+    uri = 'neovim://selection',
+    description = 'Includes the content of the current visual selection with diagnostics. Useful for discussing specific code snippets or text blocks.',
+
+    resolve = function(_, source)
+      utils.schedule_main()
+
+      local select = require('CopilotChat.select')
+      local selection = select.get(source.bufnr)
+      if not selection then
+        return {}
+      end
+
+      local data = selection.content
+      local diag_text = get_diagnostics_text(source.bufnr, selection.start_line, selection.end_line)
+      if diag_text ~= '' then
+        data = data .. diag_text
+      end
+
+      return {
+        {
+          uri = 'neovim://selection',
+          name = selection.filename,
+          mimetype = files.mimetype_to_filetype(selection.filetype),
+          data = data,
+          annotations = {
+            start_line = selection.start_line,
+            end_line = selection.end_line,
+          },
+        },
+      }
+    end,
+  },
+
+  clipboard = {
+    group = 'copilot',
+    uri = 'neovim://clipboard',
+    description = 'Provides access to the system clipboard content. Useful for discussing copied text or code snippets.',
+
+    resolve = function()
+      utils.schedule_main()
+      local lines = vim.fn.getreg('+')
+      if not lines or lines == '' then
+        return {}
+      end
+
+      return {
+        {
+          uri = 'neovim://clipboard',
+          mimetype = 'text/plain',
+          data = lines,
         },
       }
     end,
@@ -113,344 +343,6 @@ return {
     end,
   },
 
-  buffer = {
-    group = 'copilot',
-    uri = 'buffer://{name}',
-    description = 'Retrieves content from a specific buffer. Useful for discussing or analyzing code from a particular file that is currently loaded.',
-
-    schema = {
-      type = 'object',
-      required = { 'name' },
-      properties = {
-        name = {
-          type = 'string',
-          description = 'Buffer filename to include in chat context.',
-          enum = function()
-            return vim
-              .iter(vim.api.nvim_list_bufs())
-              :filter(function(buf)
-                return buf and utils.buf_valid(buf) and vim.fn.buflisted(buf) == 1
-              end)
-              :map(function(buf)
-                return vim.api.nvim_buf_get_name(buf)
-              end)
-              :totable()
-          end,
-        },
-      },
-    },
-
-    resolve = function(input, source)
-      utils.schedule_main()
-      local name = input.name or vim.api.nvim_buf_get_name(source.bufnr)
-      local found_buf = nil
-      for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-        if vim.api.nvim_buf_get_name(buf) == name then
-          found_buf = buf
-          break
-        end
-      end
-      if not found_buf then
-        error('Buffer not found: ' .. name)
-      end
-      local data, mimetype = resources.get_buffer(found_buf)
-      if not data then
-        error('Buffer not found: ' .. name)
-      end
-      return {
-        {
-          uri = 'buffer://' .. name,
-          name = name,
-          mimetype = mimetype,
-          data = data,
-        },
-      }
-    end,
-  },
-
-  buffers = {
-    group = 'copilot',
-    uri = 'buffers://{scope}',
-    description = 'Fetches content from multiple buffers. Helps with discussing or analyzing code across multiple files simultaneously.',
-
-    schema = {
-      type = 'object',
-      required = { 'scope' },
-      properties = {
-        scope = {
-          type = 'string',
-          description = 'Scope of buffers to include in chat context.',
-          enum = { 'listed', 'visible' },
-          default = 'listed',
-        },
-      },
-    },
-
-    resolve = function(input)
-      utils.schedule_main()
-      return vim
-        .iter(vim.api.nvim_list_bufs())
-        :filter(function(bufnr)
-          return utils.buf_valid(bufnr)
-            and vim.fn.buflisted(bufnr) == 1
-            and (input.scope == 'listed' or #vim.fn.win_findbuf(bufnr) > 0)
-        end)
-        :map(function(bufnr)
-          local name = vim.api.nvim_buf_get_name(bufnr)
-          local data, mimetype = resources.get_buffer(bufnr)
-          if not data then
-            return nil
-          end
-          return {
-            uri = 'buffer://' .. name,
-            name = name,
-            mimetype = mimetype,
-            data = data,
-          }
-        end)
-        :filter(function(file_data)
-          return file_data ~= nil
-        end)
-        :totable()
-    end,
-  },
-
-  selection = {
-    group = 'copilot',
-    uri = 'neovim://selection',
-    description = 'Includes the content of the current visual selection. Useful for discussing specific code snippets or text blocks.',
-
-    resolve = function(_, source)
-      utils.schedule_main()
-      local selection = require('CopilotChat.select').get(source.bufnr)
-      if not selection then
-        return {}
-      end
-
-      return {
-        {
-          uri = 'neovim://selection',
-          name = selection.filename,
-          mimetype = files.mimetype_to_filetype(selection.filetype),
-          data = selection.content,
-          annotations = {
-            start_line = selection.start_line,
-            end_line = selection.end_line,
-          },
-        },
-      }
-    end,
-  },
-
-  quickfix = {
-    group = 'copilot',
-    uri = 'neovim://quickfix',
-    description = 'Includes the content of all files referenced in the current quickfix list. Useful for discussing compilation errors, search results, or other collected locations.',
-
-    resolve = function()
-      utils.schedule_main()
-
-      local items = vim.fn.getqflist()
-      if not items or #items == 0 then
-        return {}
-      end
-
-      local file_to_bufnr = {}
-      for _, item in ipairs(items) do
-        local filename = item.filename or vim.api.nvim_buf_get_name(item.bufnr)
-        if filename then
-          if item.bufnr and utils.buf_valid(item.bufnr) then
-            file_to_bufnr[filename] = item.bufnr
-          else
-            file_to_bufnr[filename] = false
-          end
-        end
-      end
-
-      return vim
-        .iter(vim.tbl_keys(file_to_bufnr))
-        :map(function(file)
-          local bufnr = file_to_bufnr[file]
-          local data, mimetype, uri
-          if bufnr and bufnr ~= false then
-            data, mimetype = resources.get_buffer(bufnr)
-            uri = 'buffer://' .. file
-          else
-            data, mimetype = resources.get_file(file)
-            uri = 'file://' .. file
-          end
-          if not data then
-            return nil
-          end
-          return {
-            uri = uri,
-            name = file,
-            mimetype = mimetype,
-            data = data,
-          }
-        end)
-        :filter(function(file_data)
-          return file_data ~= nil
-        end)
-        :totable()
-    end,
-  },
-
-  diagnostics = {
-    group = 'copilot',
-    uri = 'neovim://diagnostics/{scope}/{severity}',
-    description = 'Collects code diagnostics (errors, warnings, etc.) from specified buffers. Helpful for troubleshooting and fixing code issues.',
-
-    schema = {
-      type = 'object',
-      required = { 'scope', 'severity' },
-      properties = {
-        scope = {
-          type = 'string',
-          description = 'Scope of buffers to use for retrieving diagnostics.',
-          enum = { 'current', 'listed', 'visible', 'selection' },
-          default = 'current',
-        },
-        severity = {
-          type = 'string',
-          description = 'Minimum severity level of diagnostics to include.',
-          enum = { 'error', 'warn', 'info', 'hint' },
-          default = 'warn',
-        },
-      },
-    },
-
-    resolve = function(input, source)
-      utils.schedule_main()
-      local out = {}
-      local scope = input.scope or 'current'
-      local buffers = {}
-
-      -- Get buffers based on scope
-      if scope == 'current' or scope == 'selection' then
-        if source and source.bufnr and utils.buf_valid(source.bufnr) then
-          buffers = { source.bufnr }
-        end
-      elseif scope == 'listed' then
-        buffers = vim.tbl_filter(function(b)
-          return utils.buf_valid(b) and vim.fn.buflisted(b) == 1
-        end, vim.api.nvim_list_bufs())
-      elseif scope == 'visible' then
-        buffers = vim.tbl_filter(function(b)
-          return utils.buf_valid(b) and vim.fn.buflisted(b) == 1 and #vim.fn.win_findbuf(b) > 0
-        end, vim.api.nvim_list_bufs())
-      else
-        buffers = vim.tbl_filter(function(b)
-          return utils.buf_valid(b) and vim.api.nvim_buf_get_name(b) == input.scope
-        end, vim.api.nvim_list_bufs())
-      end
-
-      -- By default, collect from the whole buffer
-      local selection_start_line = 1
-      local selection_end_line = vim.api.nvim_buf_line_count(source.bufnr)
-      -- Determine selection range if scope is 'selection'
-      if scope == 'selection' then
-        local select = require('CopilotChat.select')
-        local selection = select.get(source.bufnr)
-        if selection then
-          selection_start_line = selection.start_line
-          selection_end_line = selection.end_line
-        else
-          return out
-        end
-      end
-
-      -- Collect diagnostics for each buffer
-      for _, bufnr in ipairs(buffers) do
-        local name = vim.api.nvim_buf_get_name(bufnr)
-        local diagnostics = vim.diagnostic.get(bufnr, {
-          severity = {
-            min = vim.diagnostic.severity[input.severity:upper()],
-          },
-        })
-
-        if #diagnostics > 0 then
-          local diag_lines = {}
-          for _, diag in ipairs(diagnostics) do
-            -- Diagnostics.lnum are 0-indexed, so add 1 for comparison
-            local diag_lnum = diag.lnum + 1
-            if diag_lnum >= selection_start_line and diag_lnum <= selection_end_line then
-              local severity = vim.diagnostic.severity[diag.severity] or 'UNKNOWN'
-              local line_text = vim.api.nvim_buf_get_lines(bufnr, diag.lnum, diag.lnum + 1, false)[1] or ''
-
-              table.insert(
-                diag_lines,
-                string.format(
-                  '%s line=%d-%d: %s\n  > %s',
-                  severity,
-                  diag.lnum + 1,
-                  diag.end_lnum and (diag.end_lnum + 1) or (diag.lnum + 1),
-                  diag.message,
-                  line_text
-                )
-              )
-            end
-          end
-
-          table.insert(out, {
-            uri = 'neovim://diagnostics/' .. name,
-            mimetype = 'text/plain',
-            data = table.concat(diag_lines, '\n'),
-          })
-        end
-      end
-
-      return out
-    end,
-  },
-
-  register = {
-    group = 'copilot',
-    uri = 'neovim://register/{register}',
-    description = 'Provides access to the content of a specified Vim register. Useful for discussing yanked text, clipboard content, or previously executed commands.',
-
-    schema = {
-      type = 'object',
-      required = { 'register' },
-      properties = {
-        register = {
-          type = 'string',
-          description = 'Register to include in chat context.',
-          enum = {
-            '+',
-            '*',
-            '"',
-            '0',
-            '-',
-            '.',
-            '%',
-            ':',
-            '#',
-            '=',
-            '/',
-          },
-          default = '+',
-        },
-      },
-    },
-
-    resolve = function(input)
-      utils.schedule_main()
-      local lines = vim.fn.getreg(input.register)
-      if not lines or lines == '' then
-        return {}
-      end
-
-      return {
-        {
-          uri = 'neovim://register/' .. input.register,
-          mimetype = 'text/plain',
-          data = lines,
-        },
-      }
-    end,
-  },
-
   gitdiff = {
     group = 'copilot',
     uri = 'git://diff/{target}',
@@ -499,65 +391,104 @@ return {
     end,
   },
 
-  gitstatus = {
+  bash = {
     group = 'copilot',
-    uri = 'git://status',
-    description = 'Retrieves the status of the current git repository. Useful for discussing changes, commits, and other git-related tasks.',
+    description = 'Executes a bash command and returns its output. Useful for running shell commands, checking file contents, or gathering system information.',
 
-    resolve = function(_, source)
-      local cmd = {
-        'git',
-        '-C',
-        source.cwd(),
-        'status',
-      }
+    schema = {
+      type = 'object',
+      required = { 'command' },
+      properties = {
+        command = {
+          type = 'string',
+          description = 'Bash command to execute.',
+        },
+      },
+    },
 
-      local out = utils.system(cmd)
+    resolve = function(input, source)
+      local cmd = { 'bash', '-c', input.command }
+      local out = utils.system(cmd, { cwd = source.cwd() })
 
       return {
         {
-          uri = 'git://status',
-          mimetype = 'text/plain',
           data = out.stdout,
         },
       }
     end,
   },
 
-  url = {
+  edit = {
     group = 'copilot',
-    uri = 'https://{url}',
-    description = 'Fetches content from a specified URL. Useful for referencing documentation, examples, or other online resources.',
+    description = 'Applies a unified diff to a file. The diff should be in unified diff format (similar to diff -U0 output).',
 
     schema = {
       type = 'object',
-      required = { 'url' },
+      required = { 'filename', 'diff' },
       properties = {
-        url = {
+        filename = {
           type = 'string',
-          description = 'URL to include in chat context.',
+          description = 'Path to file to edit.',
+        },
+        diff = {
+          type = 'string',
+          description = 'Unified diff content to apply to the file.',
         },
       },
     },
 
-    resolve = function(input)
-      if not input.url:match('^https?://') then
-        input.url = 'https://' .. input.url
-      end
-
+    resolve = function(input, source)
       utils.schedule_main()
-      local data, mimetype = resources.get_url(input.url)
-      if not data then
-        error('URL not found: ' .. input.url)
+
+      local select = require('CopilotChat.select')
+      local diff = require('CopilotChat.utils.diff')
+
+      -- Find or create the buffer for the file
+      local filename = input.filename
+      local diff_bufnr = nil
+
+      -- Try to find matching buffer first
+      for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+        if files.filename_same(vim.api.nvim_buf_get_name(buf), filename) then
+          diff_bufnr = buf
+          break
+        end
       end
 
-      return {
-        {
-          uri = input.url,
-          mimetype = mimetype,
-          data = data,
-        },
-      }
+      -- If still not found, try to load or create buffer
+      if not diff_bufnr then
+        diff_bufnr = vim.fn.bufadd(filename)
+        vim.fn.bufload(diff_bufnr)
+      end
+
+      -- Get current buffer content
+      local lines = vim.api.nvim_buf_get_lines(diff_bufnr, 0, -1, false)
+      local content = table.concat(lines, '\n')
+
+      -- Apply the unified diff
+      local new_lines, applied, first, last = diff.apply_unified_diff(input.diff, content)
+
+      if applied then
+        -- Apply changes to buffer
+        vim.api.nvim_buf_set_lines(diff_bufnr, 0, -1, false, new_lines)
+
+        -- If source window is valid, switch to the edited buffer and highlight changes
+        if source and source.winnr and vim.api.nvim_win_is_valid(source.winnr) then
+          vim.api.nvim_win_set_buf(source.winnr, diff_bufnr)
+          if first and last then
+            select.set(diff_bufnr, source.winnr, first, last)
+            select.highlight(diff_bufnr)
+          end
+        end
+
+        return {
+          {
+            data = string.format('Successfully applied diff to %s (lines %d-%d)', filename, first or 0, last or 0),
+          },
+        }
+      else
+        error('Failed to apply diff to ' .. filename)
+      end
     end,
   },
 }

--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -61,6 +61,7 @@ end
 ---@field accept_diff CopilotChat.config.mapping|false|nil
 ---@field jump_to_diff CopilotChat.config.mapping|false|nil
 ---@field quickfix_diffs CopilotChat.config.mapping|false|nil
+---@field quickfix_answers CopilotChat.config.mapping|false|nil
 ---@field yank_diff CopilotChat.config.mapping.yank_diff|false|nil
 ---@field show_diff CopilotChat.config.mapping|false|nil
 ---@field show_info CopilotChat.config.mapping|false|nil
@@ -130,34 +131,6 @@ return {
 
       copilot.chat:add_sticky(current_line)
       vim.api.nvim_win_set_cursor(copilot.chat.winnr, cursor)
-    end,
-  },
-
-  clear_stickies = {
-    normal = 'grx',
-    callback = function()
-      local message = copilot.chat:get_message(constants.ROLE.USER)
-      local section = message and message.section
-      if not section then
-        return
-      end
-
-      local lines = utils.split_lines(message.content)
-      local new_lines = {}
-      local changed = false
-
-      for _, line in ipairs(lines) do
-        if not vim.startswith(vim.trim(line), '> ') then
-          table.insert(new_lines, line)
-        else
-          changed = true
-        end
-      end
-
-      if changed then
-        message.content = table.concat(new_lines, '\n')
-        copilot.chat:add_message(message, true)
-      end
     end,
   },
 


### PR DESCRIPTION
- Replace separate `buffer`, `buffers`, `selection`, `diagnostics` and 'quickfix' resources with a unified `buffer` and `selection` resource that automatically includes diagnostics in the output.
- Replace `register` resource with simplified `clipboard` resource
- Add new `bash` and `edit` tools for LLM-only usage.
- Update README to reflect new resource/tool types and usage.
- Remove unused/duplicated mappings and code for old resources.
- Improve enum handling and selection UI for resource schemas.

BREAKING CHANGE: Removes `buffers`, `diagnostics`, `register`, and `quickfix` resources. Use `buffer`, `selection`, or `clipboard` instead.