### PR TITLE
fix(ui): preserve block content formatting when parsing chat messages

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -734,7 +734,7 @@ function Chat:parse()
     message.content = vim.trim(table.concat(message.content, '\n'))
     if message.section then
       for _, block in ipairs(message.section.blocks) do
-        block.content = vim.trim(table.concat(block.content, '\n'))
+        block.content = table.concat(block.content, '\n')
       end
     end
 


### PR DESCRIPTION
Remove trimming of block content when parsing chat messages to ensure that formatting, such as leading and trailing whitespace, is preserved. This prevents unintended loss of formatting in code or text blocks within chat sections.