### PR TITLE
Remove myself from funding & add Tomas instead

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-github: [acheong08, jellydn]
+github: [deathbeam, jellydn]


### PR DESCRIPTION
I have not been involved in a very long time and it feels wrong to have a link to my profile in the sidebar. This plugin is now pretty much maintained by @deathbeam so it probably fits better.