### PR TITLE
fix(mappings): use resource name if available in preview header

### DIFF
--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -385,7 +385,7 @@ return {
         for _, resource in ipairs(resolved_resources) do
           local resource_lines = vim.split(resource.data, '\n')
           local preview = vim.list_slice(resource_lines, 1, math.min(10, #resource_lines))
-          local header = string.format('**%s** (%s lines)', resource.uri, #resource_lines)
+          local header = string.format('**%s** (%s lines)', resource.name or resource.uri, #resource_lines)
           if #resource_lines > 10 then
             header = header .. ' (truncated)'
           end


### PR DESCRIPTION
When displaying resource previews, prefer showing the resource name instead of the URI if the name is available. This improves readability in the preview header, especially for resources with user-friendly names.