### PR TITLE
fix(config): correct AGENTS.md filename casing

### DIFF
--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -109,7 +109,7 @@ return {
   -- Instruction files to look for in current working directory
   instruction_files = {
     '.github/copilot-instructions.md',
-    'AGENTS.MD',
+    'AGENTS.md',
   },
 
   selection = 'visual', -- Selection source


### PR DESCRIPTION
The instruction file 'AGENTS.MD' was renamed to 'AGENTS.md' to match
the actual file name and ensure it is properly detected in the working
directory. This resolves issues on case-sensitive file systems.
