### PR TITLE
fix(core): resolve various bugs and improve robustness

### DIFF
--- a/lua/CopilotChat/client.lua
+++ b/lua/CopilotChat/client.lua
@@ -65,7 +65,7 @@ local orderedmap = require('CopilotChat.utils.orderedmap')
 local stringbuffer = require('CopilotChat.utils.stringbuffer')
 
 --- Constants
-local RESOURCE_SHORT_FORMAT = '# %s\n```%s start_line=% end_line=%s\n%s\n```'
+local RESOURCE_SHORT_FORMAT = '# %s\n```%s start_line=%s end_line=%s\n%s\n```'
 local RESOURCE_LONG_FORMAT = '# %s\n```%s path=%s start_line=%s end_line=%s\n%s\n```'
 local CACHE_TTL = 300 -- 5 minutes
 
@@ -445,9 +445,10 @@ function Client:ask(opts)
 
     if out.tool_calls then
       for _, tool_call in ipairs(out.tool_calls) do
-        local val = tool_calls:get(tool_call.index)
+        local key = tool_call.id or tool_call.index
+        local val = tool_calls:get(key)
         if not val then
-          tool_calls:set(tool_call.index, tool_call)
+          tool_calls:set(key, tool_call)
         else
           val.arguments = val.arguments .. tool_call.arguments
         end
@@ -573,12 +574,10 @@ function Client:ask(opts)
     end
 
     error(error_msg)
-    return
   end
 
   if errored then
     error(errored)
-    return
   end
 
   local response_text = response_content_buffer:tostring()

--- a/lua/CopilotChat/config/functions.lua
+++ b/lua/CopilotChat/config/functions.lua
@@ -247,7 +247,7 @@ return {
         {
           uri = 'neovim://selection',
           name = selection.filename,
-          mimetype = files.mimetype_to_filetype(selection.filetype),
+          mimetype = files.filetype_to_mimetype(selection.filetype),
           data = data,
           annotations = {
             start_line = selection.start_line,

--- a/lua/CopilotChat/config/mappings.lua
+++ b/lua/CopilotChat/config/mappings.lua
@@ -14,23 +14,19 @@ local function prepare_diff_buffer(filename, source)
     filename = vim.api.nvim_buf_get_name(source.bufnr)
   end
 
+  -- Try to find matching buffer first
   local diff_bufnr = nil
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if files.filename_same(vim.api.nvim_buf_get_name(buf), filename) then
+      diff_bufnr = buf
+      break
+    end
+  end
 
-  -- If buffer is not found, try to load it
+  -- If not found, create a new buffer
   if not diff_bufnr then
-    -- Try to find matching buffer first
-    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-      if files.filename_same(vim.api.nvim_buf_get_name(buf), filename) then
-        diff_bufnr = buf
-        break
-      end
-    end
-
-    -- If still not found, create a new buffer
-    if not diff_bufnr then
-      diff_bufnr = vim.fn.bufadd(filename)
-      vim.fn.bufload(diff_bufnr)
-    end
+    diff_bufnr = vim.fn.bufadd(filename)
+    vim.fn.bufload(diff_bufnr)
   end
 
   -- If source exists, update it to point to the diff buffer
@@ -243,10 +239,10 @@ return {
             })
           end
         end
-
-        vim.fn.setqflist(items)
-        vim.cmd('copen')
       end
+
+      vim.fn.setqflist(items)
+      vim.cmd('copen')
     end,
   },
 

--- a/lua/CopilotChat/config/providers.lua
+++ b/lua/CopilotChat/config/providers.lua
@@ -183,7 +183,7 @@ local function get_github_models_token(tag)
   end
 
   -- loading token from gh cli if available
-  if vim.fn.executable('gh') == 0 then
+  if vim.fn.executable('gh') == 1 then
     local result = utils.system({ 'gh', 'auth', 'token', '-h', 'github.com' })
     if result and result.code == 0 and result.stdout then
       local gh_token = vim.trim(result.stdout)
@@ -400,9 +400,10 @@ local function prepare_responses_output(output)
       -- Complete output item (including tool calls)
       local item = output.item
       if item and item.type == 'function_call' then
+        local index = output.output_index or (#tool_calls + 1)
         table.insert(tool_calls, {
-          id = item.call_id or ('tooluse_' .. (#tool_calls + 1)),
-          index = #tool_calls + 1,
+          id = item.call_id or ('tooluse_' .. index),
+          index = index,
           name = item.name or '',
           arguments = item.arguments or '',
         })

--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -22,8 +22,12 @@ local M = setmetatable({}, {
     -- Lazy initialize
     local initialized = rawget(t, 'initialized')
     if not initialized then
-      rawset(t, 'initialized', true)
-      rawget(t, 'setup')()
+      local ok, err = pcall(rawget(t, 'setup'))
+      if ok then
+        rawset(t, 'initialized', true)
+      else
+        require('plenary.log').error('CopilotChat setup failed:', err)
+      end
     end
 
     return rawget(t, key)
@@ -54,8 +58,12 @@ local function process_sticky(prompt, config)
   end
 
   -- Find sticky lines in new prompt to remove them
+  in_code_block = false
   for i, line in ipairs(lines) do
-    if vim.startswith(line, '> ') then
+    if line:match('^```') then
+      in_code_block = not in_code_block
+    end
+    if vim.startswith(line, '> ') and not in_code_block then
       table.insert(sticky_indices, i)
     end
   end
@@ -349,8 +357,8 @@ end
 --- Select a prompt template to use.
 ---@param config CopilotChat.config.Shared?
 function M.select_prompt(config)
-  local prompts = prompts.list_prompts()
-  local keys = vim.tbl_keys(prompts)
+  local prompt_list = prompts.list_prompts()
+  local keys = vim.tbl_keys(prompt_list)
   table.sort(keys)
 
   local choices = vim
@@ -358,8 +366,8 @@ function M.select_prompt(config)
     :map(function(name)
       return {
         name = name,
-        description = prompts[name].description,
-        prompt = prompts[name].prompt,
+        description = prompt_list[name].description,
+        prompt = prompt_list[name].prompt,
       }
     end)
     :filter(function(choice)
@@ -696,6 +704,7 @@ function M.setup(config)
   end)
 
   -- Initialize chat
+  require('CopilotChat.notify').clear()
   if M.chat then
     M.chat:close()
     M.chat:delete()

--- a/lua/CopilotChat/notify.lua
+++ b/lua/CopilotChat/notify.lua
@@ -32,4 +32,9 @@ function M.listen(event_name, callback)
   table.insert(M.listeners[event_name], callback)
 end
 
+--- Clear all listeners
+function M.clear()
+  M.listeners = {}
+end
+
 return M

--- a/lua/CopilotChat/ui/chat.lua
+++ b/lua/CopilotChat/ui/chat.lua
@@ -863,10 +863,10 @@ function Chat:render()
       -- Highlight tools in the last user message
       local assistant_msg = self:get_message(constants.ROLE.ASSISTANT)
       if assistant_msg and assistant_msg.tool_calls and #assistant_msg.tool_calls > 0 then
-        for i, line in ipairs(utils.split_lines(message.content)) do
+        for j, line in ipairs(utils.split_lines(message.content)) do
           for _, tool_call in ipairs(assistant_msg.tool_calls) do
             if line:match(string.format('#%s:%s', tool_call.name, vim.pesc(tool_call.id))) then
-              local l = message.section.start_line + i
+              local l = message.section.start_line + j
               vim.api.nvim_buf_add_highlight(self.bufnr, highlight_ns, 'CopilotChatAnnotationHeader', l, 0, #line)
               if not utils.empty(tool_call.arguments) then
                 vim.api.nvim_buf_set_extmark(self.bufnr, highlight_ns, l, 0, {

--- a/lua/CopilotChat/ui/overlay.lua
+++ b/lua/CopilotChat/ui/overlay.lua
@@ -128,7 +128,9 @@ function Overlay:restore(winnr, bufnr)
 
   -- Manually trigger BufEnter event as nvim_win_set_buf does not trigger it
   vim.schedule(function()
-    vim.cmd(string.format('doautocmd <nomodeline> BufEnter %s', bufnr))
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_exec_autocmds('BufEnter', { buffer = bufnr })
+    end
   end)
 end
 

--- a/lua/CopilotChat/utils/diff.lua
+++ b/lua/CopilotChat/utils/diff.lua
@@ -161,16 +161,16 @@ function M.apply_unified_diff(diff_text, original_content)
   end
 
   local new_lines = vim.split(new_content, '\n', { trimempty = true })
-  local hunks = vim.diff(
+  local diff_hunks = vim.diff(
     original_content,
     new_content,
     { algorithm = 'myers', ctxlen = 10, interhunkctxlen = 10, ignore_whitespace_change = true, result_type = 'indices' }
   )
-  if not hunks or #hunks == 0 then
+  if not diff_hunks or #diff_hunks == 0 then
     return new_lines, applied, nil, nil
   end
   local first, last
-  for _, hunk in ipairs(hunks) do
+  for _, hunk in ipairs(diff_hunks) do
     local hunk_start = hunk[1]
     local hunk_end = hunk[1] + hunk[2] - 1
     if not first or hunk_start < first then

--- a/lua/CopilotChat/utils/files.lua
+++ b/lua/CopilotChat/utils/files.lua
@@ -164,7 +164,7 @@ M.grep = async.wrap(function(path, opts, callback)
 
     if opts.pattern then
       table.insert(cmd, '-e')
-      table.insert(cmd, "'" .. opts.pattern .. "'")
+      table.insert(cmd, opts.pattern)
     end
   elseif vim.fn.executable('grep') == 1 then
     table.insert(cmd, 'grep')
@@ -172,7 +172,7 @@ M.grep = async.wrap(function(path, opts, callback)
 
     if opts.pattern then
       table.insert(cmd, '-e')
-      table.insert(cmd, "'" .. opts.pattern .. "'")
+      table.insert(cmd, opts.pattern)
     end
   end
 


### PR DESCRIPTION
- Fix incorrect format string in RESOURCE_SHORT_FORMAT
- Correct tool call key usage and merging in client
- Use correct filetype to mimetype conversion in functions
- Simplify and fix buffer finding/creation logic in mappings
- Correct logic for loading GitHub token from gh CLI
- Fix prompt selection and sticky line processing in init
- Add notify.clear to setup for proper listener management
- Add clear method to notify to reset listeners
- Fix tool call highlighting in chat UI
- Use proper BufEnter autocmd invocation in overlay
- Fix diff hunk variable naming in utils.diff
- Remove unnecessary quoting of grep patterns in utils.files

These changes address several bugs, improve code clarity, and enhance
the reliability of buffer, prompt, and notification handling.

Closes #1515
Closes #1455
