### PR TITLE
fix(functions): insert explicit selected buffers

### DIFF
--- a/lua/CopilotChat/config/functions.lua
+++ b/lua/CopilotChat/config/functions.lua
@@ -150,7 +150,7 @@ return {
                 local name = vim.api.nvim_buf_get_name(buf)
                 if name and name ~= '' then
                   local display_name = vim.fn.fnamemodify(name, ':~:.')
-                  table.insert(opts, { display = display_name, value = name })
+                  table.insert(opts, { display = display_name, value = tostring(buf) })
                 end
               end
             end


### PR DESCRIPTION
Hi,
this PR fixes the error `No buffers found for input:` after selecting a specific file for `#buffer:`.
I guess this is because it uses the filename and not the buffer number. And the filename is not resolved.
By using the number as the value, the buffer number is used for the selected buffer and is then available.