### PR TITLE
fix(init): simplify lazy initialization logic

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -22,12 +22,8 @@ local M = setmetatable({}, {
     -- Lazy initialize
     local initialized = rawget(t, 'initialized')
     if not initialized then
-      local ok, err = pcall(rawget(t, 'setup'))
-      if ok then
-        rawset(t, 'initialized', true)
-      else
-        require('plenary.log').error('CopilotChat setup failed:', err)
-      end
+      rawset(t, 'initialized', true)
+      rawget(t, 'setup')()
     end
 
     return rawget(t, key)


### PR DESCRIPTION
Refactors the lazy initialization in the CopilotChat main module to call
the setup function directly and set the 'initialized' flag before
invocation. Removes the pcall error handling and logging, as setup
should not fail silently. This makes the initialization logic clearer
and more predictable.
