### PR TITLE
fix(config): include hidden files in file enum glob

### DIFF
--- a/lua/CopilotChat/config/functions.lua
+++ b/lua/CopilotChat/config/functions.lua
@@ -64,6 +64,7 @@ return {
           enum = function(source)
             return files.glob(source.cwd(), {
               max_count = 0,
+              hidden = true,
             })
           end,
         },


### PR DESCRIPTION
The file enumeration function now includes hidden files by setting
`hidden = true` in the glob options. This ensures that all files,
including dotfiles, are considered during enumeration.

Closes #1516
