### PR TITLE
Correct copilot.vim accept function in keybind

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ When you use `@copilot`, the LLM can call functions like `bash`, `edit`, `file`,
 >
 > ```lua
 > vim.g.copilot_no_tab_map = true
-> vim.keymap.set('i', '<S-Tab>', 'copilot#Accept("\\<S-Tab>")', { expr = true, replace_keycodes = false })
+> vim.keymap.set('i', '<S-Tab>', require('copilot.suggestion').accept, { expr = true, replace_keycodes = false })
 > ```
 >
 > You can also customize CopilotChat keymaps in your config.


### PR DESCRIPTION
I could only remap copilot.vim's suggestion acceptance like this. The old function call did not work for me. I think this is because copilot.vim's api has changed.