### PR TITLE
refactor!: move source/sticky logic to chat window

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,10 +408,6 @@ chat.toggle(config)           -- Toggle chat window visibility with optional con
 chat.reset()                  -- Reset the chat
 chat.stop()                   -- Stop current output
 
--- Source Management
-chat.get_source()             -- Get the current source buffer and window
-chat.set_source(winnr)        -- Set the source window
-
 -- Prompt & Model Management
 chat.select_prompt(config)    -- Open prompt selector with optional config
 chat.select_model()           -- Open model selector
@@ -441,13 +437,16 @@ window:get_message(role, cursor)               -- Get chat message by role, eith
 window:add_message({ role, content }, replace) -- Add or replace a message in chat
 window:remove_message(role, cursor)            -- Remove chat message by role, either last or closest to cursor
 window:get_block(role, cursor)                 -- Get code block by role, either last or closest to cursor
-window:add_sticky(sticky)                      -- Add sticky prompt to chat message
 
 -- Content Management
 window:append(text)          -- Append text to chat window
 window:clear()               -- Clear chat window content
 window:start()               -- Start writing to chat window
 window:finish()              -- Finish writing to chat window
+
+-- Source Management
+window.get_source()          -- Get the current source buffer and window
+window.set_source(winnr)     -- Set the source window
 
 -- Navigation
 window:follow()              -- Move cursor to end of chat content

--- a/lua/CopilotChat/completion.lua
+++ b/lua/CopilotChat/completion.lua
@@ -131,7 +131,7 @@ end
 --- Trigger the completion for the chat window.
 ---@param without_input boolean?
 function M.complete(without_input)
-  local source = require('CopilotChat').get_source()
+  local source = require('CopilotChat').chat:get_source()
   local info = M.info()
   local bufnr = vim.api.nvim_get_current_buf()
   local line = vim.api.nvim_get_current_line()

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -23,7 +23,7 @@
 ---@field language string?
 ---@field temperature number?
 ---@field headless boolean?
----@field callback nil|fun(response: CopilotChat.client.Message, source: CopilotChat.source)
+---@field callback nil|fun(response: CopilotChat.client.Message, source: CopilotChat.ui.chat.Source)
 ---@field remember_as_sticky boolean?
 ---@field window CopilotChat.config.Window?
 ---@field show_help boolean?

--- a/lua/CopilotChat/config/functions.lua
+++ b/lua/CopilotChat/config/functions.lua
@@ -45,7 +45,7 @@ end
 ---@field schema table?
 ---@field group string?
 ---@field uri string?
----@field resolve fun(input: table, source: CopilotChat.source):CopilotChat.client.Resource[]
+---@field resolve fun(input: table, source: CopilotChat.ui.chat.Source):CopilotChat.client.Resource[]
 
 ---@type table<string, CopilotChat.config.functions.Function>
 return {

--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -9,7 +9,7 @@ local files = require('CopilotChat.utils.files')
 
 --- Prepare a buffer for applying a diff
 ---@param filename string?
----@param source CopilotChat.source
+---@param source CopilotChat.ui.chat.Source
 ---@return integer
 local function prepare_diff_buffer(filename, source)
   if not filename then
@@ -47,7 +47,7 @@ end
 ---@class CopilotChat.config.mapping
 ---@field normal string?
 ---@field insert string?
----@field callback fun(source: CopilotChat.source)
+---@field callback fun(source: CopilotChat.ui.chat.Source)
 
 ---@class CopilotChat.config.mapping.yank_diff : CopilotChat.config.mapping
 ---@field register string?
@@ -57,7 +57,6 @@ end
 ---@field close CopilotChat.config.mapping|false|nil
 ---@field reset CopilotChat.config.mapping|false|nil
 ---@field submit_prompt CopilotChat.config.mapping|false|nil
----@field toggle_sticky CopilotChat.config.mapping|false|nil
 ---@field accept_diff CopilotChat.config.mapping|false|nil
 ---@field jump_to_diff CopilotChat.config.mapping|false|nil
 ---@field quickfix_diffs CopilotChat.config.mapping|false|nil
@@ -100,37 +99,6 @@ return {
       end
 
       copilot.ask(message.content)
-    end,
-  },
-
-  toggle_sticky = {
-    normal = 'grr',
-    callback = function()
-      local message = copilot.chat:get_message(constants.ROLE.USER)
-      local section = message and message.section
-      if not section then
-        return
-      end
-
-      local cursor = vim.api.nvim_win_get_cursor(copilot.chat.winnr)
-      if cursor[1] < section.start_line or cursor[1] > section.end_line then
-        return
-      end
-
-      local current_line = vim.trim(vim.api.nvim_get_current_line())
-      if current_line == '' then
-        return
-      end
-
-      local cur_line = cursor[1]
-      vim.api.nvim_buf_set_lines(copilot.chat.bufnr, cur_line - 1, cur_line, false, {})
-
-      if vim.startswith(current_line, '> ') then
-        return
-      end
-
-      copilot.chat:add_sticky(current_line)
-      vim.api.nvim_win_set_cursor(copilot.chat.winnr, cursor)
     end,
   },
 

--- a/lua/CopilotChat/functions.lua
+++ b/lua/CopilotChat/functions.lua
@@ -199,7 +199,7 @@ end
 
 --- Get input from the user based on the schema
 ---@param schema table?
----@param source CopilotChat.source
+---@param source CopilotChat.ui.chat.Source
 ---@return string?
 function M.enter_input(schema, source)
   if not schema or not schema.properties then

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -30,35 +30,18 @@ local M = setmetatable({}, {
   end,
 })
 
---- @class CopilotChat.source
---- @field bufnr number?
---- @field winnr number?
---- @field cwd fun():string
-
---- @class CopilotChat.state
---- @field source CopilotChat.source
---- @field sticky string[]
-local state = {
-  source = {
-    bufnr = nil,
-    winnr = nil,
-    cwd = function()
-      return '.'
-    end,
-  },
-
-  sticky = {},
-}
-
---- Insert sticky values from config into prompt
+--- Process sticky values from prompt and config
+--- Extracts stickies from prompt, adds config-based stickies, stores them, returns clean prompt
 ---@param prompt string
 ---@param config CopilotChat.config.Shared
-local function insert_sticky(prompt, config)
+---@return string clean_prompt The prompt without sticky prefixes
+local function process_sticky(prompt, config)
   local existing_prompt = M.chat:get_message(constants.ROLE.USER)
   local combined_prompt = (existing_prompt and existing_prompt.content or '') .. '\n' .. (prompt or '')
   local lines = vim.split(prompt or '', '\n')
   local stickies = orderedmap()
 
+  -- Extract existing stickies from combined prompt
   local sticky_indices = {}
   local in_code_block = false
   for _, line in ipairs(vim.split(combined_prompt, '\n')) do
@@ -69,6 +52,8 @@ local function insert_sticky(prompt, config)
       stickies:set(vim.trim(line:sub(3)), true)
     end
   end
+
+  -- Find sticky lines in new prompt to remove them
   for i, line in ipairs(lines) do
     if vim.startswith(line, '> ') then
       table.insert(sticky_indices, i)
@@ -80,6 +65,7 @@ local function insert_sticky(prompt, config)
 
   lines = vim.split(vim.trim(table.concat(lines, '\n')), '\n')
 
+  -- Add config-based stickies
   if config.remember_as_sticky and config.model and config.model ~= M.config.model then
     stickies:set('$' .. config.model, true)
   end
@@ -111,38 +97,17 @@ local function insert_sticky(prompt, config)
     end
   end
 
-  -- Insert stickies at start of prompt
-  local prompt_lines = {}
+  -- Store stickies
+  local sticky_array = {}
   for _, sticky in ipairs(stickies:keys()) do
     if sticky ~= '' then
-      table.insert(prompt_lines, '> ' .. sticky)
+      table.insert(sticky_array, sticky)
     end
   end
-  if #prompt_lines > 0 then
-    table.insert(prompt_lines, '')
-  end
-  for _, line in ipairs(lines) do
-    table.insert(prompt_lines, line)
-  end
-  if #lines == 0 then
-    table.insert(prompt_lines, '')
-  end
+  M.chat:set_sticky(sticky_array)
 
-  return table.concat(prompt_lines, '\n')
-end
-
-local function store_sticky(prompt)
-  local sticky = {}
-  local in_code_block = false
-  for _, line in ipairs(vim.split(prompt, '\n')) do
-    if line:match('^```') then
-      in_code_block = not in_code_block
-    end
-    if vim.startswith(line, '> ') and not in_code_block then
-      table.insert(sticky, line:sub(3))
-    end
-  end
-  state.sticky = sticky
+  -- Return clean prompt
+  return table.concat(lines, '\n')
 end
 
 --- Finish writing to chat buffer.
@@ -155,15 +120,16 @@ local function finish(start_of_chat)
         table.insert(sticky, sticky_line)
       end
     end
-    state.sticky = sticky
+    M.chat:set_sticky(sticky)
   end
 
   local prompt_content = ''
   local assistant_message = M.chat:get_message(constants.ROLE.ASSISTANT)
   local tool_calls = assistant_message and assistant_message.tool_calls or {}
 
-  if not utils.empty(state.sticky) then
-    for _, sticky in ipairs(state.sticky) do
+  local current_sticky = M.chat:get_sticky()
+  if not utils.empty(current_sticky) then
+    for _, sticky in ipairs(current_sticky) do
       prompt_content = prompt_content .. '> ' .. sticky .. '\n'
     end
     prompt_content = prompt_content .. '\n'
@@ -231,7 +197,7 @@ local function map_key(name, bufnr, fn)
 
   if not fn then
     fn = function()
-      key.callback(state.source)
+      key.callback(M.chat:get_source())
     end
   end
 
@@ -261,7 +227,7 @@ end
 --- Updates the source buffer based on previous or current window.
 local function update_source()
   local use_prev_window = M.chat:focused()
-  M.set_source(use_prev_window and vim.fn.win_getid(vim.fn.winnr('#')) or vim.api.nvim_get_current_win())
+  M.chat:set_source(use_prev_window and vim.fn.win_getid(vim.fn.winnr('#')) or vim.api.nvim_get_current_win())
 end
 
 --- Resolve enabled tools from the prompt.
@@ -299,39 +265,6 @@ function M.resolve_model(prompt, config)
   return prompts.resolve_model(prompt, config)
 end
 
---- Get the current source buffer and window.
-function M.get_source()
-  return state.source
-end
-
---- Sets the source to the given window.
----@param source_winnr number
----@return boolean if the source was set
-function M.set_source(source_winnr)
-  local source_bufnr = vim.api.nvim_win_get_buf(source_winnr)
-
-  -- Check if the window is valid to use as a source
-  if source_winnr ~= M.chat.winnr and source_bufnr ~= M.chat.bufnr and vim.fn.win_gettype(source_winnr) == '' then
-    state.source = {
-      bufnr = source_bufnr,
-      winnr = source_winnr,
-      cwd = function()
-        local ok, dir = pcall(function()
-          return vim.w[source_winnr].cchat_cwd
-        end)
-        if not ok or not dir or dir == '' then
-          return '.'
-        end
-        return dir
-      end,
-    }
-
-    return true
-  end
-
-  return false
-end
-
 --- Open the chat window.
 ---@param config CopilotChat.config.Shared?
 function M.open(config)
@@ -343,11 +276,11 @@ function M.open(config)
   -- Add sticky values from provided config when opening the chat
   local message = M.chat:get_message(constants.ROLE.USER)
   if message then
-    local prompt = insert_sticky(message.content, config)
-    if prompt then
+    local clean_prompt = process_sticky(message.content, config)
+    if clean_prompt and clean_prompt ~= '' then
       M.chat:add_message({
         role = constants.ROLE.USER,
-        content = '\n' .. prompt,
+        content = '\n> ' .. table.concat(M.chat:get_sticky(), '\n> ') .. '\n\n' .. clean_prompt,
       }, true)
     end
   end
@@ -358,7 +291,7 @@ end
 
 --- Close the chat window.
 function M.close()
-  M.chat:close(state.source.bufnr)
+  M.chat:close()
 end
 
 --- Toggle the chat window.
@@ -504,14 +437,13 @@ function M.ask(prompt, config)
   end
 
   -- Resolve prompt after window is opened
-  prompt = insert_sticky(prompt, config)
+  prompt = process_sticky(prompt, config)
   prompt = vim.trim(prompt)
 
   -- After opening window we need to schedule to next cycle so everything properly resolves
   schedule(function()
     if not config.headless then
       -- Prepare chat
-      store_sticky(prompt)
       M.chat:start()
       M.chat:append('\n')
     end
@@ -531,10 +463,12 @@ function M.ask(prompt, config)
         '\n'
       )
 
-      -- Add resolved stickies to state
+      -- Add resolved stickies to chat
+      local current_sticky = M.chat:get_sticky()
       for _, sticky in ipairs(resolved_stickies) do
-        table.insert(state.sticky, sticky)
+        table.insert(current_sticky, sticky)
       end
+      M.chat:set_sticky(current_sticky)
 
       prompt = vim.trim(prompt)
 
@@ -627,7 +561,7 @@ function M.ask(prompt, config)
       -- Call the callback function
       if config.callback then
         utils.schedule_main()
-        config.callback(response, state.source)
+        config.callback(response, M.chat:get_source())
       end
 
       if not config.headless then
@@ -656,7 +590,7 @@ function M.stop(reset)
   if reset then
     M.chat:clear()
     vim.diagnostic.reset(vim.api.nvim_create_namespace('copilot-chat-diagnostics'))
-    select.set(state.source.bufnr)
+    select.set(M.chat:get_source().bufnr)
   end
 
   if stopped or reset then
@@ -797,7 +731,7 @@ function M.setup(config)
 
   -- Initialize chat
   if M.chat then
-    M.chat:close(state.source.bufnr)
+    M.chat:close()
     M.chat:delete()
   else
     M.chat = require('CopilotChat.ui.chat')(M.config, function(bufnr)
@@ -815,7 +749,7 @@ function M.setup(config)
           end
 
           vim.schedule(function()
-            select.highlight(state.source.bufnr, not (M.config.highlight_selection and M.chat:focused()))
+            select.highlight(M.chat:get_source().bufnr, not (M.config.highlight_selection and M.chat:focused()))
           end)
         end,
       })

--- a/lua/CopilotChat/prompts.lua
+++ b/lua/CopilotChat/prompts.lua
@@ -93,7 +93,7 @@ function M.resolve_functions(prompt, config)
   config, prompt = M.resolve_prompt(prompt, config)
 
   local chat = require('CopilotChat').chat
-  local source = require('CopilotChat').get_source()
+  local source = chat:get_source()
 
   local tools = {}
   for _, tool in ipairs(functions.parse_tools(config.functions)) do
@@ -269,7 +269,7 @@ end
 ---@async
 function M.resolve_prompt(prompt, config)
   local chat = require('CopilotChat').chat
-  local source = require('CopilotChat').get_source()
+  local source = chat:get_source()
 
   if prompt == nil then
     utils.schedule_main()


### PR DESCRIPTION
This refactors the management of source and sticky prompt logic by moving it from the main module to the chat window implementation. The `CopilotChat.source` and sticky state are now encapsulated within the `CopilotChat.ui.chat.Chat` class, providing a cleaner separation of concerns and reducing global state. All related methods and type annotations have been updated accordingly. The sticky prompt insertion and retrieval logic is now handled via `get_sticky` and `set_sticky` methods on the chat window, and the source window/buffer is managed through `get_source` and `set_source` methods. This change also removes the sticky toggle mapping and updates documentation and function signatures for consistency.

BREAKING CHANGE: get_source, and set_source methods moved to require('CopilotChat').chat