### PR TITLE
fix: support file paths with spaces in block headers

### DIFF
--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -39,6 +39,7 @@ local function match_block_header(header)
   end
 
   local patterns = {
+    '^(%w+)%s+path=(.-)%s+start_line=(%d+)%s+end_line=(%d+)$',
     '^(%w+)%s+path=(%S+)%s+start_line=(%d+)%s+end_line=(%d+)$',
     '^(%w+)$',
   }


### PR DESCRIPTION
## Problem
The block header pattern matching in `match_block_header()` uses `%S+` (non-whitespace characters) to capture file paths. This fails when file paths contain spaces, causing:
- Code blocks to not be parsed (blocks array remains empty)
- Diff acceptance features (`<C-y>`, `gd`, `gy`, etc.) to be non-functional
- Treesitter correctly identifies block nodes, but they're not added to the message

Example failing path:
```
python path=/Users/name/my projects/test.py start_line=1 end_line=10
```

## Solution
- Added a new pattern with lazy match `(.-)` to support paths with spaces
- Kept the original `%S+` pattern as fallback for compatibility
- The lazy match stops at the next expected token (`start_line=`)

## Testing
Tested with file paths containing spaces and verified:
- ✅ Blocks are now correctly parsed and added to `message.section.blocks`
- ✅ All diff-related mappings work (`accept_diff`, `show_diff`, `jump_to_diff`, etc.)
- ✅ Backward compatibility maintained for paths without spaces
- ✅ Treesitter captures are properly converted to block objects

## Changes
- Modified `lua/CopilotChat/ui/chat.lua` - Added pattern to support spaces in paths
