### PR TITLE
fix(prompt): use correct variable in select_prompt

### DIFF
--- a/lua/CopilotChat/init.lua
+++ b/lua/CopilotChat/init.lua
@@ -378,7 +378,7 @@ function M.select_prompt(config)
     end,
   }, function(choice)
     if choice then
-      M.ask(prompts[choice.name].prompt, vim.tbl_extend('force', prompts[choice.name], config or {}))
+      M.ask(prompt_list[choice.name].prompt, vim.tbl_extend('force', prompt_list[choice.name], config or {}))
     end
   end)
 end


### PR DESCRIPTION
Replaces usage of the undefined 'prompts' variable with 'prompt_list'
in the select_prompt function. This ensures the correct prompt data is
used when invoking the ask method, preventing potential runtime errors.

Closes #1554
