### PR TITLE
fix: use `gpt-5-mini` as default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Most users only need to configure a few options:
 
 ```lua
 {
-  model = 'gpt-4.1',           -- AI model to use
+  model = 'gpt-5-mini',        -- AI model to use
   temperature = 0.1,           -- Lower = focused, higher = creative
   trusted_tools = nil,         -- Require approval for all tool calls
   window = {
@@ -311,7 +311,7 @@ Types of copilot highlights:
 - `CopilotChatResource` - Resource highlight in chat buffer (e.g. `#file`, `#gitdiff`)
 - `CopilotChatTool` - Tool call highlight in chat buffer (e.g. `@copilot`)
 - `CopilotChatPrompt` - Prompt highlight in chat buffer (e.g. `/Explain`, `/Review`)
-- `CopilotChatModel` - Model highlight in chat buffer (e.g. `$gpt-4.1`)
+- `CopilotChatModel` - Model highlight in chat buffer (e.g. `$gpt-5-mini`)
 - `CopilotChatUri` - URI highlight in chat buffer (e.g. `##https://...`)
 - `CopilotChatAnnotation` - Annotation highlight in chat buffer (file headers, tool call headers, tool call body)
 - `CopilotChatAnnotationHeader` - Annotation header highlight in chat buffer
@@ -418,7 +418,7 @@ Add custom AI providers:
     my_provider = {
       get_url = function(opts) return 'https://api.example.com/chat' end,
       get_headers = function() return { ['Authorization'] = 'Bearer ' .. api_key } end,
-      get_models = function() return { { id = 'gpt-4.1', name = 'GPT-4.1 model' } } end,
+      get_models = function() return { { id = 'gpt-5-mini', name = 'GPT-5 mini model' } } end,
       prepare_input = require('CopilotChat.config.providers').copilot.prepare_input,
       prepare_output = require('CopilotChat.config.providers').copilot.prepare_output,
     }
@@ -554,7 +554,7 @@ require('CopilotChat').load('my_debugging_session')
 
 -- Use custom sticky and model
 require('CopilotChat').ask('How can I optimize this?', {
-  model = 'gpt-4.1',
+  model = 'gpt-5-mini',
   sticky = { '#buffer', '#gitdiff:staged' },
 })
 

--- a/doc/CopilotChat.txt
+++ b/doc/CopilotChat.txt
@@ -330,7 +330,7 @@ Most users only need to configure a few options:
 
 >lua
     {
-      model = 'gpt-4.1',           -- AI model to use
+      model = 'gpt-5-mini',        -- AI model to use
       temperature = 0.1,           -- Lower = focused, higher = creative
       trusted_tools = nil,         -- Require approval for all tool calls
       window = {
@@ -404,7 +404,7 @@ Types of copilot highlights:
 - `CopilotChatResource` - Resource highlight in chat buffer (e.g. `#file`, `#gitdiff`)
 - `CopilotChatTool` - Tool call highlight in chat buffer (e.g. `@copilot`)
 - `CopilotChatPrompt` - Prompt highlight in chat buffer (e.g. `/Explain`, `/Review`)
-- `CopilotChatModel` - Model highlight in chat buffer (e.g. `$gpt-4.1`)
+- `CopilotChatModel` - Model highlight in chat buffer (e.g. `$gpt-5-mini`)
 - `CopilotChatUri` - URI highlight in chat buffer (e.g. `##https://...`)
 - `CopilotChatAnnotation` - Annotation highlight in chat buffer (file headers, tool call headers, tool call body)
 - `CopilotChatAnnotationHeader` - Annotation header highlight in chat buffer
@@ -516,7 +516,7 @@ Add custom AI providers:
         my_provider = {
           get_url = function(opts) return 'https://api.example.com/chat' end,
           get_headers = function() return { ['Authorization'] = 'Bearer ' .. api_key } end,
-          get_models = function() return { { id = 'gpt-4.1', name = 'GPT-4.1 model' } } end,
+          get_models = function() return { { id = 'gpt-5-mini', name = 'GPT-5 mini model' } } end,
           prepare_input = require('CopilotChat.config.providers').copilot.prepare_input,
           prepare_output = require('CopilotChat.config.providers').copilot.prepare_output,
         }
@@ -658,7 +658,7 @@ EXAMPLE USAGE                                      *CopilotChat-example-usage*
     
     -- Use custom sticky and model
     require('CopilotChat').ask('How can I optimize this?', {
-      model = 'gpt-4.1',
+      model = 'gpt-5-mini',
       sticky = { '#buffer', '#gitdiff:staged' },
     })
     

--- a/lua/CopilotChat/config.lua
+++ b/lua/CopilotChat/config.lua
@@ -61,7 +61,7 @@ return {
 
   system_prompt = require('CopilotChat.config.prompts').COPILOT_INSTRUCTIONS.system_prompt, -- System prompt to use (can be specified manually in prompt via /).
 
-  model = 'gpt-4.1', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
+  model = 'gpt-5-mini', -- Default model to use, see ':CopilotChatModels' for available models (can be specified manually in prompt via $).
   tools = nil, -- Default tool or array of tools (or groups) to share with LLM (can be specified manually in prompt via @).
   resources = 'selection', -- Default resources to share with LLM (can be specified manually in prompt via #).
   sticky = nil, -- Default sticky prompt or array of sticky prompts to use at start of every new chat (can be specified manually in prompt via >).


### PR DESCRIPTION
## what

Updated CopilotChat’s default model from `gpt-4.1` to `gpt-5-mini`.

Also updated the README and generated vimdoc examples so documented defaults and model examples match the new config value.

## why

GitHub Copilot lists GPT-4.1 as closing down on June 1, 2026. `gpt-5-mini` is the closest replacement because GitHub describes it as a general-purpose model suitable for fast, accurate coding and explanation tasks, matching the previous GPT-4.1 default use case.

## references

- GitHub Copilot supported models: https://docs.github.com/en/copilot/reference/ai-models/supported-models
- GitHub Copilot model comparison: https://docs.github.com/en/copilot/reference/ai-models/model-comparison